### PR TITLE
Allow users to create new threads that are actually persisted to the DB

### DIFF
--- a/frontend/components/Dashboard/Post/Post.tsx
+++ b/frontend/components/Dashboard/Post/Post.tsx
@@ -161,6 +161,10 @@ const Post: React.FC<IPostProps> = ({ post, refetch }: IPostProps) => {
   const [popoverPosition, setPopoverPosition] = React.useState({ x: 0, y: 0, w: 0, h: 0 })
   const [createThread] = useCreateThreadMutation({
     onCompleted: ({ createThread }) => {
+      if (!createThread) {
+        return
+      }
+
       refetch()
       setActiveThreadId(createThread.id)
     },
@@ -177,7 +181,7 @@ const Post: React.FC<IPostProps> = ({ post, refetch }: IPostProps) => {
     selectableTextArea.innerHTML = DOMPurify.sanitize(post.body)
 
     // Re-construct all comments from DB
-    post.threads.forEach((thread: ThreadType, threadIndex: number) => {
+    post.threads.forEach((thread: ThreadType) => {
       const { startIndex, endIndex, id } = thread
       // Rebuild list on every iteration b/c the DOM & the POL change with every new comment
       // Done for simplicity of logic, but can be refactored to update original list if performance becomes an issues
@@ -286,7 +290,7 @@ const Post: React.FC<IPostProps> = ({ post, refetch }: IPostProps) => {
     })
   }
 
-  const activeThread = post.threads.find((thread) => thread.id === activeThreadId)
+  const activeThread = post.threads.find((thread: ThreadType) => thread.id === activeThreadId)
 
   return (
     <div className="post-container">

--- a/frontend/components/Dashboard/Post/Post.tsx
+++ b/frontend/components/Dashboard/Post/Post.tsx
@@ -2,7 +2,11 @@ import React from 'react'
 import Head from 'next/head'
 import DOMPurify from 'dompurify'
 
-import { Post as PostType, Thread as ThreadType } from '../../../generated/graphql'
+import {
+  Post as PostType,
+  Thread as ThreadType,
+  useCreateThreadMutation,
+} from '../../../generated/graphql'
 import theme from '../../../theme'
 import LeaveACommentIcon from '../../Icons/LeaveACommentIcon'
 import InlineFeedbackPopover from '../../InlineFeedbackPopover'
@@ -60,13 +64,15 @@ const CommentSelectionButton = ({ position, display, onClick }: CommentSelection
 }
 
 // Construct highlighted text/selection & replace original selection with highlighted construction
-function highlightRange(range: Range, threadIndex: number) {
+function highlightRange(range: Range, threadId: number): string {
   const selectedText = range.extractContents()
   const commentedTextSpan = document.createElement('span')
   commentedTextSpan.classList.add('thread-highlight')
-  commentedTextSpan.dataset.tidx = `${threadIndex}`
+  commentedTextSpan.dataset.tid = `${threadId}`
   commentedTextSpan.appendChild(selectedText)
   range.insertNode(commentedTextSpan)
+
+  return commentedTextSpan.innerHTML
 }
 
 function buildPreOrderList(rootEl: HTMLElement): (HTMLElement | Node)[] {
@@ -150,9 +156,15 @@ function buildPreOrderListAndOffsets(selectableTextArea: HTMLElement) {
 const Post: React.FC<IPostProps> = ({ post, refetch }: IPostProps) => {
   const selectableRef = React.useRef<HTMLDivElement>(null)
   const [displayCommentButton, setDisplayCommentButton] = React.useState(false)
-  const [selectedThreadIndex, setSelectedThreadIndex] = React.useState<number>(-1)
+  const [activeThreadId, setActiveThreadId] = React.useState<number>(-1)
   const [commentButtonPosition, setCommentButtonPosition] = React.useState({ x: '0', y: '0' })
   const [popoverPosition, setPopoverPosition] = React.useState({ x: 0, y: 0, w: 0, h: 0 })
+  const [createThread] = useCreateThreadMutation({
+    onCompleted: ({ createThread }) => {
+      refetch()
+      setActiveThreadId(createThread.id)
+    },
+  })
 
   React.useEffect(() => {
     if (!selectableRef.current) {
@@ -166,7 +178,7 @@ const Post: React.FC<IPostProps> = ({ post, refetch }: IPostProps) => {
 
     // Re-construct all comments from DB
     post.threads.forEach((thread: ThreadType, threadIndex: number) => {
-      const { startIndex, endIndex } = thread
+      const { startIndex, endIndex, id } = thread
       // Rebuild list on every iteration b/c the DOM & the POL change with every new comment
       // Done for simplicity of logic, but can be refactored to update original list if performance becomes an issues
       // Would complicate logic quite a lot.
@@ -181,13 +193,13 @@ const Post: React.FC<IPostProps> = ({ post, refetch }: IPostProps) => {
       range.setStart(preOrderList[startElIndex], startIndex - offsets[startElIndex])
       range.setEnd(preOrderList[endElIndex], endIndex - offsets[endElIndex])
 
-      highlightRange(range, threadIndex)
+      highlightRange(range, id)
     })
-  }, [selectableRef.current])
+  }, [selectableRef.current, post.threads.length])
 
   const sanitizedHTML = DOMPurify.sanitize(post.body)
 
-  const createComment = (e: React.MouseEvent) => {
+  const createThreadHandler = (e: React.MouseEvent) => {
     e.preventDefault()
     e.stopPropagation()
 
@@ -207,9 +219,18 @@ const Post: React.FC<IPostProps> = ({ post, refetch }: IPostProps) => {
       // Temporary local state > will be stored in DB
       allSelections.push([startIndex, endIndex])
 
-      highlightRange(firstRange, -1)
+      const highlightedContent = highlightRange(firstRange, -1)
       window.getSelection()?.empty()
       setDisplayCommentButton(false)
+
+      createThread({
+        variables: {
+          postId: post.id,
+          startIndex,
+          endIndex,
+          highlightedContent,
+        },
+      })
     }
   }
 
@@ -242,7 +263,7 @@ const Post: React.FC<IPostProps> = ({ post, refetch }: IPostProps) => {
 
   const onMouseDownHandler = () => {
     setDisplayCommentButton(false)
-    setSelectedThreadIndex(-1)
+    setActiveThreadId(-1)
   }
 
   const onThreadClick = (e: React.MouseEvent<HTMLSpanElement>) => {
@@ -252,11 +273,11 @@ const Post: React.FC<IPostProps> = ({ post, refetch }: IPostProps) => {
 
     const target = e.target as HTMLElement
 
-    if (!target.classList.contains('thread-highlight') || !target.dataset.tidx) {
+    if (!target.classList.contains('thread-highlight') || !target.dataset.tid) {
       return
     }
 
-    setSelectedThreadIndex(parseInt(target.dataset.tidx, 10))
+    setActiveThreadId(parseInt(target.dataset.tid, 10))
     setPopoverPosition({
       x: target.offsetLeft,
       y: target.offsetTop,
@@ -264,6 +285,8 @@ const Post: React.FC<IPostProps> = ({ post, refetch }: IPostProps) => {
       h: target.offsetHeight,
     })
   }
+
+  const activeThread = post.threads.find((thread) => thread.id === activeThreadId)
 
   return (
     <div className="post-container">
@@ -288,14 +311,14 @@ const Post: React.FC<IPostProps> = ({ post, refetch }: IPostProps) => {
         </div>
       </div>
       <CommentSelectionButton
-        onClick={createComment}
+        onClick={createThreadHandler}
         position={commentButtonPosition}
         display={displayCommentButton}
       />
       <div id="popover-root" />
-      {selectedThreadIndex >= 0 && (
+      {activeThread && (
         <InlineFeedbackPopover
-          thread={post.threads[selectedThreadIndex]}
+          thread={activeThread}
           target={popoverPosition}
           onNewComment={refetch}
         />

--- a/frontend/components/InlineFeedbackPopover/index.tsx
+++ b/frontend/components/InlineFeedbackPopover/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
+import CSS from 'csstype'
 
 import { useCreateCommentMutation } from '../../generated/graphql'
 import { Thread as ThreadType } from '../../generated/graphql'
@@ -32,7 +33,7 @@ const VP_PADDING = 20
 const Popover: React.FC<PopoverProps> = ({ target, children }) => {
   const popoverRoot = document.getElementById('popover-root') as HTMLElement
 
-  const ownPosition = {}
+  const ownPosition: CSS.Properties = {}
 
   const vpw = document.documentElement.clientWidth
   const vph = document.documentElement.clientHeight
@@ -63,7 +64,6 @@ const Popover: React.FC<PopoverProps> = ({ target, children }) => {
     ownPosition.left = `${idealX}px`
   }
 
-  console.log(ownPosition)
   const popover = (
     <>
       <div className="popover-container" style={ownPosition}>

--- a/frontend/components/InlineFeedbackPopover/index.tsx
+++ b/frontend/components/InlineFeedbackPopover/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import CSS from 'csstype'
+import DOMPurify from 'dompurify'
 
 import { useCreateCommentMutation } from '../../generated/graphql'
 import { Thread as ThreadType } from '../../generated/graphql'
@@ -111,10 +112,12 @@ const Thread: React.FC<ThreadProps> = ({ thread, onNewComment }) => {
     })
   }
 
+  const sanitizedHTML = DOMPurify.sanitize(thread.highlightedContent)
+
   return (
     <div className="thread">
       <div className="thread-subject">
-        <span className="highlighted-content">{thread.highlightedContent}</span>
+        <span className="highlighted-content" dangerouslySetInnerHTML={{ __html: sanitizedHTML }} />
       </div>
       <div className="thread-body">
         <div className="comments">

--- a/frontend/components/InlineFeedbackPopover/index.tsx
+++ b/frontend/components/InlineFeedbackPopover/index.tsx
@@ -32,11 +32,12 @@ const VP_PADDING = 20
 const Popover: React.FC<PopoverProps> = ({ target, children }) => {
   const popoverRoot = document.getElementById('popover-root') as HTMLElement
 
-  let x, y
+  const ownPosition = {}
 
   const vpw = document.documentElement.clientWidth
   const vph = document.documentElement.clientHeight
   const st = document.documentElement.scrollTop
+  const dh = document.documentElement.offsetHeight
 
   const ownWidth = Math.min(vpw - VP_PADDING * 2, 480)
   const ownHeight = Math.min(vph - VP_PADDING * 2, 300)
@@ -47,33 +48,36 @@ const Popover: React.FC<PopoverProps> = ({ target, children }) => {
   const rBottom = vph + st - (target.y + target.h)
 
   if (rTop > rBottom) {
-    y = target.y - ownHeight - 5
+    ownPosition.bottom = `${dh - target.y + 5}px`
   } else {
-    y = target.y + target.h + 5
+    ownPosition.top = `${target.y + target.h + 5}px`
   }
 
   const idealX = tCenterX - ownWidth / 2
 
   if (idealX < VP_PADDING) {
-    x = VP_PADDING
+    ownPosition.left = `${VP_PADDING}px`
   } else if (idealX + ownWidth > vpw - VP_PADDING) {
-    x = vpw - ownWidth - VP_PADDING
+    ownPosition.left = `${vpw - ownWidth - VP_PADDING}px`
   } else {
-    x = idealX
+    ownPosition.left = `${idealX}px`
   }
 
+  console.log(ownPosition)
   const popover = (
     <>
-      <div className="popover-container">{children}</div>
+      <div className="popover-container" style={ownPosition}>
+        {children}
+      </div>
       <style jsx>{`
         .popover-container {
           position: absolute;
           z-index: 100;
-          left: ${x}px;
-          top: ${y}px;
+          display: flex;
+          flex-direction: column;
 
           width: ${ownWidth}px;
-          height: ${ownHeight}px;
+          max-height: ${ownHeight}px;
 
           background-color: #f9f9f9;
           border: 1px solid #dadada;
@@ -90,7 +94,10 @@ const Popover: React.FC<PopoverProps> = ({ target, children }) => {
 const Thread: React.FC<ThreadProps> = ({ thread, onNewComment }) => {
   const [commentBody, setCommentBody] = React.useState<string>('')
   const [createComment, { loading }] = useCreateCommentMutation({
-    onCompleted: onNewComment,
+    onCompleted: () => {
+      onNewComment()
+      setCommentBody('')
+    },
   })
 
   const createNewComment = (e: React.FormEvent<HTMLFormElement>) => {
@@ -125,26 +132,32 @@ const Thread: React.FC<ThreadProps> = ({ thread, onNewComment }) => {
               </div>
             )
           })}
+
+          {!thread.comments.length && <div className="empty-notice">No comments... yet!</div>}
         </div>
-        <form className="new-comment-block" onSubmit={createNewComment}>
+        <form onSubmit={createNewComment}>
           <fieldset>
-            <textarea
-              value={commentBody}
-              onChange={(e) => setCommentBody(e.target.value)}
-              disabled={loading}
-            />
-            <button type="submit" disabled={loading}>
-              Submit
-            </button>
+            <div className="new-comment-block">
+              <textarea
+                placeholder="Add a comment..."
+                value={commentBody}
+                onChange={(e) => setCommentBody(e.target.value)}
+                disabled={loading}
+              />
+              <button type="submit" disabled={loading}>
+                Submit
+              </button>
+            </div>
           </fieldset>
         </form>
       </div>
       <style jsx>{`
         .thread {
+          flex: 1;
           display: flex;
           flex-direction: column;
           overflow: hidden;
-          height: 100%;
+          max-height: 100%;
         }
 
         .thread-subject {
@@ -166,9 +179,34 @@ const Thread: React.FC<ThreadProps> = ({ thread, onNewComment }) => {
           padding: 5px 20px;
         }
 
+        .empty-notice {
+          text-align: center;
+          padding: 20px;
+          font-style: italic;
+        }
+
         .author-block {
           font-weight: bold;
           font-size: 0.75em;
+        }
+
+        .new-comment-block {
+          display: flex;
+          flex-direction: row;
+        }
+
+        .new-comment-block textarea {
+          flex: 1;
+          min-height: 4em;
+          background-color: #f9f9f9;
+          padding: 0.5em 1em;
+          font-family: 'Source Sans Pro', sans-serif;
+        }
+
+        .new-comment-block button {
+          background-color: #f9f9f9;
+          padding: 5px 15px;
+          cursor: pointer;
         }
       `}</style>
     </div>

--- a/frontend/components/InlineFeedbackPopover/index.tsx
+++ b/frontend/components/InlineFeedbackPopover/index.tsx
@@ -68,7 +68,7 @@ const Popover: React.FC<PopoverProps> = ({ target, children }) => {
       <style jsx>{`
         .popover-container {
           position: absolute;
-          z-index: 5;
+          z-index: 100;
           left: ${x}px;
           top: ${y}px;
 

--- a/frontend/graphql/createThread.graphql
+++ b/frontend/graphql/createThread.graphql
@@ -1,0 +1,15 @@
+mutation createThread(
+  $postId: Int!
+  $startIndex: Int!
+  $endIndex: Int!
+  $highlightedContent: String!
+) {
+  createThread(
+    postId: $postId
+    startIndex: $startIndex
+    endIndex: $endIndex
+    highlightedContent: $highlightedContent
+  ) {
+    ...ThreadFragment
+  }
+}

--- a/frontend/graphql/fragments.graphql
+++ b/frontend/graphql/fragments.graphql
@@ -1,0 +1,35 @@
+fragment AuthorFragment on User {
+  id
+  name
+  handle
+}
+
+fragment CommentFragment on Comment {
+  body
+  author {
+    ...AuthorFragment
+  }
+}
+
+fragment ThreadFragment on Thread {
+  id
+  startIndex
+  endIndex
+  highlightedContent
+  comments {
+    ...CommentFragment
+  }
+}
+
+fragment PostFragment on Post {
+  id
+  title
+  body
+  status
+  author {
+    ...AuthorFragment
+  }
+  threads {
+    ...ThreadFragment
+  }
+}

--- a/frontend/graphql/postById.graphql
+++ b/frontend/graphql/postById.graphql
@@ -1,25 +1,5 @@
 query postById($id: Int!) {
   postById(id: $id) {
-    title
-    body
-    status
-    author {
-      id
-      name
-    }
-    threads {
-      id
-      startIndex
-      endIndex
-      highlightedContent
-      comments {
-        body
-        author {
-          id
-          name
-          handle
-        }
-      }
-    }
+    ...PostFragment
   }
 }


### PR DESCRIPTION
## Description

Allow users to create new threads that are actually persisted to the DB.

Also created query fragments for queries/mutations so we get a consistent type/fieldset when querying.

*caveat*: Thread creation happens independently of creating the first comment on that thread, so you can highlight something and make a thread out of the highlight, but bail out of creating the comment so you get an empty thread. This seemed acceptable to me since you can come back and create a comment later and nothing in the UI is particularly wrong in this scenario, but wanted to call it out. Backing out a local highlight that's not yet committed to the DB is a little trickier if we want to mandate that threads have a single comment, but not too hard if we wanted to do that later.
