### PR TITLE
Light refactoring of our Nexus GraphQL schema

### DIFF
--- a/backend/src/graphql.ts
+++ b/backend/src/graphql.ts
@@ -5,14 +5,14 @@ import { prisma } from 'nexus-plugin-prisma'
 
 use(prisma())
 
-const { objectType, queryType, mutationType, intArg, stringArg } = schema
+const { intArg, stringArg } = schema
 
 // Time constants
 const ONE_YEAR = 1000 * 60 * 60 * 24 * 365
 const ONE_HOUR_FROM_NOW = Date.now() + 3600000
 const WITHIN_ONE_HOUR = Date.now() - 3600000
 
-const User = objectType({
+schema.objectType({
   name: 'User',
   definition(t) {
     t.model.id()
@@ -29,7 +29,7 @@ const User = objectType({
   },
 })
 
-const Post = objectType({
+schema.objectType({
   name: 'Post',
   definition(t) {
     t.model.id()
@@ -43,7 +43,7 @@ const Post = objectType({
   },
 })
 
-const Thread = objectType({
+schema.objectType({
   name: 'Thread',
   definition(t) {
     t.model.id()
@@ -54,7 +54,7 @@ const Thread = objectType({
   },
 })
 
-const Comment = objectType({
+schema.objectType({
   name: 'Comment',
   definition(t) {
     t.model.id()
@@ -63,7 +63,7 @@ const Comment = objectType({
   },
 })
 
-const Location = objectType({
+schema.objectType({
   name: 'Location',
   definition(t) {
     t.model.id()
@@ -72,7 +72,7 @@ const Location = objectType({
   },
 })
 
-const Language = objectType({
+schema.objectType({
   name: 'Language',
   definition(t) {
     t.model.id()
@@ -94,7 +94,7 @@ const Language = objectType({
   },
 })
 
-const Query = queryType({
+schema.queryType({
   definition(t) {
     t.list.field('posts', {
       type: 'Post',
@@ -150,7 +150,7 @@ const Query = queryType({
   },
 })
 
-const Mutation = mutationType({
+schema.mutationType({
   definition(t) {
     t.field('createUser', {
       type: 'User',


### PR DESCRIPTION
## Description

I got some helpful feedback from the Nexus core team that there's no need to declare all these `const`s in our GQL schema which makes perfect sense, so this is just to make some small improvements there 🙂

...

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Remove all unused `const`s and unused imports.
