### PR TITLE
Update PostCards for use on the My Feed Page

### DIFF
--- a/frontend/components/Dashboard/MyFeed/MyFeed.tsx
+++ b/frontend/components/Dashboard/MyFeed/MyFeed.tsx
@@ -27,7 +27,7 @@ const MyFeed: React.FC<Props> = ({ posts, currentUser }) => {
       </div>
       <div className="my-feed-container">
         {posts.length > 0 ? (
-          posts.map((post) => <PostCard key={post.id} post={post} />)
+          posts.map((post) => <PostCard key={post.id} post={post} stacked avatar />)
         ) : (
           <p>Nothing to see yet...</p>
         )}

--- a/frontend/components/Dashboard/MyPosts/MyPosts.tsx
+++ b/frontend/components/Dashboard/MyPosts/MyPosts.tsx
@@ -6,7 +6,7 @@ import {
   usePostsQuery,
 } from '../../../generated/graphql'
 import LoadingSpinner from '../../Icons/LoadingSpinner'
-import PostCard from '../PostCard/PostCard'
+import PostCard from '../PostCard'
 import theme from '../../../theme'
 
 type Props = {

--- a/frontend/components/Dashboard/PostCard/PostCard.tsx
+++ b/frontend/components/Dashboard/PostCard/PostCard.tsx
@@ -1,21 +1,29 @@
 import React from 'react'
 import Link from 'next/link'
+import classNames from 'classnames'
 import { useTranslation } from '../../../config/i18n'
 import { formatShortDate } from '../../../utils/date'
 import { Post as PostType, PostStatus as PostStatusType } from '../../../generated/graphql'
 import LikeIcon from '../../Icons/LikeIcon'
 import CommentIcon from '../../Icons/CommentIcon'
 import theme from '../../../theme'
+import BlankAvatarIcon from '../../Icons/BlankAvatarIcon'
 
 type Props = {
   post: PostType
   status?: PostStatusType
   avatar?: boolean
+  stacked?: boolean
 }
 
 const postBorderRadius = '5px'
 
-const PostCard: React.FC<Props> = ({ post, status = PostStatusType.Published, avatar = false }) => {
+const PostCard: React.FC<Props> = ({
+  post,
+  status = PostStatusType.Published,
+  avatar = false,
+  stacked = false,
+}) => {
   const { t } = useTranslation('post')
   const {
     id,
@@ -31,15 +39,14 @@ const PostCard: React.FC<Props> = ({ post, status = PostStatusType.Published, av
   const isDraft = status === PostStatusType.Draft
   const isPublished = status === PostStatusType.Published
   const displayImage = images.length ? images[0].smallSize : '/images/samples/sample-post-img.jpg'
-  console.log(handle, name, profileImage, avatar)
-  // const authorDisplayName = author.handle || author.name
-  // const profileImage = author.profileImage
+  const imageAlt = images.length === 0 ? 'Typewriter on an old wooden desk' : ''
+  const postCardStyles = classNames('post-card-container', { stacked })
 
   return (
     <>
       <Link href={`/post/${id}`}>
-        <a className="post-card-container">
-          <img className="post-image" src={displayImage} alt="" />
+        <a className={postCardStyles}>
+          <img className="post-image" src={displayImage} alt={imageAlt} />
 
           <div className="post-card-details">
             <div className="post-text">
@@ -47,24 +54,42 @@ const PostCard: React.FC<Props> = ({ post, status = PostStatusType.Published, av
               <p className="post-excerpt">{excerpt}</p>
             </div>
 
-            <div className="post-data">
-              {isPublished && (
-                <div className="post-stats">
-                  <div className="post-stat">
-                    <LikeIcon />
-                    <span>{likes.length}</span>
-                  </div>
-                  <div className="post-stat">
-                    <CommentIcon />
-                    <span>{threads.length}</span>
-                  </div>
+            <div className="post-avatar-and-data">
+              {avatar && (
+                <div className="post-avatar">
+                  {profileImage ? (
+                    <img className="profile-image" src={profileImage} alt="" />
+                  ) : (
+                    <BlankAvatarIcon size={27} />
+                  )}
+
+                  <p className="author">{handle || name}</p>
                 </div>
               )}
-              <div className="post-subtext">
-                {formatShortDate(createdAt)} - {t('readTime', { minutes: readTime })}
+
+              <div className="post-data">
+                {isPublished && (
+                  <div className="post-stats">
+                    <div className="post-stat">
+                      <LikeIcon />
+                      <span>{likes.length}</span>
+                    </div>
+                    <div className="post-stat">
+                      <CommentIcon />
+                      <span>{threads.length}</span>
+                    </div>
+                  </div>
+                )}
+
+                <div className="post-subtext">
+                  {formatShortDate(createdAt)} - {t('readTime', { minutes: readTime })}
+                </div>
               </div>
             </div>
-            <p className="post-action">{isDraft ? t('finishAction') : t('readAction')}</p>
+
+            {!avatar && (
+              <p className="post-action">{isDraft ? t('finishAction') : t('readAction')}</p>
+            )}
           </div>
         </a>
       </Link>
@@ -80,7 +105,7 @@ const PostCard: React.FC<Props> = ({ post, status = PostStatusType.Published, av
           transition: all 150ms ease-in;
         }
         @media (min-width: ${theme.breakpoints.MD}) {
-          .post-card-container {
+          .post-card-container:not(.stacked) {
             flex-direction: row;
             justify-content: center;
             align-items: stretch;
@@ -101,7 +126,7 @@ const PostCard: React.FC<Props> = ({ post, status = PostStatusType.Published, av
           border-top-left-radius: ${postBorderRadius};
         }
         @media (min-width: ${theme.breakpoints.MD}) {
-          .post-image {
+          :not(.stacked) .post-image {
             width: 125px;
             align-self: center;
             margin-right: 30px;
@@ -119,7 +144,7 @@ const PostCard: React.FC<Props> = ({ post, status = PostStatusType.Published, av
           padding: 12px;
         }
         @media (min-width: ${theme.breakpoints.MD}) {
-          .post-card-details {
+          :not(.stacked) .post-card-details {
             padding: 0;
             height: auto;
           }
@@ -130,8 +155,40 @@ const PostCard: React.FC<Props> = ({ post, status = PostStatusType.Published, av
           ${theme.typography.headingLG};
         }
 
-        .post-data {
-          margin-top: 14px;
+        .post-avatar-and-data {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          margin-top: 12px;
+        }
+
+        .stacked .post-avatar-and-data {
+          margin-top: 24px;
+        }
+
+        .post-avatar {
+          display: flex;
+          align-items: center;
+          margin-bottom: 4px;
+        }
+
+        .post-avatar > :global(*) {
+          border-radius: 50%;
+          margin-right: 12px;
+        }
+
+        .post-avatar :global(svg) {
+          background-color: ${theme.colors.blueLight};
+        }
+
+        .profile-image {
+          width: 27px;
+          height: 27px;
+          object-fit: cover;
+        }
+
+        .author {
+          font-size: 14px;
         }
 
         .post-stats {
@@ -164,7 +221,7 @@ const PostCard: React.FC<Props> = ({ post, status = PostStatusType.Published, av
           display: none;
         }
         @media (min-width: ${theme.breakpoints.MD}) {
-          .post-action {
+          :not(.stacked) .post-action {
             position: absolute;
             bottom: 0;
             right: 0;


### PR DESCRIPTION
## Description

🚨 Note: this PR originally came from #135 . The PR it pointed to needed to be broken up into smaller PRs, so now this one points to a different base branch (#140). Here is the original description:

**Issue:** #79 

This PR adds support for displaying avatars in the `<PostCard />` component. It also adds a `stacked` prop, which keeps the card in the stacked arrangement (image on top of post details), even on large screens.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Add support for stacked `PostCard`s
- [x] Add support for displaying avatars / author name in `PostCard`s
- [x] Make sure non-stacked `PostCard`s still look good

## Screenshots

![image](https://user-images.githubusercontent.com/5829188/86499699-83cd1180-bd41-11ea-9e2d-b3ef845655e8.png)

🚨 Note: [this comment](https://github.com/Journaly/journaly/pull/135#pullrequestreview-442573798) has been addressed and now the post cards look like this:

![image](https://user-images.githubusercontent.com/5829188/86505965-7cc4f400-bd7f-11ea-866f-770536156082.png)
