### PR TITLE
Autosave editor content on new post page.

### DIFF
--- a/frontend/components/Dashboard/Post/Post.tsx
+++ b/frontend/components/Dashboard/Post/Post.tsx
@@ -329,7 +329,7 @@ const Post: React.FC<IPostProps> = ({ post, currentUser, refetch }: IPostProps) 
           <div dangerouslySetInnerHTML={{ __html: sanitizedHTML }} />
         </div>
 
-        {post.author.id === currentUser.id && (
+        {currentUser && post.author.id === currentUser.id && (
           <div className="post-controls">
             {post.status === 'DRAFT' && (
               <Button

--- a/frontend/hooks/useAutosavedState.ts
+++ b/frontend/hooks/useAutosavedState.ts
@@ -1,15 +1,10 @@
 import React from 'react'
 
-type optionsType = {
-  key: Maybe<string>
-  debounceTime: Maybe<number>
-}
-
 export default function useAutosavedState<T>(
   initialValue: T,
   opts = { key: 'default', debounceTime: 1000 },
-) {
-  const storage = (typeof window !== 'undefined' && window.localStorage) || {}
+): [T, (value: T) => void, () => void] {
+  const storage: any = (typeof window !== 'undefined' && window.localStorage) || {}
   const storageKey = `autsave[${opts.key || 'default'}]`
 
   const [value, setValue] = React.useState<T>(initialValue)

--- a/frontend/hooks/useAutosavedState.ts
+++ b/frontend/hooks/useAutosavedState.ts
@@ -1,0 +1,46 @@
+import React from 'react'
+
+type optionsType = {
+  key: Maybe<string>
+  debounceTime: Maybe<number>
+}
+
+export default function useAutosavedState<T>(
+  initialValue: T,
+  opts = { key: 'default', debounceTime: 1000 },
+) {
+  const storage = (typeof window !== 'undefined' && window.localStorage) || {}
+  const storageKey = `autsave[${opts.key || 'default'}]`
+
+  const [value, setValue] = React.useState<T>(initialValue)
+  const valueRef = React.useRef({ savePending: false, value })
+
+  React.useEffect(() => {
+    if (storageKey in storage) {
+      console.info('Restoring value from storage')
+      const restoredInitialValue = JSON.parse(storage[storageKey])
+      setValue(restoredInitialValue)
+    }
+  }, [])
+
+  React.useEffect(() => {
+    valueRef.current.value = value
+
+    if (!valueRef.current.savePending) {
+      valueRef.current.savePending = true
+
+      setTimeout(() => {
+        storage[storageKey] = JSON.stringify(valueRef.current.value)
+        valueRef.current.savePending = false
+        console.info(`Saved value on key ${storageKey}`)
+      }, opts.debounceTime)
+    }
+  }, [value])
+
+  const reset = () => {
+    delete storage[storageKey]
+    setValue(initialValue)
+  }
+
+  return [value, setValue, reset]
+}

--- a/frontend/lib/apollo.tsx
+++ b/frontend/lib/apollo.tsx
@@ -55,8 +55,8 @@ export function withApollo<PageProps extends object, PageInitialProps = PageProp
     WithApollo.getInitialProps = async (ctx) => {
       const { AppTree, req } = ctx
 
-      const headers = {}
-      if (typeof window === 'undefined') {
+      const headers: any = {}
+      if (typeof window === 'undefined' && req) {
         // If SSR, copy the request cookies into apollo client so it has the same
         // auth context as the request for the page.
         headers['cookie'] = req.headers.cookie

--- a/frontend/pages/dashboard/new-post.tsx
+++ b/frontend/pages/dashboard/new-post.tsx
@@ -15,6 +15,7 @@ import {
   PostStatus as PostStatusType,
 } from '../../generated/graphql'
 import AuthGate from '../../components/AuthGate'
+import useAutosavedState from '../../hooks/useAutosavedState'
 
 const initialValue = [
   {
@@ -30,7 +31,7 @@ const NewPostPage: NextPage = () => {
   const router = useRouter()
   const [title, setTitle] = React.useState<string>('')
   const [langId, setLangId] = React.useState<number>(-1)
-  const [body, setBody] = React.useState<Node[]>(initialValue)
+  const [body, setBody, resetBody] = useAutosavedState<Node[]>(initialValue, { key: 'new-post' })
 
   const [createPost] = useCreatePostMutation({
     onCompleted: ({ createPost }) => {
@@ -38,6 +39,7 @@ const NewPostPage: NextPage = () => {
         return
       }
 
+      resetBody()
       router.push({ pathname: `/post/${createPost.id}` })
     },
   })

--- a/frontend/pages/dashboard/new-post.tsx
+++ b/frontend/pages/dashboard/new-post.tsx
@@ -31,7 +31,10 @@ const NewPostPage: NextPage = () => {
   const router = useRouter()
   const [title, setTitle] = React.useState<string>('')
   const [langId, setLangId] = React.useState<number>(-1)
-  const [body, setBody, resetBody] = useAutosavedState<Node[]>(initialValue, { key: 'new-post' })
+  const [body, setBody, resetBody] = useAutosavedState<Node[]>(initialValue, {
+    key: 'new-post',
+    debounceTime: 1000,
+  })
 
   const [createPost] = useCreatePostMutation({
     onCompleted: ({ createPost }) => {


### PR DESCRIPTION
Title says it all.

Do we want any kind of visual indication that a post is saved locally? It wouldn't be too hard to add a little piece of copy that says like "unsaved changes" or "saved locally" or something. I didn't add it because my thought was that you don't really care about the feature until you fat finger something and think you've lost your post, at which point you'll discovery it was saved on going back, but if you think it will make folks more comfortable to have feedback on it right away we can throw that in.