### PR TITLE
Make dashboard, nav, and scrolled content responsive and visible

### DIFF
--- a/frontend/components/Dashboard/Header/HamburgerIcon.tsx
+++ b/frontend/components/Dashboard/Header/HamburgerIcon.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import classNames from 'classnames'
+import theme from '../../../theme'
+
+type Props = {
+  onClick: () => void
+  className?: string
+}
+
+const HamburgerIcon: React.FC<Props> = ({ onClick, className }) => {
+  const hamburgerStyles = classNames('hamburger-container', className)
+
+  return (
+    <div className={hamburgerStyles} onClick={onClick}>
+      <div />
+      <div />
+      <div />
+
+      <style jsx>{`
+        .hamburger-container {
+          padding: 10px;
+          cursor: pointer;
+        }
+
+        .hamburger-container div {
+          height: 1px;
+          width: 32px;
+          background-color: ${theme.colors.white};
+        }
+
+        .hamburger-container div:nth-child(2) {
+          margin-top: 7px;
+          width: 24px;
+        }
+
+        .hamburger-container div:nth-child(3) {
+          margin-top: 7px;
+          width: 18px;
+        }
+      `}</style>
+    </div>
+  )
+}
+
+export default HamburgerIcon

--- a/frontend/components/Dashboard/Header/Header.tsx
+++ b/frontend/components/Dashboard/Header/Header.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import theme from '../../../theme'
 import { navConstants } from '../Nav'
+import { headerHeight } from '../dashboardConstants'
+import HamburgerIcon from './HamburgerIcon'
 
 interface Props {
   onMenuClick: () => void
@@ -9,23 +11,25 @@ interface Props {
 const Header: React.FC<Props> = ({ onMenuClick }) => {
   return (
     <div className="header">
-      <div className="hamburger-icon" onClick={onMenuClick}>
-        <div />
-        <div />
-        <div />
-      </div>
+      <HamburgerIcon onClick={onMenuClick} className="hamburger-icon" />
 
       <span className="logo-text">Journaly</span>
 
       <style jsx>{`
         .header {
+          position: fixed;
+          top: 0;
+          left: 0;
+          right: 0;
           display: flex;
           justify-content: space-between;
           align-items: center;
-          height: 72px;
+          height: ${headerHeight};
           padding: 20px 0;
           color: white;
           background-color: ${theme.colors.black};
+          /* Show header above scrolled dashboard content */
+          z-index: 1;
         }
         /* Header should disappear when the mobile nav does */
         @media (${navConstants.aboveMobileNav}) {
@@ -34,28 +38,8 @@ const Header: React.FC<Props> = ({ onMenuClick }) => {
           }
         }
 
-        .hamburger-icon {
+        :global(.hamburger-icon) {
           margin-left: 10px;
-          padding: 10px;
-          cursor: pointer;
-          /* Allow hamburger icon to appear through open, overlaid mobile <Nav /> */
-          z-index: ${navConstants.zIndex + 1};
-        }
-
-        .hamburger-icon div {
-          height: 1px;
-          width: 32px;
-          background-color: white;
-        }
-
-        .hamburger-icon div:nth-child(2) {
-          margin-top: 7px;
-          width: 24px;
-        }
-
-        .hamburger-icon div:nth-child(3) {
-          margin-top: 7px;
-          width: 18px;
         }
 
         .logo-text {

--- a/frontend/components/Dashboard/Header/Header.tsx
+++ b/frontend/components/Dashboard/Header/Header.tsx
@@ -29,7 +29,7 @@ const Header: React.FC<Props> = ({ onMenuClick }) => {
           color: white;
           background-color: ${theme.colors.black};
           /* Show header above scrolled dashboard content */
-          z-index: 1;
+          z-index: ${navConstants.zIndex - 1};
         }
         /* Header should disappear when the mobile nav does */
         @media (${navConstants.aboveMobileNav}) {

--- a/frontend/components/Dashboard/Nav/Nav.tsx
+++ b/frontend/components/Dashboard/Nav/Nav.tsx
@@ -2,8 +2,10 @@ import React, { useEffect } from 'react'
 import Link from 'next/link'
 import classNames from 'classnames'
 import { navConstants } from './nav-constants'
+import HamburgerIcon from '../Header/HamburgerIcon'
 import NavLinks from './NavLinks'
 import { useCurrentUserQuery, User as UserType } from '../../../generated/graphql'
+import theme from '../../../theme'
 
 interface Props {
   expanded: boolean
@@ -35,6 +37,8 @@ const Nav: React.FC<Props> = ({ expanded, collapse }) => {
       <div className="nav-background" onClick={handleCollapse} />
 
       <nav>
+        <HamburgerIcon onClick={handleCollapse} className="mobile-hamburger-icon" />
+
         {currentUser && <NavLinks onClick={handleCollapse} currentUser={currentUser} />}
 
         <h1 className="nav-logo">
@@ -70,19 +74,39 @@ const Nav: React.FC<Props> = ({ expanded, collapse }) => {
           }
         }
 
+        :global(.mobile-hamburger-icon) {
+          display: none;
+        }
+
+        @media (${navConstants.mobileNavOnly}) {
+          :global(.mobile-hamburger-icon) {
+            position: absolute;
+            top: 20px;
+            left: 10px;
+            display: block;
+          }
+        }
+
         nav {
           position: fixed;
           top: 0;
+          bottom: 0;
           left: 0;
           display: grid;
           grid-template-rows: 1fr 2fr 1fr;
-          height: 100vh;
+          grid-gap: 10px;
           width: ${navConstants.navWidth}px;
           background-color: #313131;
           z-index: ${navConstants.zIndex};
           transform: translateX(-100%);
           transition: transform ${navConstants.transitionDuration}ms linear,
             width ${navConstants.transitionDuration}ms linear;
+        }
+
+        @media (min-width: ${theme.breakpoints.XS}) {
+          nav {
+            grid-gap: 30px;
+          }
         }
 
         .expanded nav {

--- a/frontend/components/Dashboard/Nav/NavLinks.tsx
+++ b/frontend/components/Dashboard/Nav/NavLinks.tsx
@@ -93,7 +93,12 @@ const NavLinks: React.FC<Props> = ({ onClick, currentUser }) => {
         */
 
         .nav-top {
-          margin-top: 50px;
+          margin-top: 30px;
+        }
+        @media (min-width: ${theme.breakpoints.XS}) {
+          .nav-top {
+            margin-top: 50px;
+          }
         }
 
         .nav-top a {

--- a/frontend/components/Dashboard/Profile/PostList.tsx
+++ b/frontend/components/Dashboard/Profile/PostList.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useTranslation } from '../../../config/i18n'
-import { layoutLeftRightPadding } from '../../Dashboard/dashboardConstants'
+import { layoutTopBottomPadding, layoutLeftRightPadding } from '../../Dashboard/dashboardConstants'
 import {
   usePostsQuery,
   Post as PostType,
@@ -43,7 +43,7 @@ const PostList: React.FC<Props> = ({ currentUserId }) => {
           flex-direction: column;
           justify-content: center;
           align-items: center;
-          padding: 0 ${layoutLeftRightPadding};
+          padding: 0 ${layoutLeftRightPadding} ${layoutTopBottomPadding};
         }
         @media (min-width: ${theme.breakpoints.MD}) {
           .post-list {

--- a/frontend/components/Dashboard/dashboardConstants.ts
+++ b/frontend/components/Dashboard/dashboardConstants.ts
@@ -1,3 +1,4 @@
+export const headerHeight = '72px'
 export const layoutTopBottomPadding = '50px'
 export const layoutLeftRightPadding = '25px'
 export const layoutPadding = `${layoutTopBottomPadding} ${layoutLeftRightPadding}`

--- a/frontend/components/Layouts/DashboardLayout.tsx
+++ b/frontend/components/Layouts/DashboardLayout.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 import classNames from 'classnames'
 import { useRouter } from 'next/router'
 import Nav, { navConstants } from '../Dashboard/Nav'
-import { layoutPadding } from '../Dashboard/dashboardConstants'
+import { layoutPadding, headerHeight } from '../Dashboard/dashboardConstants'
 import Header from '../Dashboard/Header'
 import useWindowSize from '../../hooks/useWindowSize'
 
@@ -57,12 +57,20 @@ const DashboardLayout: React.FC<Props> = ({ children, withPadding = true }) => {
       <style jsx>{`
         .dashboard {
           position: relative;
-          height: 100vh;
+          height: 100%;
           width: 100%;
+          overflow: hidden;
+        }
+
+        @media (${navConstants.mobileNavOnly}) {
+          .dashboard {
+            padding-top: ${headerHeight};
+          }
         }
 
         .dashboard-container {
           height: 100%;
+          overflow-y: auto;
           transition: margin-left ${navConstants.transitionDuration}ms ease-in-out;
         }
 

--- a/frontend/components/Layouts/SettingsPageLayout.tsx
+++ b/frontend/components/Layouts/SettingsPageLayout.tsx
@@ -23,12 +23,12 @@ const SettingsPageLayout: React.FC<Props> = ({ children }) => {
         .settings-container {
           display: flex;
           flex-direction: column;
-          margin: 35px 0;
+          margin-top: 35px;
         }
         @media (min-width: ${theme.breakpoints.SM}) {
           .settings-container {
             flex-direction: row;
-            margin: 65px 0;
+            margin-top: 65px;
           }
         }
 


### PR DESCRIPTION
## Description

**Issue:** #161 

This PR makes sure that no matter what the screen height or width, the user can view page content and scroll if necessary.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Extract the hamburger icon to use in both the nav and the header
- [x] Make the header `position: fixed` so that you can still see it when scrolled down the page (allows mobile users to not have to scroll all the way back up to open the side nav)
- [x] Add `bottom: 0` to nav so that it extends to the bottom of the visible screen
- [x] Add a grid gap so that the side nav isn't squished on very small screen heights
- [x] Add `overflow-y` to dashboard container so we can see all of the page's content

## Screenshots

### iPhone 6/7/8

<img width="283" alt="Screen Shot 2020-07-12 at 2 31 10 PM" src="https://user-images.githubusercontent.com/5829188/87257042-6b997880-c44c-11ea-8849-c47f13686fb3.png">

### iPhone 6/7/8 scrolled

<img width="282" alt="Screen Shot 2020-07-12 at 2 32 29 PM" src="https://user-images.githubusercontent.com/5829188/87257056-88ce4700-c44c-11ea-845d-55129d1cf9da.png">

### Desktop super wide and super short, scrolled down

<img width="1103" alt="Screen Shot 2020-07-12 at 2 55 06 PM" src="https://user-images.githubusercontent.com/5829188/87257437-b963b000-c44f-11ea-8d09-18f78e2a26a2.png">
