### PR TITLE
Handle URL typed `href` prop to `ExternalLink`

### DIFF
--- a/frontend/elements/ExternalLink/ExternalLink.tsx
+++ b/frontend/elements/ExternalLink/ExternalLink.tsx
@@ -13,7 +13,7 @@ type Props = {
 }
 
 const ExternalLink: React.FC<Props> = (props) => {
-  const { ariaLabel, className, icon = false, ...otherProps } = props
+  const { ariaLabel, className, href, icon = false, ...otherProps } = props
 
   const externalLinkClasses = classNames(className, { icon })
 
@@ -24,6 +24,7 @@ const ExternalLink: React.FC<Props> = (props) => {
         rel="noopener noreferrer"
         className={externalLinkClasses}
         aria-label={ariaLabel}
+        href={href.toString()}
         {...otherProps}
       />
 


### PR DESCRIPTION
`<a>`'s `href` prop doesn't seem to accept `URL`s, so cast to string here

Error:

```
Failed to compile.

/Users/ryanjenkins/journaly/frontend/elements/ExternalLink/ExternalLink.tsx
ERROR in /Users/ryanjenkins/journaly/frontend/elements/ExternalLink/ExternalLink.tsx(22,8):
22:8 Type '{ children: ReactNode; href: string | URL; target: string; rel: string; className: string; "aria-label": string | undefined; }' is not assignable to type 'DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>'.
  Type '{ children: ReactNode; href: string | URL; target: string; rel: string; className: string; "aria-label": string | undefined; }' is not assignable to type 'AnchorHTMLAttributes<HTMLAnchorElement>'.
    Types of property 'href' are incompatible.
      Type 'string | URL' is not assignable to type 'string | undefined'.
        Type 'URL' is not assignable to type 'string'.
    20 |   return (
    21 |     <>
  > 22 |       <a
       |        ^
    23 |         target="_blank"
    24 |         rel="noopener noreferrer"
    25 |         className={externalLinkClasses}
```