### PR TITLE
Implement nav with transitions

### DIFF
--- a/frontend/components/Dashboard/Dashboard.tsx
+++ b/frontend/components/Dashboard/Dashboard.tsx
@@ -1,21 +1,52 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
+import { useRouter } from 'next/router'
 import Nav, { navConstants } from './Nav'
 import Header from './Header'
-import { lightGrey } from '../../utils'
+import useWindowSize from '../Hooks/useWindowSize'
 
-const Dashboard = ({ children }) => {
-  const handleMenuClick = () => {
+interface Props {
+  children: React.ReactNode
+}
+
+const Dashboard: React.FC<Props> = ({ children }) => {
+  const { width } = useWindowSize()
+  const router = useRouter()
+  const [navExpanded, setNavExpanded] = useState(false)
+
+  const toggleNav = (): void => {
+    setNavExpanded(!navExpanded)
   }
+
+  useEffect((): void => {
+    // Going from tablet to desktop expands the nav
+    if (width >= navConstants.desktopBreakpoint) {
+      if (router.pathname.endsWith('/settings')) {
+        setNavExpanded(false)
+        return
+      }
+
+      setNavExpanded(true)
+      return
+    }
+
+    // Going from mobile to tablet collapses the nav
+    if (width >= navConstants.mobileBreakpoint) {
+      setNavExpanded(false)
+    }
+  }, [width, router.pathname])
 
   return (
     <div className="dashboard">
-      <Header onMenuClick={handleMenuClick} />
-      <Nav />
+      <Header onMenuClick={toggleNav} />
+
+      <Nav expanded={navExpanded} collapse={() => setNavExpanded(false)} />
+
       <div className="dashboard-container">{children}</div>
+
       <style jsx>{`
         .dashboard {
+          position: relative;
           width: 100%;
-          background-color: ${lightGrey};
         }
 
         .dashboard-container {
@@ -24,13 +55,12 @@ const Dashboard = ({ children }) => {
           background-color: white;
         }
 
-        @media (min-width: ${navConstants.mobileBreakpoint}px) and (max-width: ${navConstants.desktopBreakpoint -
-          1}px) {
+        @media (${navConstants.skinnyNavToDesktop}) {
           .dashboard-container {
             margin-left: ${navConstants.skinnyNavWidth}px;
           }
         }
-        @media (min-width: ${navConstants.desktopBreakpoint}px) {
+        @media (${navConstants.aboveDesktopNav}) {
           .dashboard-container {
             margin-left: ${navConstants.navWidth}px;
           }

--- a/frontend/components/Dashboard/Dashboard.tsx
+++ b/frontend/components/Dashboard/Dashboard.tsx
@@ -1,19 +1,39 @@
 import React from 'react'
-import Nav from './Nav'
+import Nav, { navConstants } from './Nav'
+import Header from './Header'
+import { lightGrey } from '../../utils'
 
 const Dashboard = ({ children }) => {
+  const handleMenuClick = () => {
+  }
+
   return (
-    <div>
+    <div className="dashboard">
+      <Header onMenuClick={handleMenuClick} />
       <Nav />
       <div className="dashboard-container">{children}</div>
       <style jsx>{`
-        display: flex;
+        .dashboard {
+          width: 100%;
+          background-color: ${lightGrey};
+        }
 
         .dashboard-container {
-          display: flex;
-          flex-direction: column;
-          width: 100%;
+          margin: 0 auto;
+          padding: 2rem;
           background-color: white;
+        }
+
+        @media (min-width: ${navConstants.mobileBreakpoint}px) and (max-width: ${navConstants.desktopBreakpoint -
+          1}px) {
+          .dashboard-container {
+            margin-left: ${navConstants.skinnyNavWidth}px;
+          }
+        }
+        @media (min-width: ${navConstants.desktopBreakpoint}px) {
+          .dashboard-container {
+            margin-left: ${navConstants.navWidth}px;
+          }
         }
       `}</style>
     </div>

--- a/frontend/components/Dashboard/Dashboard.tsx
+++ b/frontend/components/Dashboard/Dashboard.tsx
@@ -50,9 +50,10 @@ const Dashboard: React.FC<Props> = ({ children }) => {
         }
 
         .dashboard-container {
-          margin: 0 auto;
           padding: 2rem;
           background-color: white;
+          transition: margin-left ${navConstants.transitionDuration}ms
+            ease-in-out;
         }
 
         @media (${navConstants.skinnyNavToDesktop}) {

--- a/frontend/components/Dashboard/Header/Header.tsx
+++ b/frontend/components/Dashboard/Header/Header.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { brandBlack } from '../../../utils'
+import { black } from '../../../utils'
 import { navConstants } from '../Nav'
 
 interface Props {
@@ -25,10 +25,10 @@ const Header: React.FC<Props> = ({ onMenuClick }) => {
           height: 72px;
           padding: 20px 0;
           color: white;
-          background-color: ${brandBlack};
+          background-color: ${black};
         }
         /* Header should disappear when the mobile nav does */
-        @media (min-width: ${navConstants.mobileBreakpoint}px) {
+        @media (${navConstants.aboveMobileNav}) {
           .header {
             display: none;
           }

--- a/frontend/components/Dashboard/Header/Header.tsx
+++ b/frontend/components/Dashboard/Header/Header.tsx
@@ -59,6 +59,7 @@ const Header: React.FC<Props> = ({ onMenuClick }) => {
         }
 
         .logo-text {
+          font-family: 'Playfair Display', serif;
           margin-right: 20px;
         }
       `}</style>

--- a/frontend/components/Dashboard/Header/Header.tsx
+++ b/frontend/components/Dashboard/Header/Header.tsx
@@ -1,0 +1,69 @@
+import React from 'react'
+import { brandBlack } from '../../../utils'
+import { navConstants } from '../Nav'
+
+interface Props {
+  onMenuClick: () => void
+}
+
+const Header: React.FC<Props> = ({ onMenuClick }) => {
+  return (
+    <div className="header">
+      <div className="hamburger-icon" onClick={onMenuClick}>
+        <div />
+        <div />
+        <div />
+      </div>
+
+      <span className="logo-text">Journaly</span>
+
+      <style jsx>{`
+        .header {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          height: 72px;
+          padding: 20px 0;
+          color: white;
+          background-color: ${brandBlack};
+        }
+        /* Header should disappear when the mobile nav does */
+        @media (min-width: ${navConstants.mobileBreakpoint}px) {
+          .header {
+            display: none;
+          }
+        }
+
+        .hamburger-icon {
+          margin-left: 10px;
+          padding: 10px;
+          cursor: pointer;
+          /* Allow hamburger icon to appear through open, overlaid mobile <Nav /> */
+          z-index: ${navConstants.zIndex + 1};
+        }
+
+        .hamburger-icon div {
+          height: 1px;
+          width: 32px;
+          background-color: white;
+        }
+
+        .hamburger-icon div:nth-child(2) {
+          margin-top: 7px;
+          width: 24px;
+        }
+
+        .hamburger-icon div:nth-child(3) {
+          margin-top: 7px;
+          width: 18px;
+        }
+
+        .logo-text {
+          margin-right: 20px;
+        }
+      `}</style>
+    </div>
+  )
+}
+
+export default Header

--- a/frontend/components/Dashboard/Header/index.ts
+++ b/frontend/components/Dashboard/Header/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Header'

--- a/frontend/components/Dashboard/Nav/Nav.tsx
+++ b/frontend/components/Dashboard/Nav/Nav.tsx
@@ -1,166 +1,140 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import Link from 'next/link'
-import { brandBlack, darkBlue, darkGrey } from '../../../utils'
-import { useTranslation } from '../../../config/i18n'
-import { useCurrentUserQuery } from '../../../generated/graphql'
+import { navConstants } from './nav-constants'
+import NavLinks from './NavLinks'
+import { black } from '../../../utils'
 
-const Nav = () => {
-  const { t } = useTranslation()
-  const { loading, error, data } = useCurrentUserQuery()
+interface Props {
+  expanded: boolean
+  collapse: () => void
+}
 
-  if (loading) {
-    return <p>{t('loading')}</p>
-  } else if (error) {
-    return <p>{t('error')}</p>
+const Nav: React.FC<Props> = ({ expanded, collapse }) => {
+  useEffect(() => {
+    setTimeout(() => {
+      document.body.classList.remove('block-transitions-on-page-load')
+    }, 0)
+  }, [])
+
+  const handleCollapse = (): void => {
+    // Collapse the nav after clicking a link for mobile only
+    if (window.innerWidth < navConstants.mobileBreakpoint) {
+      collapse()
+    }
   }
 
-  const currentUser = data.currentUser
-
   return (
-    <nav>
-      {currentUser && (
-        <>
-          <div className="nav-top">
-            <Link href="/dashboard/profile">
-              <a>
-                <img className="profile-img" src="/images/robin-small.png" />
-                <p className="current-user-name">Robin MacPherson</p>
-              </a>
-            </Link>
-          </div>
-          <div className="nav-bottom">
-            <Link href="/dashboard/my-feed">
-              <a className="nav-link">
-                <img src="../images/icons/your-feed-icon.svg" alt="" />
-                <span className="nav-link-text">My Feed</span>
-              </a>
-            </Link>
-            <Link href="/dashboard/my-posts">
-              <a className="nav-link">
-                <img src="../images/icons/your-feed-icon.svg" alt="" />
-                <span className="nav-link-text">My Posts</span>
-              </a>
-            </Link>
-            <Link href="/dashboard/new-post">
-              <a className="nav-link">
-                <img src="../images/icons/new-post-icon.svg" alt="" />
-                <span className="nav-link-text">New Post</span>
-              </a>
-            </Link>
-            <Link href="/dashboard/drafts">
-              <a className="nav-link">
-                <img src="../images/icons/drafts-icon.svg" alt="" />
-                <span className="nav-link-text">Drafts</span>
-              </a>
-            </Link>
+    <div className={expanded ? 'expanded' : ''}>
+      <div className="nav-background" onClick={handleCollapse} />
 
-            <hr />
+      <nav>
+        <NavLinks onClick={handleCollapse} />
 
-            <Link href="/dashboard/settings">
-              <a className="nav-link">
-                <img src="../images/icons/settings-icon.svg" alt="" />
-                <span className="nav-link-text">Settings</span>
-              </a>
-            </Link>
-            <Link href="/">
-              <a className="log-out nav-link">
-                <img src="../images/icons/logout-icon.svg" alt="Log out" />
-                <span className="nav-link-text">Log Out</span>
-              </a>
-            </Link>
-          </div>
-        </>
-      )}
-      <h1>
-        <Link href="/">
-          <a className="nav-logo">
-            J<span>ournaly</span>
-          </a>
-        </Link>
-      </h1>
+        <h1 className="nav-logo">
+          <Link href="/">
+            <a onClick={handleCollapse}>
+              J<span>ournaly</span>
+            </a>
+          </Link>
+        </h1>
+      </nav>
       <style jsx>{`
+        .nav-background {
+          position: fixed;
+          top: 0;
+          left: 0;
+          width: 100%;
+          background-color: rgba(0, 0, 0, 0.4);
+          opacity: 0;
+          transition: opacity 300ms ease-in-out;
+          z-index: ${navConstants.zIndex};
+        }
+
+        .expanded .nav-background {
+          opacity: 1;
+          /* Make background take up full screen */
+          bottom: 0;
+          right: 0;
+        }
+
+        @media (${navConstants.aboveMobileNav}) {
+          .nav-background {
+            display: none;
+          }
+        }
+
         nav {
-          position: absolute;
+          position: fixed;
+          top: 0;
+          left: 0;
           display: flex;
           flex-direction: column;
-          justify-content: space-between;
-          background-color: black;
-          background-size: contain;
-          width: 230px;
           height: 100vh;
-          padding-bottom: 20px;
+          width: ${navConstants.navWidth}px;
+          background-color: ${black};
+          z-index: ${navConstants.zIndex};
+          transform: translateX(-100%);
+          transition: transform 300ms ease-in-out, width 300ms ease-in-out;
         }
 
-        .nav-top a {
-          display: flex;
-          flex-direction: column;
-          align-items: center;
-          justify-content: center;
-          width: 100%;
+        .expanded nav {
+          /* Move the nav from off the screen to on the screen */
+          transform: translateX(0%);
         }
 
-        .nav-top .profile-img {
-          margin-top: 50px;
-          margin-bottom: 10px;
-          width: 60px;
-          height: 60px;
-          border-radius: 50%;
-          background-color: ${darkBlue};
-          object-fit: cover;
+        @media (${navConstants.aboveMobileNav}) {
+          nav {
+            transform: translateX(0%);
+          }
         }
-
-        .nav-top p {
-          margin: 5px 0 25px;
-          width: 100%;
-          text-align: center;
-          color: white;
-          font-size: 16px;
+        @media (${navConstants.skinnyNavToDesktop}) {
+          nav {
+            width: ${navConstants.skinnyNavWidth}px;
+          }
         }
-
-        .nav-bottom {
-          display: flex;
-          flex-direction: column;
-          padding-left: 25px;
-        }
-
-        .nav-bottom hr {
-          width: 140px;
-          border: 1px solid white;
-          margin: 0;
-        }
-
-        .nav-link {
-          display: flex;
-          align-items: center;
-          color: white;
-          font-size: 16px;
-          padding: 25px 0;
-        }
-
-        .nav-link:hover {
-          background-color: ${darkGrey};
-        }
-
-        .nav-link img {
-          width: 25px;
-          margin-right: 15px;
+        @media (${navConstants.aboveDesktopNav}) {
+          /* Allow certain pages, like settings, to have the skinny nav for the desktop breakpoint */
+          :not(.expanded) nav {
+            width: ${navConstants.skinnyNavWidth}px;
+          }
         }
 
         .nav-logo {
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          width: 100%;
-          margin: ${currentUser ? '0 15px 0 0' : '50vh 15px 0 0'};
-          font-size: 24px;
+          margin-bottom: 15px;
+          text-align: center;
+        }
+
+        .nav-logo a {
+          font-size: 40px;
+          /* Match the line-height of the parent h1 */
+          line-height: 56px;
           color: white;
         }
 
-        .logo a {
-          color: ${brandBlack};
+        .nav-logo span {
+          display: none;
+        }
+
+        .expanded .nav-logo a {
+          font-size: 24px;
+          animation: fadeIn 300ms linear;
+        }
+
+        .expanded .nav-logo span {
+          display: inline;
+        }
+        @media (${navConstants.mobileNavOnly}) {
+          .nav-logo a {
+            font-size: 24px;
+            animation: fadeIn 300ms linear;
+          }
+
+          .nav-logo span {
+            display: inline;
+          }
         }
       `}</style>
-    </nav>
+    </div>
   )
 }
 

--- a/frontend/components/Dashboard/Nav/Nav.tsx
+++ b/frontend/components/Dashboard/Nav/Nav.tsx
@@ -124,6 +124,10 @@ const Nav: React.FC<Props> = ({ expanded, collapse }) => {
         .expanded .nav-logo span {
           display: inline;
         }
+        /*
+          See comment in NavLinks for why these styles must be duplicated
+          for both .expanded and the mobile nav media query
+        */
         @media (${navConstants.mobileNavOnly}) {
           .nav-logo a {
             font-size: 24px;

--- a/frontend/components/Dashboard/Nav/Nav.tsx
+++ b/frontend/components/Dashboard/Nav/Nav.tsx
@@ -46,7 +46,7 @@ const Nav: React.FC<Props> = ({ expanded, collapse }) => {
           width: 100%;
           background-color: rgba(0, 0, 0, 0.4);
           opacity: 0;
-          transition: opacity 300ms ease-in-out;
+          transition: opacity ${navConstants.transitionDuration}ms ease-in-out;
           z-index: ${navConstants.zIndex};
         }
 
@@ -74,7 +74,8 @@ const Nav: React.FC<Props> = ({ expanded, collapse }) => {
           background-color: ${black};
           z-index: ${navConstants.zIndex};
           transform: translateX(-100%);
-          transition: transform 300ms ease-in-out, width 300ms ease-in-out;
+          transition: transform ${navConstants.transitionDuration}ms ease-in-out,
+            width ${navConstants.transitionDuration}ms ease-in-out;
         }
 
         .expanded nav {
@@ -117,7 +118,7 @@ const Nav: React.FC<Props> = ({ expanded, collapse }) => {
 
         .expanded .nav-logo a {
           font-size: 24px;
-          animation: fadeIn 300ms linear;
+          animation: fadeIn ${navConstants.transitionDuration}ms linear;
         }
 
         .expanded .nav-logo span {
@@ -126,7 +127,7 @@ const Nav: React.FC<Props> = ({ expanded, collapse }) => {
         @media (${navConstants.mobileNavOnly}) {
           .nav-logo a {
             font-size: 24px;
-            animation: fadeIn 300ms linear;
+            animation: fadeIn ${navConstants.transitionDuration}ms linear;
           }
 
           .nav-logo span {

--- a/frontend/components/Dashboard/Nav/Nav.tsx
+++ b/frontend/components/Dashboard/Nav/Nav.tsx
@@ -80,6 +80,7 @@ const Nav = () => {
       </h1>
       <style jsx>{`
         nav {
+          position: absolute;
           display: flex;
           flex-direction: column;
           justify-content: space-between;

--- a/frontend/components/Dashboard/Nav/NavLinks.tsx
+++ b/frontend/components/Dashboard/Nav/NavLinks.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Link from 'next/link'
+import NavLink from '../../NavLink'
 import { navConstants } from './nav-constants'
 import { darkBlue, darkGrey } from '../../../utils'
 import { useTranslation } from '../../../config/i18n'
@@ -32,39 +33,39 @@ const NavLinks: React.FC<Props> = ({ onClick }) => {
         </Link>
       </div>
       <div className="nav-bottom">
-        <Link href="/dashboard/my-feed">
+        <NavLink href="/dashboard/my-feed">
           <a className="nav-link" onClick={onClick}>
             <img src="../images/icons/your-feed-icon.svg" alt="" />
             <span className="nav-link-text">{t('nav.myFeed')}</span>
           </a>
-        </Link>
-        <Link href="/dashboard/my-posts">
+        </NavLink>
+        <NavLink href="/dashboard/my-posts">
           <a className="nav-link" onClick={onClick}>
             <img src="../images/icons/your-feed-icon.svg" alt="" />
             <span className="nav-link-text">{t('nav.myPosts')}</span>
           </a>
-        </Link>
-        <Link href="/dashboard/new-post">
+        </NavLink>
+        <NavLink href="/dashboard/new-post">
           <a className="nav-link" onClick={onClick}>
             <img src="../images/icons/new-post-icon.svg" alt="" />
             <span className="nav-link-text">{t('nav.newPost')}</span>
           </a>
-        </Link>
-        <Link href="/dashboard/drafts">
+        </NavLink>
+        <NavLink href="/dashboard/drafts">
           <a className="nav-link" onClick={onClick}>
             <img src="../images/icons/drafts-icon.svg" alt="" />
             <span className="nav-link-text">{t('nav.drafts')}</span>
           </a>
-        </Link>
+        </NavLink>
 
         <hr />
 
-        <Link href="/dashboard/settings">
+        <NavLink href="/dashboard/settings">
           <a className="nav-link" onClick={onClick}>
             <img src="../images/icons/settings-icon.svg" alt="" />
             <span className="nav-link-text">{t('nav.settings')}</span>
           </a>
-        </Link>
+        </NavLink>
 
         <Link href="/">
           <a className="log-out nav-link" onClick={handleLogOut}>
@@ -216,6 +217,7 @@ const NavLinks: React.FC<Props> = ({ onClick }) => {
           }
         }
 
+        .nav-link.active,
         .nav-link:hover {
           background-color: ${darkGrey};
         }

--- a/frontend/components/Dashboard/Nav/NavLinks.tsx
+++ b/frontend/components/Dashboard/Nav/NavLinks.tsx
@@ -74,6 +74,23 @@ const NavLinks: React.FC<Props> = ({ onClick }) => {
         </Link>
       </div>
       <style jsx>{`
+        /*
+          Note:
+
+          Default styles are for the skinny nav, which appears between mobile and desktop.
+
+          For mobile and desktop, duplicated styles are required
+          in both :global(.expanded) *  { ... } and the mobile nav media query.
+
+          This is because certain pages, like settings, default to the skinny
+          nav, even on desktop.
+
+          The reverse (default styles for the expanded nav, and overrides with the
+          skinny nav media query) results in the same situation, since we'd need to
+          duplicate styles in the desktop media query to keep the skinny nav on the
+          settings page.
+        */
+
         .nav-top {
           margin-top: 50px;
           margin-bottom: 50px;

--- a/frontend/components/Dashboard/Nav/NavLinks.tsx
+++ b/frontend/components/Dashboard/Nav/NavLinks.tsx
@@ -121,7 +121,7 @@ const NavLinks: React.FC<Props> = ({ onClick }) => {
           font-size: 16px;
           text-align: center;
           color: white;
-          animation: fadeIn 300ms linear;
+          animation: fadeIn ${navConstants.transitionDuration}ms linear;
         }
 
         @media (${navConstants.mobileNavOnly}) {
@@ -132,7 +132,7 @@ const NavLinks: React.FC<Props> = ({ onClick }) => {
             font-size: 16px;
             text-align: center;
             color: white;
-            animation: fadeIn 300ms linear;
+            animation: fadeIn ${navConstants.transitionDuration}ms linear;
           }
         }
 
@@ -185,7 +185,7 @@ const NavLinks: React.FC<Props> = ({ onClick }) => {
           flex-direction: row;
           height: auto;
           padding: 25px;
-          animation: fadeIn 300ms linear;
+          animation: fadeIn ${navConstants.transitionDuration}ms linear;
         }
 
         @media (${navConstants.mobileNavOnly}) {
@@ -193,7 +193,7 @@ const NavLinks: React.FC<Props> = ({ onClick }) => {
             flex-direction: row;
             height: auto;
             padding: 25px;
-            animation: fadeIn 300ms linear;
+            animation: fadeIn ${navConstants.transitionDuration}ms linear;
           }
         }
 

--- a/frontend/components/Dashboard/Nav/NavLinks.tsx
+++ b/frontend/components/Dashboard/Nav/NavLinks.tsx
@@ -1,0 +1,235 @@
+import React from 'react'
+import Link from 'next/link'
+import { navConstants } from './nav-constants'
+import { darkBlue, darkGrey } from '../../../utils'
+import { useTranslation } from '../../../config/i18n'
+
+interface Props {
+  onClick: () => void
+}
+
+const NavLinks: React.FC<Props> = ({ onClick }) => {
+  const { t } = useTranslation()
+  // TODO: implement fetching user information (requires PR #17)
+  const user = {}
+  if (!user) return null
+  const logout = (): void => {
+    // TODO: implement logout functionality (requires PR #17)
+  }
+  const handleLogOut = (): void => {
+    onClick()
+    logout()
+  }
+
+  return (
+    <>
+      <div className="nav-top">
+        <Link href="/dashboard/profile">
+          <a onClick={onClick}>
+            <img className="profile-img" src="/images/robin-small.png" />
+            <p className="current-user-name">Robin MacPherson</p>
+          </a>
+        </Link>
+      </div>
+      <div className="nav-bottom">
+        <Link href="/dashboard/my-feed">
+          <a className="nav-link" onClick={onClick}>
+            <img src="../images/icons/your-feed-icon.svg" alt="" />
+            <span className="nav-link-text">{t('nav.myFeed')}</span>
+          </a>
+        </Link>
+        <Link href="/dashboard/my-posts">
+          <a className="nav-link" onClick={onClick}>
+            <img src="../images/icons/your-feed-icon.svg" alt="" />
+            <span className="nav-link-text">{t('nav.myPosts')}</span>
+          </a>
+        </Link>
+        <Link href="/dashboard/new-post">
+          <a className="nav-link" onClick={onClick}>
+            <img src="../images/icons/new-post-icon.svg" alt="" />
+            <span className="nav-link-text">{t('nav.newPost')}</span>
+          </a>
+        </Link>
+        <Link href="/dashboard/drafts">
+          <a className="nav-link" onClick={onClick}>
+            <img src="../images/icons/drafts-icon.svg" alt="" />
+            <span className="nav-link-text">{t('nav.drafts')}</span>
+          </a>
+        </Link>
+
+        <hr />
+
+        <Link href="/dashboard/settings">
+          <a className="nav-link" onClick={onClick}>
+            <img src="../images/icons/settings-icon.svg" alt="" />
+            <span className="nav-link-text">{t('nav.settings')}</span>
+          </a>
+        </Link>
+
+        <Link href="/">
+          <a className="log-out nav-link" onClick={handleLogOut}>
+            <img src="../images/icons/logout-icon.svg" alt="Log out" />
+            <span className="nav-link-text">{t('nav.logOut')}</span>
+          </a>
+        </Link>
+      </div>
+      <style jsx>{`
+        .nav-top {
+          margin-top: 50px;
+          margin-bottom: 50px;
+        }
+
+        :global(.expanded) .nav-top {
+          margin-bottom: 25px;
+        }
+        @media (${navConstants.mobileNavOnly}) {
+          .nav-top {
+            margin-bottom: 25px;
+          }
+        }
+
+        .nav-top a {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          justify-content: center;
+          width: 100%;
+        }
+
+        .profile-img {
+          width: 60px;
+          height: 60px;
+          border-radius: 50%;
+          background-color: ${darkBlue};
+          object-fit: cover;
+        }
+
+        .current-user-name,
+        .nav-link {
+          /* Prevent words from wrapping during transition */
+          white-space: nowrap;
+        }
+
+        .current-user-name {
+          display: none;
+        }
+
+        :global(.expanded) .current-user-name {
+          display: block;
+          width: 100%;
+          margin-top: 15px;
+          font-size: 16px;
+          text-align: center;
+          color: white;
+          animation: fadeIn 300ms linear;
+        }
+
+        @media (${navConstants.mobileNavOnly}) {
+          .current-user-name {
+            display: block;
+            width: 100%;
+            margin-top: 15px;
+            font-size: 16px;
+            text-align: center;
+            color: white;
+            animation: fadeIn 300ms linear;
+          }
+        }
+
+        .nav-bottom {
+          display: flex;
+          flex-direction: column;
+          /* Expands the links to push the Journaly "J" logo down to the bottom */
+          flex-grow: 2;
+        }
+
+        .nav-bottom hr {
+          width: 40px;
+          margin-top: 10px;
+          margin-bottom: 10px;
+          border: 1px solid white;
+        }
+
+        :global(.expanded) .nav-bottom hr {
+          width: 180px;
+          margin: 0 auto;
+        }
+
+        @media (${navConstants.mobileNavOnly}) {
+          .nav-bottom hr {
+            width: 180px;
+            margin: 0 auto;
+          }
+        }
+
+        @keyframes fadeIn {
+          from {
+            opacity: 0;
+          }
+          to {
+            opacity: 1;
+          }
+        }
+
+        .nav-link {
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+          align-items: center;
+          height: 70px;
+          font-size: 16px;
+          color: white;
+        }
+
+        :global(.expanded) .nav-link {
+          flex-direction: row;
+          height: auto;
+          padding: 25px;
+          animation: fadeIn 300ms linear;
+        }
+
+        @media (${navConstants.mobileNavOnly}) {
+          .nav-link {
+            flex-direction: row;
+            height: auto;
+            padding: 25px;
+            animation: fadeIn 300ms linear;
+          }
+        }
+
+        .nav-link:hover {
+          background-color: ${darkGrey};
+        }
+
+        .nav-link img {
+          width: 25px;
+          margin-right: 0;
+        }
+
+        :global(.expanded) .nav-link img {
+          margin-right: 15px;
+        }
+        @media (${navConstants.mobileNavOnly}) {
+          .nav-link img {
+            margin-right: 15px;
+          }
+        }
+
+        .nav-link-text {
+          font-size: 10px;
+        }
+
+        :global(.expanded) .nav-link-text {
+          font-size: 16px;
+        }
+        @media (${navConstants.mobileNavOnly}) {
+          .nav-link-text {
+            font-size: 16px;
+          }
+        }
+      `}</style>
+    </>
+  )
+}
+
+export default NavLinks

--- a/frontend/components/Dashboard/Nav/NavLinks.tsx
+++ b/frontend/components/Dashboard/Nav/NavLinks.tsx
@@ -191,8 +191,8 @@ const NavLinks: React.FC<Props> = ({ onClick }) => {
         .nav-link {
           display: flex;
           flex-direction: column;
-          justify-content: center;
           align-items: center;
+          justify-content: center;
           height: 70px;
           font-size: 16px;
           color: white;
@@ -200,6 +200,7 @@ const NavLinks: React.FC<Props> = ({ onClick }) => {
 
         :global(.expanded) .nav-link {
           flex-direction: row;
+          justify-content: normal;
           height: auto;
           padding: 25px;
           animation: fadeIn ${navConstants.transitionDuration}ms linear;
@@ -208,6 +209,7 @@ const NavLinks: React.FC<Props> = ({ onClick }) => {
         @media (${navConstants.mobileNavOnly}) {
           .nav-link {
             flex-direction: row;
+            justify-content: normal;
             height: auto;
             padding: 25px;
             animation: fadeIn ${navConstants.transitionDuration}ms linear;

--- a/frontend/components/Dashboard/Nav/index.ts
+++ b/frontend/components/Dashboard/Nav/index.ts
@@ -1,1 +1,2 @@
 export { default } from './Nav'
+export { navConstants } from './nav-constants'

--- a/frontend/components/Dashboard/Nav/nav-constants.ts
+++ b/frontend/components/Dashboard/Nav/nav-constants.ts
@@ -13,4 +13,5 @@ export const navConstants = {
   zIndex: 100,
   skinnyNavWidth: 80,
   navWidth: 230,
+  transitionDuration: 300,
 }

--- a/frontend/components/Dashboard/Nav/nav-constants.ts
+++ b/frontend/components/Dashboard/Nav/nav-constants.ts
@@ -1,8 +1,16 @@
+const mobileBreakpoint = 850
+const desktopBreakpoint = 1200
+
 export const navConstants = {
-  mobileBreakpoint: 850,
-  desktopBreakpoint: 1200,
+  mobileBreakpoint,
+  desktopBreakpoint,
+  mobileNavOnly: `max-width: ${mobileBreakpoint - 1}px`,
+  aboveMobileNav: `min-width: ${mobileBreakpoint}px`,
+  skinnyNavToDesktop: `
+    min-width: ${mobileBreakpoint}px) and (max-width: ${desktopBreakpoint - 1}px
+  `,
+  aboveDesktopNav: `min-width: ${desktopBreakpoint}px`,
   zIndex: 100,
   skinnyNavWidth: 80,
   navWidth: 230,
 }
-

--- a/frontend/components/Dashboard/Nav/nav-constants.ts
+++ b/frontend/components/Dashboard/Nav/nav-constants.ts
@@ -1,0 +1,8 @@
+export const navConstants = {
+  mobileBreakpoint: 850,
+  desktopBreakpoint: 1200,
+  zIndex: 100,
+  skinnyNavWidth: 80,
+  navWidth: 230,
+}
+

--- a/frontend/components/Hooks/useWindowSize.ts
+++ b/frontend/components/Hooks/useWindowSize.ts
@@ -1,0 +1,34 @@
+import { useState, useEffect } from 'react'
+
+interface WindowSize {
+  height: number
+  width: number
+}
+
+const useWindowSize = (): WindowSize => {
+  const isClient = typeof window === 'object'
+
+  const getSize = () => {
+    return {
+      width: isClient ? window.innerWidth : undefined,
+      height: isClient ? window.innerHeight : undefined,
+    }
+  }
+
+  const [windowSize, setWindowSize] = useState<WindowSize>(getSize)
+
+  useEffect(() => {
+    if (!isClient) return
+
+    function handleResize() {
+      setWindowSize(getSize())
+    }
+
+    window.addEventListener('resize', handleResize)
+    return () => window.removeEventListener('resize', handleResize)
+  }, [])
+
+  return windowSize
+}
+
+export default useWindowSize

--- a/frontend/components/Layouts/DashboardLayout.js
+++ b/frontend/components/Layouts/DashboardLayout.js
@@ -1,5 +1,0 @@
-import Dashboard from '../Dashboard'
-
-const DashboardLayout = props => <Dashboard>{props.children}</Dashboard>
-
-export default DashboardLayout

--- a/frontend/components/Layouts/DashboardLayout.tsx
+++ b/frontend/components/Layouts/DashboardLayout.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import Dashboard from '../Dashboard'
+
+interface Props {
+  children: React.ReactNode
+}
+
+const DashboardLayout: React.FC<Props> = (props) => (
+  <Dashboard>{props.children}</Dashboard>
+)
+
+export default DashboardLayout

--- a/frontend/components/Layouts/DashboardLayout.tsx
+++ b/frontend/components/Layouts/DashboardLayout.tsx
@@ -5,8 +5,8 @@ interface Props {
   children: React.ReactNode
 }
 
-const DashboardLayout: React.FC<Props> = (props) => (
-  <Dashboard>{props.children}</Dashboard>
+const DashboardLayout: React.FC<Props> = ({ children }) => (
+  <Dashboard>{children}</Dashboard>
 )
 
 export default DashboardLayout

--- a/frontend/pages/_document.tsx
+++ b/frontend/pages/_document.tsx
@@ -54,7 +54,7 @@ class MyDocument extends Document<
           <link rel="shortcut icon" href="/favicon.png" />
           <link rel="stylesheet" type="text/css" href="/nprogress.css" />
         </Head>
-        <body>
+        <body className="block-transitions-on-page-load">
           <Main />
           <NextScript />
         </body>

--- a/frontend/public/static/locales/en/common.json
+++ b/frontend/public/static/locales/en/common.json
@@ -1,5 +1,13 @@
 {
   "signInPrompt": "Please sign in to continue.",
   "error": "An error occurred on the server",
-  "loading": "Loading..."
+  "loading": "Loading...",
+  "nav": {
+    "myFeed": "My Feed",
+    "myPosts": "My Posts",
+    "newPost": "New Post",
+    "drafts": "Drafts",
+    "settings": "Settings",
+    "logOut": "Log Out"
+  }
 }

--- a/frontend/styles/globalStyles.css
+++ b/frontend/styles/globalStyles.css
@@ -10,6 +10,11 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+/* Prevent transitions on page load */
+.block-transitions-on-page-load * {
+  transition: none !important;
+}
+
 h1,
 h2,
 h3,

--- a/frontend/utils/breakpoints.js
+++ b/frontend/utils/breakpoints.js
@@ -4,3 +4,7 @@ export const width = {
   desktop: 1040,
   desktopHD: 1364,
 }
+
+export const above = {
+  tablet: `min-width: ${width.tablet}px`,
+}

--- a/frontend/utils/colors.js
+++ b/frontend/utils/colors.js
@@ -1,4 +1,5 @@
 export const purple = '#524763'
+export const black = '#393939'
 export const charcoal = '#535353'
 export const darkBlue = '#32567E'
 export const lightBlue = '#4391C9'


### PR DESCRIPTION
## Description

Resolves #35. This PR finishes styling the nav and adds transitions. See sub tasks for details. Follow up task for collapsing/expanding the nav manually in issue #57.


## Sub-Tasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Display background overlay on mobile only
- [x] Animate open and closed on mobile
- [x] Expose header hamburger menu icon above mobile nav for toggling
- [x] Transition between mobile and tablet smoothly
- [x] Show skinny nav for settings page, even on desktop
- [x] Transition dashboard content in sync with nav
- [x] Prevent the nav from transitioning on page load
- [x] Extract link text to translated strings

## Screenshots

![fully_animated_nav](https://user-images.githubusercontent.com/5829188/79673859-6bae1300-8192-11ea-8ac6-279900226226.gif)