### PR TITLE
Create a modal component

### DIFF
--- a/frontend/.prettierrc.js
+++ b/frontend/.prettierrc.js
@@ -2,5 +2,5 @@ module.exports = {
   semi: false,
   singleQuote: true,
   trailingComma: 'all',
-  printWidth: 80,
+  printWidth: 100,
 }

--- a/frontend/components/Hooks/useFocusTrap.ts
+++ b/frontend/components/Hooks/useFocusTrap.ts
@@ -1,0 +1,85 @@
+import { useEffect } from 'react'
+
+type Options = {
+  // The element that we want to keep focus within
+  rootElement: HTMLElement
+  // Callback for hitting the escape key
+  onClose: () => void
+  // Once the focus trap is done with, focus should return to the element that initiated it
+  returnFocusElementId?: string
+  // Class to add to the body while focus trapped
+  bodyClass?: string
+}
+
+const ESCAPE_KEY = 27
+const TAB_KEY = 9
+
+/*
+ * Focus trap is used to keep a user's focus on a particular subset of the website.
+ *
+ * For example, when a user opens a modal, tabbing should cycle through only the elements in the modal,
+ * and not the rest of the site. This pattern is an accessibility best practice, see
+ * https://www.w3.org/TR/wai-aria-practices/#dialog_modal for more detail.
+ */
+function useFocusTrap(options: Options) {
+  const { rootElement, onClose, returnFocusElementId, bodyClass } = options
+
+  const handleTabKey = (event: KeyboardEvent): void => {
+    const focusableModalElements = rootElement.querySelectorAll(
+      'a[href], button, textarea, input[type="text"], input[type="radio"], input[type="checkbox"], select',
+    )
+    const firstElement = focusableModalElements[0] as HTMLElement
+    const lastElement = focusableModalElements[focusableModalElements.length - 1] as HTMLElement
+
+    // Make sure the first element is focused
+    if (![...focusableModalElements].includes(document.activeElement as HTMLElement)) {
+      firstElement.focus()
+    }
+
+    if (!event.shiftKey && document.activeElement === lastElement) {
+      // Tabbing forwards on the last element focuses the first element
+      firstElement.focus()
+      event.preventDefault()
+    } else if (event.shiftKey && document.activeElement === firstElement) {
+      // Tabbing backwards with Shift + Tab on the first element focuses the last element
+      lastElement.focus()
+      event.preventDefault()
+    }
+  }
+
+  const keyListenersMap = new Map([
+    [ESCAPE_KEY, onClose],
+    [TAB_KEY, handleTabKey],
+  ])
+
+  useEffect(() => {
+    function keyListener(event: KeyboardEvent): void {
+      const listener = keyListenersMap.get(event.keyCode)
+      return listener && listener(event)
+    }
+    document.addEventListener('keydown', keyListener)
+
+    return () => {
+      document.removeEventListener('keydown', keyListener)
+    }
+  })
+
+  useEffect(() => {
+    if (bodyClass) {
+      document.body.classList.add(bodyClass)
+    }
+
+    return () => {
+      if (bodyClass) {
+        document.body.classList.remove(bodyClass)
+      }
+
+      if (returnFocusElementId) {
+        const elementToFocus = document.getElementById(returnFocusElementId)
+        if (elementToFocus) elementToFocus.focus()
+      }
+    }
+  }, [])
+}
+
+export default useFocusTrap

--- a/frontend/components/Icons/XIcon.tsx
+++ b/frontend/components/Icons/XIcon.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react'
+interface SVGRProps {
+  title?: string
+  titleId?: string
+  size?: number
+}
+
+function XIcon({ title, titleId, size, ...props }: React.SVGProps<SVGSVGElement> & SVGRProps) {
+  if (!size) size = 24
+
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" aria-labelledby={titleId} {...props}>
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M0 0h24v24H0V0z" />
+      <path d="M18.3 5.71a.996.996 0 00-1.41 0L12 10.59 7.11 5.7A.996.996 0 105.7 7.11L10.59 12 5.7 16.89a.996.996 0 101.41 1.41L12 13.41l4.89 4.89a.996.996 0 101.41-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z" />
+    </svg>
+  )
+}
+
+export default XIcon

--- a/frontend/components/Modal/Modal.tsx
+++ b/frontend/components/Modal/Modal.tsx
@@ -1,0 +1,170 @@
+import React, { useState, useEffect } from 'react'
+import ReactDOM from 'react-dom'
+import ModalHeader from './ModalHeader'
+import ModalBody from './ModalBody'
+import ModalFooter from './ModalFooter'
+import modalConstants from './modalConstants'
+import { white } from '../../utils'
+
+interface Props {
+  onClose: () => void
+  title: React.ReactNode
+  body: React.ReactNode
+  footer?: React.ReactNode
+  ariaLabelledBy?: string
+  ariaDescribedBy?: string
+  triggerElementId?: string
+  maxWidth?: string
+}
+
+const ESCAPE_KEY = 27
+const TAB_KEY = 9
+const MODAL_OPEN_CLASS = 'modal-open'
+
+const Modal: React.FC<Props> = (props) => {
+  const [shouldFadeInTitle, setShouldFadeInTitle] = useState(false)
+  const modalRoot = document.getElementById('modal-root') as HTMLElement
+  const {
+    onClose,
+    title,
+    body,
+    footer,
+    ariaLabelledBy,
+    ariaDescribedBy,
+    triggerElementId = '',
+    maxWidth = modalConstants.modalBreakpoint,
+  } = props
+
+  const handleTabKey = (event: KeyboardEvent): void => {
+    const focusableModalElements = modalRoot.querySelectorAll(
+      'a[href], button, textarea, input[type="text"], input[type="radio"], input[type="checkbox"], select',
+    )
+    const firstElement = focusableModalElements[0] as HTMLElement
+    const lastElement = focusableModalElements[focusableModalElements.length - 1] as HTMLElement
+
+    // Make sure the first element is focused
+    if (![...focusableModalElements].includes(document.activeElement as HTMLElement)) {
+      firstElement.focus()
+    }
+
+    if (!event.shiftKey && document.activeElement === lastElement) {
+      // Tabbing forwards on the last element focuses the first element
+      firstElement.focus()
+      event.preventDefault()
+    } else if (event.shiftKey && document.activeElement === firstElement) {
+      // Tabbing backwards with Shift + Tab on the first element focuses the last element
+      lastElement.focus()
+      event.preventDefault()
+    }
+  }
+
+  const handleModalBodyScroll = (event: Event): void => {
+    if ((event.target as Element)?.scrollTop > 28) {
+      setShouldFadeInTitle(true)
+      return
+    }
+    setShouldFadeInTitle(false)
+  }
+
+  const keyListenersMap = new Map([
+    [ESCAPE_KEY, onClose],
+    [TAB_KEY, handleTabKey],
+  ])
+
+  useEffect(() => {
+    document.body.classList.add(MODAL_OPEN_CLASS)
+    return () => {
+      document.body.classList.remove(MODAL_OPEN_CLASS)
+      const elementToFocus = document.getElementById(triggerElementId)
+      if (elementToFocus) elementToFocus.focus()
+    }
+  }, [])
+
+  useEffect(() => {
+    function keyListener(event: KeyboardEvent): void {
+      const listener = keyListenersMap.get(event.keyCode)
+      return listener && listener(event)
+    }
+    document.addEventListener('keydown', keyListener)
+
+    return () => document.removeEventListener('keydown', keyListener)
+  })
+
+  return ReactDOM.createPortal(
+    <div className="modal-container" onClick={onClose}>
+      <div className="modal-wrapper">
+        <div
+          className="modal-content"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={ariaLabelledBy}
+          aria-describedby={ariaDescribedBy}
+          data-testid="modal"
+          onClick={(event) => event.stopPropagation()}
+        >
+          <ModalHeader title={title} onClose={onClose} showTitle={shouldFadeInTitle} />
+          <ModalBody ariaLabelledBy={ariaLabelledBy} title={title} onScroll={handleModalBodyScroll}>
+            {body}
+          </ModalBody>
+          {footer && <ModalFooter>{footer}</ModalFooter>}
+        </div>
+      </div>
+      <style jsx>{`
+        @keyframes enterFromBottom {
+          from {
+            transform: translateY(100%);
+          }
+
+          to {
+            transform: translateY(0);
+          }
+        }
+
+        .modal-container {
+          position: fixed;
+          top: 0;
+          bottom: 0;
+          left: 0;
+          right: 0;
+          background: rgba(0, 0, 0, 0.5);
+        }
+
+        .modal-wrapper {
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+          align-items: center;
+          height: 100%;
+          padding: 0;
+          overflow: auto;
+          animation: 375ms enterScreenFromBottom cubic-bezier(0, 0, 0.2, 1);
+        }
+        @media (min-width: ${modalConstants.modalBreakpoint}) {
+          .modal-wrapper {
+            padding: 64px 0;
+          }
+        }
+        .modal-content {
+          flex-grow: 1;
+          display: flex;
+          flex-direction: column;
+          max-height: 100%;
+          max-width: ${maxWidth};
+          background-color: ${white};
+        }
+        @media (min-width: ${modalConstants.modalBreakpoint}) {
+          .modal-content {
+            flex-grow: 0;
+            border-radius: 8px;
+          }
+          .modal-content .modal-body {
+            ${Boolean(footer) && `padding-bottom: 48px;`};
+          }
+        }
+      `}</style>
+    </div>,
+    modalRoot,
+  )
+}
+
+export default Modal

--- a/frontend/components/Modal/Modal.tsx
+++ b/frontend/components/Modal/Modal.tsx
@@ -112,11 +112,20 @@ const Modal: React.FC<Props> = (props) => {
       <style jsx>{`
         @keyframes enterFromBottom {
           from {
-            transform: translateY(100%);
+            transform: translateY(10%);
           }
 
           to {
             transform: translateY(0);
+          }
+        }
+        @keyframes fadeIn {
+          from {
+            opacity: 0;
+          }
+
+          to {
+            opacity: 1;
           }
         }
 
@@ -127,6 +136,7 @@ const Modal: React.FC<Props> = (props) => {
           left: 0;
           right: 0;
           background: rgba(0, 0, 0, 0.5);
+          animation: 100ms fadeIn linear;
         }
 
         .modal-wrapper {

--- a/frontend/components/Modal/Modal.tsx
+++ b/frontend/components/Modal/Modal.tsx
@@ -137,7 +137,7 @@ const Modal: React.FC<Props> = (props) => {
           height: 100%;
           padding: 0;
           overflow: auto;
-          animation: 375ms enterScreenFromBottom cubic-bezier(0, 0, 0.2, 1);
+          animation: 300ms enterFromBottom cubic-bezier(0, 0, 0.2, 1);
         }
         @media (min-width: ${modalConstants.modalBreakpoint}) {
           .modal-wrapper {

--- a/frontend/components/Modal/ModalBody.tsx
+++ b/frontend/components/Modal/ModalBody.tsx
@@ -1,0 +1,55 @@
+import React, { useEffect } from 'react'
+import modalConstants from './modalConstants'
+
+interface Props {
+  title: React.ReactNode
+  ariaLabelledBy?: string
+  children: React.ReactNode
+  onScroll: (event: Event) => void
+}
+
+const ModalBody: React.FC<Props> = (props) => {
+  const { title, ariaLabelledBy, children, onScroll } = props
+
+  const handleScroll = (event: Event): void => {
+    onScroll(event)
+  }
+
+  useEffect(() => {
+    const modalBody = document.getElementById('modal-body') as HTMLDivElement
+    modalBody.addEventListener('scroll', handleScroll)
+
+    return () => modalBody.removeEventListener('scroll', handleScroll)
+  }, [])
+
+  return (
+    <div id="modal-body">
+      <h1 id={ariaLabelledBy}>{title}</h1>
+
+      {children}
+
+      <style jsx>{`
+        #modal-body {
+          flex-grow: 1;
+          max-height: 100vh;
+          padding: 0 24px 48px;
+          overflow: auto;
+        }
+        @media (min-width: ${modalConstants.modalBreakpoint}) {
+          #modal-body {
+            padding: 0 64px 64px;
+          }
+        }
+
+        h1 {
+          margin-bottom: 16px;
+          font-size: 24px;
+          line-height: 32px;
+          font-weight: 500;
+        }
+      `}</style>
+    </div>
+  )
+}
+
+export default ModalBody

--- a/frontend/components/Modal/ModalFooter.tsx
+++ b/frontend/components/Modal/ModalFooter.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+
+interface Props {
+  children: React.ReactNode
+}
+
+const ModalFooter: React.FC<Props> = (props) => {
+  return (
+    <>
+      <div className="modal-footer" {...props} />
+      <style jsx>{`
+        .modal-footer {
+          display: flex;
+          justify-content: space-between;
+          padding: 24px 32px;
+          border-top: 1px solid #d4d8db;
+        }
+
+        /* If there's only one button in the footer, place all the way to the right */
+        .modal-footer :global(> *:last-child) {
+          margin-left: auto;
+        }
+      `}</style>
+    </>
+  )
+}
+
+export default ModalFooter

--- a/frontend/components/Modal/ModalHeader.tsx
+++ b/frontend/components/Modal/ModalHeader.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import Button from '../../elements/Button'
+import XIcon from '../Icons/XIcon'
+import modalConstants from './modalConstants'
+import { truncate, lightGrey } from '../../utils'
+
+interface Props {
+  onClose: () => void
+  title: React.ReactNode
+  showTitle: boolean
+}
+
+const ModalHeader: React.FC<Props> = ({ onClose, title, showTitle }) => {
+  return (
+    <div className="modal-header">
+      <Button plain onClick={onClose} className="modal-close-button">
+        <XIcon size={40} />
+        <span className="screen-reader">Close dialog</span>
+      </Button>
+
+      <h1 className="modal-title">{title}</h1>
+
+      <style jsx>{`
+        .modal-header {
+          position: relative;
+          padding: 14px 64px;
+          border-bottom: ${showTitle ? '1px solid #d4d8db' : 0};
+        }
+        @media (min-width: ${modalConstants.modalBreakpoint}) {
+          .modal-header {
+            padding: 22px 64px;
+          }
+        }
+
+        :global(.modal-close-button) {
+          position: absolute;
+          top: 8px;
+          right: 16px;
+          border-radius: 8px;
+        }
+        :global(.modal-close-button):hover {
+          background-color: ${lightGrey};
+        }
+        @media (min-width: ${modalConstants.modalBreakpoint}) {
+          :global(.modal-close-button) {
+            top: 16px;
+          }
+        }
+
+        h1 {
+          margin: 0 auto;
+          opacity: ${showTitle ? 1 : 0};
+          font-size: 20px;
+          line-height: 28px;
+          font-weight: 500;
+          text-align: center;
+          transition: opacity 150ms ease-in, border 150ms ease-in;
+          ${truncate(247)};
+        }
+        @media (min-width: ${modalConstants.modalBreakpoint}) {
+          h1 {
+            ${truncate(432)};
+          }
+        }
+      `}</style>
+    </div>
+  )
+}
+
+export default ModalHeader

--- a/frontend/components/Modal/index.ts
+++ b/frontend/components/Modal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Modal'

--- a/frontend/components/Modal/modalConstants.ts
+++ b/frontend/components/Modal/modalConstants.ts
@@ -1,0 +1,5 @@
+const modalConstants = {
+  modalBreakpoint: '560px',
+}
+
+export default modalConstants

--- a/frontend/elements/Button/Button.tsx
+++ b/frontend/elements/Button/Button.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+
+interface Props {
+  children: React.ReactNode
+  onClick?: () => void
+  className?: string
+  id?: string
+  plain?: boolean
+}
+
+const Button: React.FC<Props> = (props) => {
+  const { children, onClick, plain = false, ...otherProps } = props
+
+  return (
+    <button onClick={onClick} {...otherProps}>
+      {children}
+
+      <style jsx>{`
+        button {
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          padding: 8px 16px;
+          font-size: 14px;
+          font-family: inherit;
+          font-weight: 500;
+          line-height: 24px;
+          border-radius: 4px;
+          box-shadow: none;
+          cursor: pointer;
+
+          ${plain &&
+          `
+            padding: 0;
+            font: inherit;
+            border: none;
+            background: none;
+          `}
+        }
+      `}</style>
+    </button>
+  )
+}
+
+export default Button

--- a/frontend/elements/Button/index.ts
+++ b/frontend/elements/Button/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Button'

--- a/frontend/pages/_document.tsx
+++ b/frontend/pages/_document.tsx
@@ -56,6 +56,7 @@ class MyDocument extends Document<
         </Head>
         <body className="block-transitions-on-page-load">
           <Main />
+          <div id="modal-root" />
           <NextScript />
         </body>
       </Html>

--- a/frontend/styles/globalStyles.css
+++ b/frontend/styles/globalStyles.css
@@ -10,6 +10,15 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+body.modal-open {
+  overflow: hidden;
+}
+
+#modal-root {
+  position: relative;
+  z-index: 500;
+}
+
 /* Prevent transitions on page load */
 .block-transitions-on-page-load * {
   transition: none !important;
@@ -89,8 +98,6 @@ textarea {
   margin: 0;
   border: 0;
   padding: 0;
-  display: inline-block;
-  vertical-align: middle;
   white-space: normal;
   background: none;
   line-height: 1;
@@ -101,9 +108,17 @@ input:focus {
   outline: 0;
 }
 
-button,
-input,
-textarea,
-select {
-  box-sizing: border-box;
+::placeholder {
+  font-family: 'Source Sans Pro', sans-serif;
+}
+
+/* Used by screen readers, but hidden visually */
+.screen-reader {
+  position: absolute;
+  clip: rect(1px, 1px, 1px, 1px);
+  padding: 0;
+  border: 0;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
 }

--- a/frontend/utils/css.ts
+++ b/frontend/utils/css.ts
@@ -1,0 +1,8 @@
+export function truncate(width: number): string {
+  return `
+    max-width: ${width}px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  `
+}

--- a/frontend/utils/index.js
+++ b/frontend/utils/index.js
@@ -1,3 +1,4 @@
 export * from './breakpoints'
 export * from './colors'
+export * from './css'
 export * from './date'


### PR DESCRIPTION
## Description

Resolves: #59 

Fully accessible modal, full screen on mobile, centered on desktop. See gifs below for UX

## Sub-Tasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Animates title and keeps header/footer fixed when there is a lot of scrollable content
- [x] Implements [a11y UX pattern](https://www.w3.org/TR/wai-aria-practices/#dialog_modal) for modals
  - [x] tabbing stays within the modal
  - [x] esc key closes the modal
  - [x] the rest of the app is not interactable when modal is up
  - [x] after you close the modal, focus returns to the button that originally opened the modal
- [x] Uses [React Portals](https://reactjs.org/docs/portals.html) so `<Modal />` components don't have to be rendered as children to content that's only responsible for opening it
- [x] Create `<Button />` component that can be unstyled (useful for wrapping icons but keeping good semantics). We can enhance it over type with different sizes, default styles, primary, secondary, error states, disabled etc.

## Example usage

```jsx
const Component = () => {
  const [openModal, setOpenModal] = useState(false)
  const triggerElementId = 'open-modal-button'
  const handleClick = () => setOpenModal(true)

  return (
    <Button id={triggerElementId} onClick={handleClick}>
      Open Modal
    </Button>

    {openModal && (
      <Modal
        onClose={() => setOpenModal(false)}
        title="This is the modal title"
        body={<div>Content of the modal</div>}
        footer={<div><button>Submit modal form</button></div>}
        triggerElementId={triggerElementId}
        maxHeight={'700px'}
      />
    )}
```
 

## Screenshots

### Desktop

![modal_desktop](https://user-images.githubusercontent.com/5829188/80929371-4dced980-8d60-11ea-9f8a-8b285399abb1.gif)

### Mobile

![modal_mobile](https://user-images.githubusercontent.com/5829188/80929378-58896e80-8d60-11ea-98cb-f94417687d38.gif)