### PR TITLE
Add Missing Styles For Journaly Editor

### DIFF
--- a/frontend/components/JournalyEditor/JournalyEditor.tsx
+++ b/frontend/components/JournalyEditor/JournalyEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useCallback } from 'react'
+import React, { useMemo, useCallback } from 'react'
 import { createEditor, Editor, Transforms, Node } from 'slate'
 import {
   Slate,
@@ -32,7 +32,6 @@ const HOTKEYS: { [key in HotKey]: string } = {
   'mod+b': 'bold',
   'mod+i': 'italic',
   'mod+u': 'underline',
-  'mod+`': 'code',
 }
 
 type ButtonProps = {
@@ -63,7 +62,6 @@ const JournalyEditor: React.FC<JournalyEditorProps> = ({
             <MarkButton format="bold" icon="format_bold" />
             <MarkButton format="italic" icon="format_italic" />
             <MarkButton format="underline" icon="format_underlined" />
-            <MarkButton format="code" icon="format_code" />
             <BlockButton format="heading-two" icon="format_title" />
             <BlockButton format="block-quote" icon="format_quote" />
             <BlockButton format="numbered-list" icon="format_list_numbered" />
@@ -96,8 +94,23 @@ const JournalyEditor: React.FC<JournalyEditorProps> = ({
           background-color: ${theme.colors.white};
         }
 
-        /* TODO: Add specific Journaly Editor styles to ol, ul, and blockquote elements */
-        /* https://github.com/Journaly/journaly/issues/82 */
+        :global(blockquote) {
+          border-left: 2px solid #ddd;
+          margin: 10px 0;
+          padding-left: 10px;
+          color: #aaa;
+          font-style: italic;
+        }
+
+        :global(ul) {
+          list-style-type: disc;
+          list-style-position: inside;
+        }
+
+        :global(ol) {
+          list-style-type: decimal;
+          list-style-position: inside;
+        }
       `}</style>
     </div>
   )
@@ -165,10 +178,6 @@ const Element: React.FC<RenderElementProps> = ({ attributes, children, element }
 const Leaf: React.FC<RenderLeafProps> = ({ attributes, children, leaf }) => {
   if (leaf.bold) {
     children = <strong>{children}</strong>
-  }
-
-  if (leaf.code) {
-    children = <code>{children}</code>
   }
 
   if (leaf.italic) {

--- a/frontend/components/JournalyEditor/JournalyEditor.tsx
+++ b/frontend/components/JournalyEditor/JournalyEditor.tsx
@@ -26,7 +26,7 @@ import Button from './Button'
  * once they publish or save draft.
  */
 
-type HotKey = 'mod+b' | 'mod+i' | 'mod+u' | 'mod+`'
+type HotKey = 'mod+b' | 'mod+i' | 'mod+u'
 
 const HOTKEYS: { [key in HotKey]: string } = {
   'mod+b': 'bold',

--- a/frontend/components/JournalyEditor/JournalyEditor.tsx
+++ b/frontend/components/JournalyEditor/JournalyEditor.tsx
@@ -87,7 +87,7 @@ const JournalyEditor: React.FC<JournalyEditorProps> = ({
       </div>
       <style jsx>{`
         .editor-container {
-          padding: 0 25px;
+          padding: 0 25px 10px;
           border: 1px solid ${theme.colors.black};
           border-radius: 5px;
           min-height: 200px;
@@ -95,10 +95,10 @@ const JournalyEditor: React.FC<JournalyEditorProps> = ({
         }
 
         :global(blockquote) {
-          border-left: 2px solid #ddd;
+          border-left: 2px solid ${theme.colors.gray800};
           margin: 10px 0;
           padding-left: 10px;
-          color: #aaa;
+          color: ${theme.colors.gray800};
           font-style: italic;
         }
 

--- a/frontend/components/JournalyEditor/Toolbar.tsx
+++ b/frontend/components/JournalyEditor/Toolbar.tsx
@@ -5,6 +5,7 @@ const Toolbar: React.FC = ({ children }) => (
       display: flex;
       justify-content: center;
       padding: 15px 0;
+      margin-bottom: 10px;
       border-bottom: 2px solid #eee;
     `}</style>
   </div>


### PR DESCRIPTION
## Description

**Issue:** closes #82 

Adds some very simple styles that are missing in the Journaly Editor. These can be improved later to be really unique and splendid aligned with the Journaly brand and style -- I already have some nice design ideas. Most important thing right now is to have something simple and nice.

Removes the "code" formatting button. This has been discussed in the past as something we won't support as we want to keep the editor as clean and simple as possible.

Also fixes one build error that I was going to fix separately but it is in the same file (unused `useState` import)

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Add missing styles
- [x] Remove unused import
- [x] Improve ToolBar appearance a wee bit 

## Screenshots

![image](https://user-images.githubusercontent.com/34203886/86088218-bbdf0680-ba5a-11ea-8b08-b473f603b874.png)

