### PR TITLE
Implement theme with typography, colors, and breakpoints

### DIFF
--- a/frontend/components/Dashboard/Header/Header.tsx
+++ b/frontend/components/Dashboard/Header/Header.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { black } from '../../../utils'
+import theme from '../../../theme'
 import { navConstants } from '../Nav'
 
 interface Props {
@@ -25,7 +25,7 @@ const Header: React.FC<Props> = ({ onMenuClick }) => {
           height: 72px;
           padding: 20px 0;
           color: white;
-          background-color: ${black};
+          background-color: ${theme.colors.black};
         }
         /* Header should disappear when the mobile nav does */
         @media (${navConstants.aboveMobileNav}) {

--- a/frontend/components/Dashboard/Header/Header.tsx
+++ b/frontend/components/Dashboard/Header/Header.tsx
@@ -59,7 +59,7 @@ const Header: React.FC<Props> = ({ onMenuClick }) => {
         }
 
         .logo-text {
-          font-family: 'Playfair Display', serif;
+          ${theme.typography.fontFamilySerif};
           margin-right: 20px;
         }
       `}</style>

--- a/frontend/components/Form/Form.tsx
+++ b/frontend/components/Form/Form.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { brandBlue } from '../../utils'
+import theme from '../../theme'
 
 interface Props {
   onSubmit: (e: React.FormEvent<HTMLFormElement>) => void
@@ -37,7 +37,7 @@ const Form: React.FC<Props> = ({ onSubmit, children }: Props) => {
         textarea,
         select:focus {
           outline: 0;
-          border-color: ${brandBlue};
+          border-color: ${theme.colors.blueLight};
         }
         fieldset {
           border: 0;
@@ -67,6 +67,7 @@ const Form: React.FC<Props> = ({ onSubmit, children }: Props) => {
         }
 
         h2 {
+          ${theme.typography.headingXL}
           margin-bottom: 10px;
         }
       `}</style>

--- a/frontend/theme/index.ts
+++ b/frontend/theme/index.ts
@@ -25,7 +25,8 @@ type Colors =
   | 'red'
 
 type Typography =
-  | 'fontFamily'
+  | 'fontFamilySansSerif'
+  | 'fontFamilySerif'
   | 'paragraphSM'
   | 'paragraphMD'
   | 'paragraphLG'
@@ -66,50 +67,55 @@ const theme: Theme = {
     Object.entries(breakpoints).map(([key, value]) => [key, `${value}px`]),
   ) as Breakpoint,
   typography: {
-    fontFamily: '"Source Sans Pro", sans-serif',
+    fontFamilySansSerif: `
+      font-family: "Source Sans Pro", sans-serif;
+    `,
+    fontFamilySerif: `
+      font-family: "Playfair Display", serif;
+    `,
     paragraphSM: `
-      font-size: 12px,
-      line-height: 20px,
+      font-size: 12px;
+      line-height: 20px;
     `,
     paragraphMD: `
-      font-size: 14px,
-      line-height: 24px,
+      font-size: 14px;
+      line-height: 24px;
     `,
     paragraphLG: `
-      font-size: 16px,
-      line-height: 24px,
+      font-size: 16px;
+      line-height: 24px;
     `,
     headingOverline: `
-      letter-spacing: 1px,
-      font-size: 12px,
-      line-height: 20px,
-      font-weight: 600,
-      text-transform: uppercase,
+      letter-spacing: 1px;
+      font-size: 12px;
+      line-height: 20px;
+      font-weight: 400;
+      text-transform: uppercase;
     `,
     headingSM: `
-      font-size: 16px,
-      line-height: 24px,
-      font-weight: 600,
+      font-size: 16px;
+      line-height: 24px;
+      font-weight: 400;
     `,
     headingMD: `
-      font-size: 20px,
-      line-height: 28px,
-      font-weight: 600,
+      font-size: 20px;
+      line-height: 28px;
+      font-weight: 400;
     `,
     headingLG: `
-      font-size: 24px,
-      line-height: 32px,
-      font-weight: 600,
+      font-size: 24px;
+      line-height: 32px;
+      font-weight: 400;
     `,
     headingXL: `
-      font-size: 30px,
-      line-height: 36px,
-      font-weight: 600,
+      font-size: 30px;
+      line-height: 36px;
+      font-weight: 400;
     `,
     displaySM: `
-      font-size: 44px,
-      line-height: 48px,
-      font-weight: 600,
+      font-size: 44px;
+      line-height: 48px;
+      font-weight: 400;
     `,
   },
 }

--- a/frontend/theme/index.ts
+++ b/frontend/theme/index.ts
@@ -74,47 +74,56 @@ const theme: Theme = {
       font-family: "Playfair Display", serif;
     `,
     paragraphSM: `
+      font-family: "Source Sans Pro", sans-serif;
       font-size: 12px;
       line-height: 20px;
     `,
     paragraphMD: `
-      font-size: 14px;
+      font-family: "Source Sans Pro", sans-serif;
+      font-size: 16px;
       line-height: 24px;
     `,
     paragraphLG: `
-      font-size: 16px;
+      font-family: "Source Sans Pro", sans-serif;
+      font-size: 18px;
       line-height: 24px;
     `,
     headingOverline: `
       letter-spacing: 1px;
+      font-family: "Playfair Display", serif;
       font-size: 12px;
       line-height: 20px;
       font-weight: 400;
       text-transform: uppercase;
     `,
     headingSM: `
+      font-family: "Playfair Display", serif;
       font-size: 16px;
       line-height: 24px;
       font-weight: 400;
     `,
     headingMD: `
+      font-family: "Playfair Display", serif;
       font-size: 20px;
       line-height: 28px;
       font-weight: 400;
     `,
     headingLG: `
+      font-family: "Playfair Display", serif;
       font-size: 24px;
       line-height: 32px;
       font-weight: 400;
     `,
     headingXL: `
-      font-size: 30px;
-      line-height: 36px;
+      font-family: "Playfair Display", serif;
+      font-size: 32px;
+      line-height: 40px;
       font-weight: 400;
     `,
     displaySM: `
-      font-size: 44px;
-      line-height: 48px;
+      font-family: "Playfair Display", serif;
+      font-size: 40px;
+      line-height: 56px;
       font-weight: 400;
     `,
   },

--- a/frontend/theme/index.ts
+++ b/frontend/theme/index.ts
@@ -1,0 +1,103 @@
+import { fromEntries } from '../utils'
+
+export const breakpoints = {
+  XS: 600,
+  SM: 786,
+  MD: 1024,
+  LG: 1280,
+} as const
+
+type BreakpointSize = keyof typeof breakpoints
+type Breakpoint = { readonly [key in BreakpointSize]: string }
+
+type Typography =
+  | 'fontFamily'
+  | 'paragraphSM'
+  | 'paragraphMD'
+  | 'paragraphLG'
+  | 'headingOverline'
+  | 'headingSM'
+  | 'headingMD'
+  | 'headingLG'
+  | 'headingXL'
+  | 'displaySM'
+
+export type Theme = {
+  colors: {
+    readonly [key: string]: string
+  }
+  breakpoints: Breakpoint
+  typography: {
+    readonly [key in Typography]: string
+  }
+}
+
+const theme: Theme = {
+  colors: {
+    black: '#393939',
+    white: '#ffffff',
+    gray100: '',
+    gray200: '',
+    gray300: '',
+    gray400: '',
+    gray500: '',
+    gray600: '',
+    gray700: '',
+    gray800: '',
+    blue: '#32567E',
+    blueLight: '#4391C9',
+    red: '#c42f14',
+  },
+  breakpoints: fromEntries(
+    Object.entries(breakpoints).map(([key, value]) => [key, `${value}px`]),
+  ) as Breakpoint,
+  typography: {
+    fontFamily: '"Source Sans Pro", sans-serif',
+    paragraphSM: `
+      font-size: 12px,
+      line-height: 20px,
+    `,
+    paragraphMD: `
+      font-size: 14px,
+      line-height: 24px,
+    `,
+    paragraphLG: `
+      font-size: 16px,
+      line-height: 24px,
+    `,
+    headingOverline: `
+      letter-spacing: 1px,
+      font-size: 12px,
+      line-height: 20px,
+      font-weight: 600,
+      text-transform: uppercase,
+    `,
+    headingSM: `
+      font-size: 16px,
+      line-height: 24px,
+      font-weight: 600,
+    `,
+    headingMD: `
+      font-size: 20px,
+      line-height: 28px,
+      font-weight: 600,
+    `,
+    headingLG: `
+      font-size: 24px,
+      line-height: 32px,
+      font-weight: 600,
+    `,
+    headingXL: `
+      font-size: 30px,
+      line-height: 36px,
+      font-weight: 600,
+    `,
+    displaySM: `
+      font-size: 44px,
+      line-height: 48px,
+      font-weight: 600,
+    `,
+  },
+}
+
+export default theme

--- a/frontend/theme/index.ts
+++ b/frontend/theme/index.ts
@@ -9,6 +9,20 @@ export const breakpoints = {
 
 type BreakpointSize = keyof typeof breakpoints
 type Breakpoint = { readonly [key in BreakpointSize]: string }
+type Colors =
+  | 'black'
+  | 'white'
+  | 'gray100'
+  | 'gray200'
+  | 'gray300'
+  | 'gray400'
+  | 'gray500'
+  | 'gray600'
+  | 'gray700'
+  | 'gray800'
+  | 'blue'
+  | 'blueLight'
+  | 'red'
 
 type Typography =
   | 'fontFamily'
@@ -24,7 +38,7 @@ type Typography =
 
 export type Theme = {
   colors: {
-    readonly [key: string]: string
+    readonly [key in Colors]: string
   }
   breakpoints: Breakpoint
   typography: {

--- a/frontend/theme/index.ts
+++ b/frontend/theme/index.ts
@@ -2,7 +2,7 @@ import { fromEntries } from '../utils'
 
 export const breakpoints = {
   XS: 600,
-  SM: 786,
+  SM: 768,
   MD: 1024,
   LG: 1280,
 } as const

--- a/frontend/utils/index.js
+++ b/frontend/utils/index.js
@@ -1,4 +1,0 @@
-export * from './breakpoints'
-export * from './colors'
-export * from './css'
-export * from './date'

--- a/frontend/utils/index.ts
+++ b/frontend/utils/index.ts
@@ -1,0 +1,12 @@
+export * from './breakpoints'
+export * from './colors'
+export * from './css'
+export * from './date'
+
+// Polyfill Object.fromEntries
+export function fromEntries<V>(iterable: Iterable<[string, V]>) {
+  return [...iterable].reduce((obj, [key, val]) => {
+    obj[key] = val
+    return obj
+  }, {} as { [k: string]: V })
+}


### PR DESCRIPTION
## Description

POC for proposal #68 

🚨 Note: current typography font values are placeholders. They are not currently updated with our values

## Sub-Tasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Simplified variable imports, just `theme` now
- [x] Use TypeScript for everything so autocomplete works
- [x] Allow breakpoints to be used as numbers as well as strings with `px` (numbers for allowing math operations, like + or - 1 scenarios, and `'px'` for regular media queries)
