### PR TITLE
Add loading spinner to AuthGate

### DIFF
--- a/frontend/components/Dashboard/MyPosts/MyPosts.tsx
+++ b/frontend/components/Dashboard/MyPosts/MyPosts.tsx
@@ -30,7 +30,7 @@ const MyPosts: React.FC<Props> = ({ currentUser, status }) => {
       {error && <p>There was an error retrieving your posts.</p>}
 
       {loading ? (
-        <LoadingSpinner size={60} className="loading-spinner" />
+        <LoadingSpinner size={60} />
       ) : (
         <>
           <h1 className="my-posts-title">{title}</h1>
@@ -51,11 +51,6 @@ const MyPosts: React.FC<Props> = ({ currentUser, status }) => {
           to {
             opacity: 1;
           }
-        }
-
-        :global(.loading-spinner) {
-          display: block;
-          margin: 0 auto;
         }
 
         .my-posts-title {

--- a/frontend/components/Dashboard/MyPosts/MyPosts.tsx
+++ b/frontend/components/Dashboard/MyPosts/MyPosts.tsx
@@ -48,12 +48,6 @@ const MyPosts: React.FC<Props> = ({ currentUser, status }) => {
           }
         }
 
-        .my-posts-title {
-          margin-bottom: 50px;
-          ${theme.typography.headingLG};
-          text-align: center;
-        }
-
         .my-posts {
           display: grid;
           grid-template-columns: 1fr;

--- a/frontend/components/Dashboard/Profile/PostList.tsx
+++ b/frontend/components/Dashboard/Profile/PostList.tsx
@@ -32,7 +32,7 @@ const PostList: React.FC<Props> = ({ currentUserId }) => {
       {error && <p>There was an error retrieving your posts.</p>}
 
       {loading ? (
-        <LoadingSpinner size={60} className="loading-spinner" />
+        <LoadingSpinner size={60} />
       ) : (
         posts.map((post) => <PostCard key={post.id} post={post} />)
       )}
@@ -50,11 +50,6 @@ const PostList: React.FC<Props> = ({ currentUserId }) => {
             padding: 25px;
             border-top: 0;
           }
-        }
-
-        :global(.loading-spinner) {
-          display: block;
-          margin: 0 auto;
         }
 
         .posts-title {

--- a/frontend/components/Icons/LoadingSpinner.tsx
+++ b/frontend/components/Icons/LoadingSpinner.tsx
@@ -12,20 +12,29 @@ function LoadingSpinner({
   ...props
 }: React.SVGProps<SVGSVGElement> & SVGRProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 50 50" aria-labelledby={titleId} {...props}>
-      {title ? <title id={titleId}>{title}</title> : null}
-      <path d="M43.935 25.145c0-10.318-8.364-18.683-18.683-18.683-10.318 0-18.683 8.365-18.683 18.683h4.068c0-8.071 6.543-14.615 14.615-14.615s14.615 6.543 14.615 14.615h4.068z">
-        <animateTransform
-          attributeType="xml"
-          attributeName="transform"
-          type="rotate"
-          from="0 25 25"
-          to="360 25 25"
-          dur="0.6s"
-          repeatCount="indefinite"
-        />
-      </path>
-    </svg>
+    <>
+      <svg width={size} height={size} viewBox="0 0 50 50" aria-labelledby={titleId} {...props}>
+        {title ? <title id={titleId}>{title}</title> : null}
+        <path d="M43.935 25.145c0-10.318-8.364-18.683-18.683-18.683-10.318 0-18.683 8.365-18.683 18.683h4.068c0-8.071 6.543-14.615 14.615-14.615s14.615 6.543 14.615 14.615h4.068z">
+          <animateTransform
+            attributeType="xml"
+            attributeName="transform"
+            type="rotate"
+            from="0 25 25"
+            to="360 25 25"
+            dur="0.6s"
+            repeatCount="indefinite"
+          />
+        </path>
+      </svg>
+
+      <style jsx>{`
+        svg {
+          display: block;
+          margin: 0 auto;
+        }
+      `}</style>
+    </>
   )
 }
 

--- a/frontend/components/LoadingWrapper/LoadingWrapper.tsx
+++ b/frontend/components/LoadingWrapper/LoadingWrapper.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { ApolloError } from '@apollo/client'
 
 import { useTranslation } from '../../config/i18n'
+import LoadingSpinner from '../Icons/LoadingSpinner'
 
 type Props = {
   loading: boolean
@@ -18,7 +19,7 @@ const LoadingWrapper: React.FC<Props> = ({ loading, error, children }) => {
   if (error) {
     return <p>{t('error')}</p>
   } else if (loading) {
-    return <p>{t('loading')}</p>
+    return <LoadingSpinner size={60} />
   } else {
     return <>{children}</>
   }


### PR DESCRIPTION
## Description

**Issue:** #164 

Replace the loading text with a loading spinner while AuthGate is loading 

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Center the spinner on the page

## Screenshots

<img src="https://user-images.githubusercontent.com/5829188/87328610-96d2a500-c4ea-11ea-8b1d-371a57197513.png" width="400" />
