### PR TITLE
FEATURE: Inline Feedback Experience PART 2 - Handle Loading Persisted Comments

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,6 +1,6 @@
 datasource db {
   provider = "postgresql"
-  url      = "postgresql://jlyuser:jlypass@localhost:5433/jlydb"
+  url      = env("DATABASE_URL")
 }
 
 generator prisma_client {


### PR DESCRIPTION
## Description

**Issue:** #88 

Handle loading a post with existing comments and being able to reconstruct the post with all highlights and comment threads in the exact position they were left in with the same text selection.

- We built this in a way that allows us to perfectly position persisted/exisitng comments and their text selections upon visiting a post, while not breaking that positioning when adding new comments.
- We achieved this by anchoring comment thread locations to the beginning of the document as a single source of truth.
- Some refactoring of re-used logic into functions and better function/variable names
- Added documentation/comments

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Write mechanism for correctly storing a comment's position and selection and loading them in the correct place
- [x] Handle conflicts with old and new comment positioning
- [x] Test lots of scenarios
- [x] Clean up and refactor
- [x] Add documentation with comments

## Screenshots
![persisted-comments](https://user-images.githubusercontent.com/34203886/84583360-d2276a00-adac-11ea-84f9-8cee9a22e090.gif)
