### PR TITLE
Support querying posts by userId, status; expose excerpt, readTime

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,42 +39,42 @@ We use Python for data science, leveraging a number of powerful libraries for da
    ```sh
    $ git clone git@github.com:Journaly/journaly.git
    ```
-1. In your backend directory, locate your `.env.example` file and create a new one alongside it called `.env`
-1. Run `npm ci` in both the `frontend` and `backend` directories
+1. In your backend directory, locate your `.env.example` file and copy the contents into a new `.env` file alongside it.
+1. Run `npm ci` in both the `frontend` and `backend` directories.
 
 #### Setting Up Your Local DB Instance
 
 1. Install Postgres with Homebrew
    _Note that this set your Postgres DB to run when your computer starts up and will stay running in the background_.
 
-```bash
-$ brew install postgres
-$ brew services start postgresql
-```
+   ```bash
+   $ brew install postgres
+   $ brew services start postgresql
+   ```
 
-2. Start up your Postgres shell and create your user
+1. Start up your Postgres shell and create your user
 
-```bash
-$ psql postgres
-$ create user <your_username> with createdb password '<your_password>';
-```
+   ```bash
+   $ psql postgres
+   $ create user <your_username> with createdb password '<your_password>';
+   ```
 
-3. Create your local instance of Journaly DB and give your user permissions
+1. Create your local instance of Journaly DB and give your user permissions
 
-```bash
-$ create database journaly_db;
-$ alter user <your_username> with superuser;
-```
+   ```bash
+   $ create database journaly_db;
+   $ alter user <your_username> with superuser;
+   ```
 
-4. Apply database migrations to your new database instance:
+1. If you haven't created a `backend/prisma/.env` file yet, copy and paste `backend/prisma/.env.example` into the new `.env` file. Then, replace the placeholders with your new postgres username & password.
 
-```bash
-$ npx prisma migrate up --experimental
-```
+1. Finally, from the `backend` directory, apply database migrations to your new database instance:
 
-5. Finally, go to your `.env` file in the backend directory and replace the placeholders with your new postgres username & password.
+   ```bash
+   $ npm run migrate:up
+   ```
 
-You've got a local Journaly PostgreSQL DB, woohoo! 🎉
+   You've got a local Journaly PostgreSQL DB, woohoo! 🎉
 
 #### Useful Commands For Working With Your DB
 
@@ -83,13 +83,8 @@ You've got a local Journaly PostgreSQL DB, woohoo! 🎉
 ### Running Journaly
 
 1. To run the entire app in local development mode, simply run `npm run dev` from the root of the project! This will use `concurrently` to start up both the frontend and backend dev servers.
-2. If you would like to run frontend or backend separately, you can run `npm run dev` from each respective directory.
-
-### Seeding your database
-
-3. Let's seed that baby DB!  
-   `$ cd backend/`
-   `$ npm run seed`
+1. If you would like to run frontend or backend separately, you can run `npm run dev` from each respective directory.
+1. Let's seed that baby DB! From the root of the repo, run `npm run reseed-db`
 
 BOOM! You now have some users, along with a wee selection of posts :)
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,1 +1,2 @@
-DATABASE_URL='postgresql://<your_username>:<your_password>@localhost:5432/journaly_db'
+FRONTEND_URL='http://localhost:3000'
+APP_SECRET='journaly'

--- a/backend/prisma/.env.example
+++ b/backend/prisma/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL='postgresql://<your_username>:<your_password>@localhost:5432/journaly_db'

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -5,6 +5,9 @@ import { server, schema } from 'nexus'
 
 require('dotenv').config({ path: '../.env ' })
 
+// Watch https://github.com/graphql-nexus/nexus/issues/524
+// and https://github.com/graphql-nexus/nexus/issues/523 for future
+// changes to this function
 schema.addToContext((request: any) => ({
   request,
   response: request.response,

--- a/backend/src/graphql.ts
+++ b/backend/src/graphql.ts
@@ -53,11 +53,22 @@ schema.objectType({
     t.model.title()
     t.model.body()
     t.model.excerpt()
+    t.model.readTime()
     t.model.author()
     t.model.status()
+    t.model.images()
+    t.model.likes({ type: 'PostLike' })
     t.model.threads()
     t.model.language({ type: 'Language' })
     t.model.createdAt()
+  },
+})
+
+schema.objectType({
+  name: 'Image',
+  definition(t) {
+    t.model.id()
+    t.model.smallSize()
   },
 })
 
@@ -89,6 +100,13 @@ schema.objectType({
     t.model.id()
     t.model.country()
     t.model.city()
+  },
+})
+
+schema.objectType({
+  name: 'PostLike',
+  definition(t) {
+    t.model.id()
   },
 })
 
@@ -132,7 +150,20 @@ schema.queryType({
   definition(t) {
     t.list.field('posts', {
       type: 'Post',
-      resolve: async (_parent, _args, ctx) => ctx.db.post.findMany(),
+      args: {
+        status: arg({ type: 'PostStatus', required: true }),
+        authorId: intArg({ required: true }),
+      },
+      resolve: async (_parent, args, ctx) => {
+        return ctx.db.post.findMany({
+          where: {
+            AND: {
+              author: { id: args.authorId },
+              status: args.status,
+            },
+          },
+        })
+      },
     }),
       t.field('postById', {
         type: 'Post',

--- a/backend/src/utils.ts
+++ b/backend/src/utils.ts
@@ -109,11 +109,21 @@ export const generateExcerpt = (
   return bodyText.substr(0, end)
 }
 
+// TODO: enhance accuracy by taking into account HTML tags (only look at text and disregard HTML)
+export const readTime = (text: string): number => {
+  const numWords = text.split(' ').length
+
+  return Math.round(numWords / 200)
+}
+
 export const processEditorDocument = (document: NodeType[]) => {
+  const body = htmlifyEditorNodes(document)
+
   return {
-    body: htmlifyEditorNodes(document),
+    body,
     bodySrc: JSON.stringify(document),
     excerpt: generateExcerpt(document),
+    readTime: readTime(body),
   }
 }
 

--- a/frontend/codegen.yml
+++ b/frontend/codegen.yml
@@ -3,6 +3,9 @@ schema: 'http://localhost:4000/graphql'
 documents: 'graphql/**/*.graphql'
 generates:
   generated/graphql.tsx:
+    hooks:
+      afterOneFileWrite:
+        - prettier --write
     plugins:
       - 'typescript'
       - 'typescript-operations'

--- a/frontend/graphql/feed.graphql
+++ b/frontend/graphql/feed.graphql
@@ -1,12 +1,5 @@
 query feed {
   feed {
-    id
-    title
-    body
-    author {
-      id
-      name
-      email
-    }
+    ...PostCardFragment
   }
 }

--- a/frontend/graphql/fragments.graphql
+++ b/frontend/graphql/fragments.graphql
@@ -11,6 +11,7 @@ fragment AuthorFragment on User {
   id
   name
   handle
+  profileImage
 }
 
 fragment CommentFragment on Comment {
@@ -36,12 +37,35 @@ fragment PostFragment on Post {
   title
   body
   status
+  excerpt
+  readTime
   createdAt
   author {
     ...AuthorFragment
   }
   threads {
     ...ThreadFragment
+  }
+}
+
+fragment PostCardFragment on Post {
+  id
+  title
+  body
+  excerpt
+  readTime
+  createdAt
+  images {
+    smallSize
+  }
+  likes {
+    id
+  }
+  threads {
+    id
+  }
+  author {
+    ...AuthorFragment
   }
 }
 

--- a/frontend/graphql/posts.graphql
+++ b/frontend/graphql/posts.graphql
@@ -1,0 +1,5 @@
+query posts($authorId: Int!, $status: PostStatus!) {
+  posts(authorId: $authorId, status: $status) {
+    ...PostCardFragment
+  }
+}


### PR DESCRIPTION
## Description

**Issue:** #78 

This PR supports querying for posts by `authorId` and `status` (published / draft) on the frontend. All code comes directly from preexisting, closed PRs (#98, #134) in an effort to create smaller, more manageable PRs.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Allow querying for `authorId` and `status`, which will be used for posts that appear on the profile page and my posts page (published and draft tabs)
- [x] Expose `excerpt` and `readTime` to the frontend
- [x] Update the readme with information on setting up `.env` files
- [x] Test that My Feed page still works ✅
- [x] Test that `excerpt` and `readTime` appear on the my feed API response

## Screenshots

No visual changes