### PR TITLE
Display published and draft posts on the My Posts page

### DIFF
--- a/frontend/components/Dashboard/MyPosts/MyPosts.tsx
+++ b/frontend/components/Dashboard/MyPosts/MyPosts.tsx
@@ -1,0 +1,95 @@
+import React from 'react'
+import {
+  PostStatus as PostStatusType,
+  Post as PostType,
+  User as UserType,
+  usePostsQuery,
+} from '../../../generated/graphql'
+import LoadingSpinner from '../../Icons/LoadingSpinner'
+import PostCard from '../PostCard/PostCard'
+import theme from '../../../theme'
+
+type Props = {
+  currentUser: UserType
+  status: PostStatusType
+}
+
+const MyPosts: React.FC<Props> = ({ currentUser, status }) => {
+  const { loading, data, error } = usePostsQuery({
+    variables: {
+      status,
+      authorId: currentUser.id,
+    },
+  })
+
+  let posts = (data?.posts as PostType[]) || []
+  const title = status === PostStatusType.Published ? 'My Published Posts' : 'My Drafts'
+
+  return (
+    <div className="my-posts-container">
+      {error && <p>There was an error retrieving your posts.</p>}
+
+      {loading ? (
+        <LoadingSpinner size={60} className="loading-spinner" />
+      ) : (
+        <>
+          <h1 className="my-posts-title">{title}</h1>
+
+          <div className="my-posts">
+            {posts?.map((post) => (
+              <PostCard key={post.id} post={post} status={status} />
+            ))}
+          </div>
+        </>
+      )}
+
+      <style jsx>{`
+        @keyframes fadeIn {
+          from {
+            opacity: 0;
+          }
+          to {
+            opacity: 1;
+          }
+        }
+
+        :global(.loading-spinner) {
+          display: block;
+          margin: 0 auto;
+        }
+
+        .my-posts-title {
+          margin-bottom: 50px;
+          ${theme.typography.headingLG};
+          text-align: center;
+        }
+
+        .my-posts {
+          display: grid;
+          grid-template-columns: 1fr;
+          grid-gap: 50px;
+          animation: 150ms fadeIn ease-in;
+        }
+
+        @media (min-width: ${theme.breakpoints.SM}) {
+          .my-posts {
+            grid-template-columns: 1fr 1fr;
+          }
+        }
+
+        @media (min-width: ${theme.breakpoints.MD}) {
+          .my-posts {
+            grid-template-columns: 1fr;
+          }
+
+          .my-posts :global(.post-card-container) {
+            max-width: 768px;
+            margin: 0 auto;
+          }
+        }
+      `}</style>
+    </div>
+  )
+}
+
+export default MyPosts

--- a/frontend/components/Dashboard/MyPosts/index.ts
+++ b/frontend/components/Dashboard/MyPosts/index.ts
@@ -1,0 +1,1 @@
+export { default } from './MyPosts'

--- a/frontend/components/Dashboard/PostCard/PostCard.tsx
+++ b/frontend/components/Dashboard/PostCard/PostCard.tsx
@@ -2,19 +2,20 @@ import React from 'react'
 import Link from 'next/link'
 import { useTranslation } from '../../../config/i18n'
 import { formatShortDate } from '../../../utils/date'
-import { Post as PostType } from '../../../generated/graphql'
+import { Post as PostType, PostStatus as PostStatusType } from '../../../generated/graphql'
 import LikeIcon from '../../Icons/LikeIcon'
 import CommentIcon from '../../Icons/CommentIcon'
 import theme from '../../../theme'
 
 type Props = {
   post: PostType
+  status?: PostStatusType
   avatar?: boolean
 }
 
 const postBorderRadius = '5px'
 
-const PostCard: React.FC<Props> = ({ post, avatar = false }) => {
+const PostCard: React.FC<Props> = ({ post, status = PostStatusType.Published, avatar = false }) => {
   const { t } = useTranslation('post')
   const {
     id,
@@ -27,7 +28,8 @@ const PostCard: React.FC<Props> = ({ post, avatar = false }) => {
     author: { handle, name, profileImage },
     createdAt,
   } = post
-
+  const isDraft = status === PostStatusType.Draft
+  const isPublished = status === PostStatusType.Published
   const displayImage = images.length ? images[0].smallSize : '/images/samples/sample-post-img.jpg'
   console.log(handle, name, profileImage, avatar)
   // const authorDisplayName = author.handle || author.name
@@ -46,21 +48,23 @@ const PostCard: React.FC<Props> = ({ post, avatar = false }) => {
             </div>
 
             <div className="post-data">
-              <div className="post-stats">
-                <div className="post-stat">
-                  <LikeIcon />
-                  <span>{likes.length}</span>
+              {isPublished && (
+                <div className="post-stats">
+                  <div className="post-stat">
+                    <LikeIcon />
+                    <span>{likes.length}</span>
+                  </div>
+                  <div className="post-stat">
+                    <CommentIcon />
+                    <span>{threads.length}</span>
+                  </div>
                 </div>
-                <div className="post-stat">
-                  <CommentIcon />
-                  <span>{threads.length}</span>
-                </div>
-              </div>
+              )}
               <div className="post-subtext">
                 {formatShortDate(createdAt)} - {t('readTime', { minutes: readTime })}
               </div>
             </div>
-            <p className="read-post">{t('readAction')}</p>
+            <p className="post-action">{isDraft ? t('finishAction') : t('readAction')}</p>
           </div>
         </a>
       </Link>
@@ -79,7 +83,7 @@ const PostCard: React.FC<Props> = ({ post, avatar = false }) => {
           .post-card-container {
             flex-direction: row;
             justify-content: center;
-            align-items: center;
+            align-items: stretch;
             padding: 15px;
           }
         }
@@ -99,6 +103,7 @@ const PostCard: React.FC<Props> = ({ post, avatar = false }) => {
         @media (min-width: ${theme.breakpoints.MD}) {
           .post-image {
             width: 125px;
+            align-self: center;
             margin-right: 30px;
             border-radius: 0;
           }
@@ -116,6 +121,7 @@ const PostCard: React.FC<Props> = ({ post, avatar = false }) => {
         @media (min-width: ${theme.breakpoints.MD}) {
           .post-card-details {
             padding: 0;
+            height: auto;
           }
         }
 
@@ -124,10 +130,13 @@ const PostCard: React.FC<Props> = ({ post, avatar = false }) => {
           ${theme.typography.headingLG};
         }
 
+        .post-data {
+          margin-top: 14px;
+        }
+
         .post-stats {
           display: flex;
           align-items: center;
-          margin-top: 14px;
           font-size: 14px;
           line-height: 1;
           color: ${theme.colors.blueLight};
@@ -151,11 +160,11 @@ const PostCard: React.FC<Props> = ({ post, avatar = false }) => {
           color: #95989a;
         }
 
-        .read-post {
+        .post-action {
           display: none;
         }
         @media (min-width: ${theme.breakpoints.MD}) {
-          .read-post {
+          .post-action {
             position: absolute;
             bottom: 0;
             right: 0;

--- a/frontend/pages/dashboard/my-posts.tsx
+++ b/frontend/pages/dashboard/my-posts.tsx
@@ -4,17 +4,24 @@ import { withApollo } from '../../lib/apollo'
 import DashboardLayout from '../../components/Layouts/DashboardLayout'
 import TabToggle from '../../elements/TabToggle'
 import AuthGate from '../../components/AuthGate'
+import MyPosts from '../../components/Dashboard/MyPosts'
+import { PostStatus as PostStatusType } from '../../generated/graphql'
+
+type Tab = {
+  key: PostStatusType
+  text: string
+}
 
 const MyPostsPage: NextPage = () => {
-  const tabs = [
-    { key: 'published', text: 'Published' },
-    { key: 'drafts', text: 'Drafts' },
+  const tabs: Tab[] = [
+    { key: PostStatusType.Published, text: 'Published' },
+    { key: PostStatusType.Draft, text: 'Drafts' },
   ]
-  const [activeKey, setActiveKey] = useState(tabs[0].key)
+  const [activeKey, setActiveKey] = useState<PostStatusType>(tabs[0].key)
 
   const handleToggle = (key: string): void => {
     // TODO(nick): wire up query params so you can directly link to a tab
-    setActiveKey(key)
+    setActiveKey(key as PostStatusType)
   }
 
   return (
@@ -24,8 +31,7 @@ const MyPostsPage: NextPage = () => {
           <TabToggle activeKey={activeKey} tabs={tabs} onToggle={handleToggle} />
 
           <div className="posts-wrapper">
-            {activeKey === 'published' && <div>My Posts</div>}
-            {activeKey === 'drafts' && <div>Drafts</div>}
+            <MyPosts status={activeKey} currentUser={currentUser} />
           </div>
 
           <style jsx>{`
@@ -34,21 +40,11 @@ const MyPostsPage: NextPage = () => {
             }
             .posts-wrapper {
               margin: 0 auto 50px;
-              padding: 50px 200px;
-            }
-
-            @keyframes fadeIn {
-              from {
-                opacity: 0;
-              }
-              to {
-                opacity: 1;
-              }
+              padding: 50px 0;
             }
 
             .posts-wrapper > div {
               padding: 50px;
-              animation: 150ms fadeIn ease-in;
             }
           `}</style>
         </DashboardLayout>


### PR DESCRIPTION
## Description

🚨 Note: this PR originally came from #134 . The PR it pointed to needed to be broken up into smaller PRs, so now this one points to a different base branch (#139 ). Here is the original description:

**Issue:** Closes #103 

Now that we have a TabToggle on the My Posts page, we can add published and draft posts 

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Support querying for posts based on status

## Screenshots

### iPhone 6, 7, 8 (360px)

<img src="https://user-images.githubusercontent.com/5829188/86497452-99890980-bd36-11ea-9c08-43e890ddc396.png" width="360px" />

### iPad (768px)

<img src="https://user-images.githubusercontent.com/5829188/86497441-90983800-bd36-11ea-91dd-9e3991c0c58c.png" width="768px" />

### Desktop (Published)

<img src="https://user-images.githubusercontent.com/5829188/86497475-a9085280-bd36-11ea-8046-e82de2cad0dc.png" />

### Desktop (Draft)

![localhost_3000_dashboard_my-posts (3)](https://user-images.githubusercontent.com/5829188/86497498-b9b8c880-bd36-11ea-84a3-202e7f0cb2f4.png)
