### PR TITLE
Fix logo position for non-logged in users

### DIFF
--- a/frontend/components/Dashboard/Nav/Nav.tsx
+++ b/frontend/components/Dashboard/Nav/Nav.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react'
 import Link from 'next/link'
+import classNames from 'classnames'
 import { navConstants } from './nav-constants'
 import NavLinks from './NavLinks'
 import { User as UserType } from '../../../generated/graphql'
@@ -11,6 +12,8 @@ interface Props {
 }
 
 const Nav: React.FC<Props> = ({ currentUser, expanded, collapse }) => {
+  const navStyles = classNames('nav-wrapper', { expanded, 'logged-in': Boolean(currentUser) })
+
   useEffect(() => {
     setTimeout(() => {
       document.body.classList.remove('block-transitions-on-page-load')
@@ -25,7 +28,7 @@ const Nav: React.FC<Props> = ({ currentUser, expanded, collapse }) => {
   }
 
   return (
-    <div className={expanded ? 'expanded' : ''}>
+    <div className={navStyles}>
       <div className="nav-background" onClick={handleCollapse} />
 
       <nav>
@@ -105,6 +108,10 @@ const Nav: React.FC<Props> = ({ currentUser, expanded, collapse }) => {
           /* The auto top margin allows the logo to take up enough space, but push itself down */
           margin: auto 0 15px;
           text-align: center;
+        }
+
+        .nav-wrapper:not(.logged-in) .nav-logo {
+          margin: 6px 0 15px;
         }
 
         .nav-logo a {


### PR DESCRIPTION
## Description

This is a quick fix for positioning the Journaly logo in the side nav when users are not logged in

## Subtasks

- [x] Fix the position (remove `margin-top: auto` for non-logged in users)

## Screenshots

![image](https://user-images.githubusercontent.com/5829188/86523570-4a6cd280-be23-11ea-8be2-21cc45678bc6.png)

![image](https://user-images.githubusercontent.com/5829188/86523575-5062b380-be23-11ea-8cc6-11e5fb007e32.png)

