### PR TITLE
More BE build fixes

### DIFF
--- a/backend/seed.ts
+++ b/backend/seed.ts
@@ -142,8 +142,8 @@ async function main() {
             threads: {
               create: [
                 {
-                  startIndex: 57,
-                  endIndex: 84,
+                  startIndex: 47,
+                  endIndex: 74,
                   highlightedContent: 'I think this is a good song',
                   comments: {
                     create: [
@@ -244,9 +244,9 @@ async function main() {
       threads: {
         create: [
           {
-            startIndex: 15,
-            endIndex: 38,
-            highlightedContent: 'Les Pluies de Castamere',
+            startIndex: 11,
+            endIndex: 36,
+            highlightedContent: "This One's for you, Tywin",
             comments: {
               create: [
                 {


### PR DESCRIPTION
BE build should now work without TSC getting angry.

Also fixed issue with threads in seed data. Looks like commit a369380d610c4858b90df37e410b58fa0a6dc904 which removed the h1s from the post bodies threw off the indices  for the threads. At some point we should probably handle invalid selection ranges (e.g. which cross `<p>` tags, in these two cases) more gracefully. We do prevent these selections from happening in the UI, but they can still be created through request tampering and will cause the wonky rendering of posts seen here.