### PR TITLE
Add nprogress bar for page loads

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2576,6 +2576,12 @@
       "integrity": "sha512-EPZBIGed5gNnfWCiwEIwTE2Jdg4813odnG8iNPMQGrqVxrI+wL68SPtPeCX+ZxGBaA6pKAVc6jaKgP/Q0QzfdQ==",
       "dev": true
     },
+    "@types/nprogress": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@types/nprogress/-/nprogress-0.2.0.tgz",
+      "integrity": "sha512-1cYJrqq9GezNFPsWTZpFut/d4CjpZqA0vhqDUPFWYKF1oIyBz5qnoYMzR+0C/T96t3ebLAC1SSnwrVOm5/j74A==",
+      "dev": true
+    },
     "@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,6 +53,7 @@
     "@types/classnames": "^2.2.10",
     "@types/express": "^4.17.4",
     "@types/node": "^13.7.6",
+    "@types/nprogress": "^0.2.0",
     "@types/react": "^16.9.23",
     "@types/react-dom": "^16.9.5",
     "@typescript-eslint/eslint-plugin": "^2.29.0",

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,14 +1,22 @@
 import App from 'next/app'
 import Head from 'next/head'
 import Router, { withRouter } from 'next/router'
+import NProgress from 'nprogress'
 import { initializeTracking, trackPageView } from '../lib/google-analytics'
 import '../styles/reset.css'
 import '../styles/globalStyles.css'
 import { appWithTranslation } from '../config/i18n'
 
 initializeTracking()
-// Tracks all page views except the first page render
-Router.events.on('routeChangeComplete', (url) => trackPageView(url))
+
+// Show loading progress on page loads
+Router.events.on('routeChangeStart', () => NProgress.start())
+Router.events.on('routeChangeError', () => NProgress.done())
+Router.events.on('routeChangeComplete', (url) => {
+  // Tracks all page views except the first page render
+  trackPageView(url)
+  NProgress.done()
+})
 
 class JournalyApp extends App {
   componentDidMount() {
@@ -24,6 +32,7 @@ class JournalyApp extends App {
       <>
         <Head>
           <title>Journaly</title>
+          <link rel="stylesheet" type="text/css" href="/nprogress.css" />
         </Head>
         <Component {...pageProps} />
       </>

--- a/frontend/pages/_document.tsx
+++ b/frontend/pages/_document.tsx
@@ -50,7 +50,6 @@ class MyDocument extends Document<DocumentProps & { children?: ReactNode } & Cus
             rel="stylesheet"
           />
           <link rel="shortcut icon" href="/favicon.png" />
-          <link rel="stylesheet" type="text/css" href="/nprogress.css" />
         </Head>
         <body className="block-transitions-on-page-load">
           <Main />


### PR DESCRIPTION
## Description

**Issue:** #146

Adding back the nprogress bar that we used to have 🕺🏻

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Add the router events for starting/stopping the nprogress bar

## Screenshots

