### PR TITLE
Upgrade `nexus-future` & move to relying on them for managing Prisma2 dependency

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -23,13 +23,18 @@
         "@babel/highlight": "^7.8.3"
       }
     },
+    "@babel/helper-validator-identifier": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz",
+      "integrity": "sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw=="
+    },
     "@babel/highlight": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-      "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
+      "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
       "requires": {
+        "@babel/helper-validator-identifier": "^7.9.0",
         "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
       },
       "dependencies": {
@@ -80,12 +85,12 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
-      "integrity": "sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.0.tgz",
+      "integrity": "sha512-cTIudHnzuWLS56ik4DnRnqqNf8MkdUzV4iFFI1h7Jo9xvrpQROYaAnaSd2mHLQAzzZAPfATynX5ord6YlNYNMA==",
       "dev": true,
       "requires": {
-        "regenerator-runtime": "^0.13.2"
+        "regenerator-runtime": "^0.13.4"
       }
     },
     "@dsherret/to-absolute-glob": {
@@ -328,9 +333,9 @@
       },
       "dependencies": {
         "@prisma/get-platform": {
-          "version": "0.1.29",
-          "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-0.1.29.tgz",
-          "integrity": "sha512-aiRbbUKr24UwUqnH/K/asOObAQvcSvlp/sbz/LPi6HIc5iZrMCn+I6zWyTVOiu176KVAnCUFUWkYEP+mkAlspA==",
+          "version": "0.1.31",
+          "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-0.1.31.tgz",
+          "integrity": "sha512-W1puX5yiG7NyQPu/V08VK3K04+XhLdXN1nDHMlZePQNHCqURh5tcya7vNPyPJQcH3LsdsgVYiqotDgpobzxAoQ==",
           "requires": {
             "debug": "^4.1.1"
           }
@@ -478,71 +483,71 @@
       }
     },
     "@sentry/apm": {
-      "version": "5.13.2",
-      "resolved": "https://registry.npmjs.org/@sentry/apm/-/apm-5.13.2.tgz",
-      "integrity": "sha512-Pv6PRVkcmmYYIT422gXm968F8YQyf5uN1RSHOFBjWsxI3Ke/uRgeEdIVKPDo78GklBfETyRN6GyLEZ555jRe6g==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/apm/-/apm-5.15.0.tgz",
+      "integrity": "sha512-2N33gcl+MIcRDAdV150pRb+IkSnoqLdu0mZV9Cm7dIYvCxeZ6J+k903qAwTPdoR6/MCu795aiw4zUvsRbMJy6Q==",
       "requires": {
-        "@sentry/browser": "5.13.2",
-        "@sentry/hub": "5.13.2",
-        "@sentry/minimal": "5.13.2",
-        "@sentry/types": "5.13.2",
-        "@sentry/utils": "5.13.2",
+        "@sentry/browser": "5.15.0",
+        "@sentry/hub": "5.15.0",
+        "@sentry/minimal": "5.15.0",
+        "@sentry/types": "5.15.0",
+        "@sentry/utils": "5.15.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/browser": {
-      "version": "5.13.2",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.13.2.tgz",
-      "integrity": "sha512-4MeauHs8Rf1c2FF6n84wrvA4LexEL1K/Tg3r+1vigItiqyyyYBx1sPjHGZeKeilgBi+6IEV5O8sy30QIrA/NsQ==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.15.0.tgz",
+      "integrity": "sha512-9sgqWGaoT5jb3vk8sgQ1bz1LzhUf3oKoDMp/c6vX0reuA6Vz+/jwOC7a/FPWtQir2PwRJfbak2QOxw8W6Mwa3g==",
       "requires": {
-        "@sentry/core": "5.13.2",
-        "@sentry/types": "5.13.2",
-        "@sentry/utils": "5.13.2",
+        "@sentry/core": "5.15.0",
+        "@sentry/types": "5.15.0",
+        "@sentry/utils": "5.15.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/core": {
-      "version": "5.13.2",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.13.2.tgz",
-      "integrity": "sha512-iB7CQSt9e0EJhSmcNOCjzJ/u7E7qYJ3mI3h44GO83n7VOmxBXKSvtUl9FpKFypbWrsdrDz8HihLgAZZoMLWpPA==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.15.0.tgz",
+      "integrity": "sha512-ujwHMwinPwuADoIBFjh1BiC6Li7RpEG3Mmo0MxOqKm7xKngkRUk5uH5e36roORnx+ngr/3NCe80QuvSqK7gQsw==",
       "requires": {
-        "@sentry/hub": "5.13.2",
-        "@sentry/minimal": "5.13.2",
-        "@sentry/types": "5.13.2",
-        "@sentry/utils": "5.13.2",
+        "@sentry/hub": "5.15.0",
+        "@sentry/minimal": "5.15.0",
+        "@sentry/types": "5.15.0",
+        "@sentry/utils": "5.15.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "5.13.2",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.13.2.tgz",
-      "integrity": "sha512-/U7yq3DTuRz8SRpZVKAaenW9sD2F5wbj12kDVPxPnGspyqhy0wBWKs9j0YJfBiDXMKOwp3HX964O3ygtwjnfAw==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.15.0.tgz",
+      "integrity": "sha512-wIDcaIuaYpg+Ma01NfFQTOnZLDCKSx2D06TTBqlo93WfMFNgyEgdMbU5Fk1PFZzjj2AMtzlc9DJzAfvt1hZx3w==",
       "requires": {
-        "@sentry/types": "5.13.2",
-        "@sentry/utils": "5.13.2",
+        "@sentry/types": "5.15.0",
+        "@sentry/utils": "5.15.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "5.13.2",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.13.2.tgz",
-      "integrity": "sha512-VV0eA3HgrnN3mac1XVPpSCLukYsU+QxegbmpnZ8UL8eIQSZ/ZikYxagDNlZbdnmXHUpOEUeag2gxVntSCo5UcA==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.15.0.tgz",
+      "integrity": "sha512-VBkMfR6ahmuJrx4V51BNYd6XzGZ7GB8sfnBufMzqK6MsKe+g5oSyXeqHFd4oFC0co0YlFIw7IphF2JZLwVs0zA==",
       "requires": {
-        "@sentry/hub": "5.13.2",
-        "@sentry/types": "5.13.2",
+        "@sentry/hub": "5.15.0",
+        "@sentry/types": "5.15.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/node": {
-      "version": "5.13.2",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.13.2.tgz",
-      "integrity": "sha512-LwNOUvc0+28jYfI0o4HmkDTEYdY3dWvSCnL5zggO12buon7Wc+jirXZbEQAx84HlXu7sGSjtKCTzUQOphv7sPw==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.15.0.tgz",
+      "integrity": "sha512-uy53L3O7Ood0RGRnFPT+EDTkK63qkbvGM5Al7Le6r9Sl6joACng+K3zmkJWzW5xrjcG6m8ExT3bm1hPjVOmOJA==",
       "requires": {
-        "@sentry/apm": "5.13.2",
-        "@sentry/core": "5.13.2",
-        "@sentry/hub": "5.13.2",
-        "@sentry/types": "5.13.2",
-        "@sentry/utils": "5.13.2",
+        "@sentry/apm": "5.15.0",
+        "@sentry/core": "5.15.0",
+        "@sentry/hub": "5.15.0",
+        "@sentry/types": "5.15.0",
+        "@sentry/utils": "5.15.0",
         "cookie": "^0.3.1",
         "https-proxy-agent": "^4.0.0",
         "lru_map": "^0.3.3",
@@ -579,16 +584,16 @@
       }
     },
     "@sentry/types": {
-      "version": "5.13.2",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.13.2.tgz",
-      "integrity": "sha512-mgAEQyc77PYBnAjnslSXUz6aKgDlunlg2c2qSK/ivKlEkTgTWWW/dE76++qVdrqM8SupnqQoiXyPDL0wUNdB3g=="
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.15.0.tgz",
+      "integrity": "sha512-MC96wUAHhzRuH3xo4Qd+EXTOap8+d+SWbAdLBukScxuwhOSY/HNRh1TW17CuAu7s1oXa7xxO2ZCdyamSZinIiQ=="
     },
     "@sentry/utils": {
-      "version": "5.13.2",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.13.2.tgz",
-      "integrity": "sha512-LwPQl6WRMKEnd16kg35HS3yE+VhBc8vN4+BBIlrgs7X0aoT+AbEd/sQLMisDgxNboCF44Ho3RCKtztiPb9blqg==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.15.0.tgz",
+      "integrity": "sha512-td+wSBdVUPO3mEPcEHZwJiVEQ0+wplJCHBvM1PHqwQd+miB2mQAaiSkzdAAHzUpTeqPBI3rzjWPn59WkCcVF5Q==",
       "requires": {
-        "@sentry/types": "5.13.2",
+        "@sentry/types": "5.15.0",
         "tslib": "^1.9.3"
       }
     },
@@ -728,9 +733,9 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
     },
     "@types/node": {
-      "version": "13.9.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
-      "integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ=="
+      "version": "13.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.2.tgz",
+      "integrity": "sha512-bnoqK579sAYrQbp73wwglccjJ4sfRdKU7WNEZ5FW4K2U6Kc0/eZ5kvXG0JKsEKFB50zrFmfFt52/cvBbZa7eXg=="
     },
     "@types/node-fetch": {
       "version": "2.5.5",
@@ -963,12 +968,9 @@
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "array-union": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "requires": {
-        "array-uniq": "^1.0.1"
-      }
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
     },
     "array-uniq": {
       "version": "1.0.3",
@@ -1470,19 +1472,12 @@
       "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
     },
     "cookie-parser": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.4.tgz",
-      "integrity": "sha512-lo13tqF3JEtFO7FyA49CqbhaFkskRJ0u/UAiINgrIXeRCY41c88/zxtrECl8AKH3B0hj9q10+h3Kt8I7KlW4tw==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.5.tgz",
+      "integrity": "sha512-f13bPUj/gG/5mDr+xLmSxxDsB9DQiTIfhJS/sqjrmfAWiAN+x2O4i/XguTL9yDZ+/IFDanJ+5x7hC4CXT9Tdzw==",
       "requires": {
-        "cookie": "0.3.1",
+        "cookie": "0.4.0",
         "cookie-signature": "1.0.6"
-      },
-      "dependencies": {
-        "cookie": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
-        }
       }
     },
     "cookie-signature": {
@@ -1800,11 +1795,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
       "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w=="
-    },
-    "esutils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "etag": {
       "version": "1.8.1",
@@ -2276,6 +2266,14 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
           "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
+        },
+        "array-union": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+          "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+          "requires": {
+            "array-uniq": "^1.0.1"
+          }
         },
         "braces": {
           "version": "2.3.2",
@@ -2846,9 +2844,9 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isbinaryfile": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.4.tgz",
-      "integrity": "sha512-pEutbN134CzcjlLS1myKX/uxNjwU5eBVSprvkpv3+3dqhBHUZLIWJQowC40w5c0Zf19vBY8mrZl88y5J4RAPbQ=="
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.5.tgz",
+      "integrity": "sha512-Jvz0gpTh1AILHMCBUyqq7xv1ZOQrxTDwyp1/QUq1xFpOBvp4AH5uEobPePJht8KnBGqQIH7We6OR73mXsjG0cA=="
     },
     "isexe": {
       "version": "2.0.0",
@@ -3145,9 +3143,9 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minipass": {
       "version": "3.1.1",
@@ -3186,11 +3184,11 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
+      "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
       }
     },
     "mri": {
@@ -3214,13 +3212,6 @@
         "array-union": "^2.1.0",
         "arrify": "^2.0.1",
         "minimatch": "^3.0.4"
-      },
-      "dependencies": {
-        "array-union": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-          "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
-        }
       }
     },
     "mz": {
@@ -3257,18 +3248,18 @@
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
     "nexus": {
-      "version": "0.12.0-rc.13",
-      "resolved": "https://registry.npmjs.org/nexus/-/nexus-0.12.0-rc.13.tgz",
-      "integrity": "sha512-RugEHXQyQXYg1i0PX0y9T/ZXliJidOnlmJxl4OeDqxedWM5QEl2qSA6Y0cOyd7p+xFh4y37zlDVh/nXw8LMnHg==",
+      "version": "0.12.0-rc.14",
+      "resolved": "https://registry.npmjs.org/nexus/-/nexus-0.12.0-rc.14.tgz",
+      "integrity": "sha512-cXJh+ZS0xq2ra+EidpUrKxRd1oc1Wipv3n8HlIUJF8nbN3ojzmyDylJ4VxjizhGjH+Wu0AGsCUuNukUNGkPr3Q==",
       "requires": {
         "iterall": "^1.2.2",
         "tslib": "^1.9.3"
       }
     },
     "nexus-future": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/nexus-future/-/nexus-future-0.11.1.tgz",
-      "integrity": "sha512-vTs7RGfoOYU0XDJ4ThbqAcbn9gRCF361/uNA3DMCLOMxvmaO8xvQBhcTnmT9skR5fUOH4FE+RpNBa03hP4Fyqg==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/nexus-future/-/nexus-future-0.12.0.tgz",
+      "integrity": "sha512-5hnv15Q3xbMZsf9E7qeqlSDVyo/RXwW3TuHNAlNQ8bMuSwE3MzjvPuW/MsHN4jFbS6wgAWN0wrAHoHXR+qrj8g==",
       "requires": {
         "@nexus/schema": "^0.12.0-rc.13",
         "@types/express": "^4.17.2",
@@ -3301,9 +3292,9 @@
       }
     },
     "nexus-plugin-prisma": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/nexus-plugin-prisma/-/nexus-plugin-prisma-0.4.4.tgz",
-      "integrity": "sha512-A6n8H6NYkZvPuKU1aUfTRAlq91GlSeoBr43WAhxonbI14vqW+u5zQ7H5HAmtIQzuPPJJSWOYCEZb8XFBrbt6FQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/nexus-plugin-prisma/-/nexus-plugin-prisma-0.5.1.tgz",
+      "integrity": "sha512-pii4vWVFmEXX+Tc4aOwihjPYvSvYLzWeJqwVBy8bUohDX5xHdFIMN6hWIcXSBQbPg95E/iFm+ssOLQKa4otRaw==",
       "requires": {
         "@prisma/client": "2.0.0-preview023",
         "@prisma/generator-helper": "0.0.43",
@@ -3776,10 +3767,9 @@
       "integrity": "sha512-VVtxR7sOh0VsG8o06Ttq5TrI1aiZKmC+ClSn4eBPaNf4SHr5lzbYW+kYGX3HocBL/MfpVrRfFZ9V3vCbLaiplg=="
     },
     "prisma2": {
-      "version": "2.0.0-preview024",
-      "resolved": "https://registry.npmjs.org/prisma2/-/prisma2-2.0.0-preview024.tgz",
-      "integrity": "sha512-hQJjD0/Wv7evgH2XzHN1pSJPiVgZd8QI0cDyP+1mECUs4NBCUCrxPao7eNF5g8HGsjs30YR2/ree6i6TuwmfiQ==",
-      "dev": true
+      "version": "2.0.0-preview023",
+      "resolved": "https://registry.npmjs.org/prisma2/-/prisma2-2.0.0-preview023.tgz",
+      "integrity": "sha512-rwK1fzVcC9S9eJJBn1qBwO3ccuN0FRii3UkQcwIGg98jyo3nx0QuLSmH0c6xtxDWhzIN1sRMepZf959AaVNxkA=="
     },
     "prismjs": {
       "version": "1.19.0",
@@ -3800,9 +3790,9 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
     },
     "prompts": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.1.tgz",
-      "integrity": "sha512-qIP2lQyCwYbdzcqHIUi2HAxiWixhoM9OdLCWf8txXsapC/X9YdsCoeyRIXE/GP+Q0J37Q7+XN/MFqbUa7IzXNA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
+      "integrity": "sha512-Q06uKs2CkNYVID0VqwfAl9mipo99zkBv/n2JtWY89Yxa3ZabWSrs0e2KTudKVa3peLUvYXMefDqIleLPVUBZMA==",
       "requires": {
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.4"
@@ -3915,9 +3905,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
       "dev": true
     },
     "regex-not": {
@@ -4148,9 +4138,9 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "simple-git": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.131.0.tgz",
-      "integrity": "sha512-z/art7YYtmPnnLItT/j+nKwJt6ap6nHZ4D8sYo9PdCKK/ug56SN6m/evfxJk7uDV3e9JuCa8qIyDU2P3cxmiNQ==",
+      "version": "1.132.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.132.0.tgz",
+      "integrity": "sha512-xauHm1YqCTom1sC9eOjfq3/9RKiUA9iPnxBbrY2DdL8l4ADMu0jjM5l5lphQP5YWNqAL2aXC/OeuQ76vHtW5fg==",
       "requires": {
         "debug": "^4.0.1"
       },
@@ -4166,9 +4156,9 @@
       }
     },
     "sisteransi": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.4.tgz",
-      "integrity": "sha512-/ekMoM4NJ59ivGSfKapeG+FWtrmWvA1p6FBZwXrqojw90vJu8lBmrTxCMuBCydKtkaUe2zt4PlxeTKpjwMbyig=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
     },
     "slash": {
       "version": "2.0.0",
@@ -4644,9 +4634,9 @@
       }
     },
     "ts-node": {
-      "version": "8.6.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.6.2.tgz",
-      "integrity": "sha512-4mZEbofxGqLL2RImpe3zMJukvEvcO1XP8bj8ozBPySdCUXEcU5cIRwR0aM3R+VoZq7iXc8N86NC0FspGRqP4gg==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.7.0.tgz",
+      "integrity": "sha512-s659CsHrsxaRVDEleuOkGvbsA0rWHtszUNEt1r0CgAFN5ZZTQtDzpsluS7W5pOGJIa1xZE8R/zK4dEs+ldFezg==",
       "requires": {
         "arg": "^4.1.0",
         "diff": "^4.0.1",
@@ -4883,12 +4873,12 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.7.2.tgz",
-      "integrity": "sha512-qXROVp90sb83XtAoqE8bP9RwAkTTZbugRUTm5YeFCBfNRPEp2YzTeqWiz7m5OORHzEvrA/qcGS8hp/E+MMROYw==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.8.2.tgz",
+      "integrity": "sha512-omakb0d7FjMo3R1D2EbTKVIk6dAVLRxFXdLZMEUToeAvuqgG/YuHMuQOZ5fgk+vQ8cx+cnGKwyg+8g8PNT0xQg==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.6.3"
+        "@babel/runtime": "^7.8.7"
       }
     },
     "yn": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -38,14 +38,13 @@
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",
     "jsonwebtoken": "^8.5.1",
-    "nexus-future": "^0.11.1",
-    "nexus-plugin-prisma": "^0.4.4"
+    "nexus-future": "^0.12.0",
+    "nexus-plugin-prisma": "^0.5.1"
   },
   "devDependencies": {
     "@types/cors": "^2.8.6",
     "husky": "^4.2.3",
     "prettier": "^1.19.1",
-    "pretty-quick": "^2.0.1",
-    "prisma2": "^2.0.0-preview024"
+    "pretty-quick": "^2.0.1"
   }
 }


### PR DESCRIPTION
## Description

The `nexus-future` package now ships with `prisma2` which greatly reduces our overhead and need to manage this rapidly changing dependency ourselves 🙌🏼 So I'm removing this from our `devDependencies` and moving to the version that ships with `nexus-future`.

Upgrade packages:
```
"nexus-future": "^0.12.0",
"nexus-plugin-prisma": "^0.5.1"
```

## Sub-Tasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Perform upgrades
- [x] Test 🧪
