### PR TITLE
Add pagination component

### DIFF
--- a/frontend/components/Dashboard/MyFeed/MyFeed.tsx
+++ b/frontend/components/Dashboard/MyFeed/MyFeed.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import Head from 'next/head'
 import { useRouter } from 'next/router'
 import PostCard from '../PostCard'
 import Pagination from '../../Pagination'
@@ -17,10 +18,14 @@ const MyFeed: React.FC<Props> = ({ posts, currentUser }) => {
   const total = posts.length
   const currentPage = query.page ? Math.max(1, parseInt(query.page as string, 10)) : 1
   const showPagination = total > NUM_POSTS_PER_PAGE
+  const pageTitle = 'My Feed'
 
   console.log(currentUser)
   return (
     <div className="my-feed-wrapper">
+      <Head>
+        <title>{pageTitle}</title>
+      </Head>
       <h1>My Feed</h1>
       <div className="my-feed-search">
         <input type="text" placeholder="Search..." />
@@ -42,7 +47,12 @@ const MyFeed: React.FC<Props> = ({ posts, currentUser }) => {
       </div>
 
       {showPagination && (
-        <Pagination currentPage={currentPage} total={total} numPerPage={NUM_POSTS_PER_PAGE} />
+        <Pagination
+          currentPage={currentPage}
+          total={total}
+          numPerPage={NUM_POSTS_PER_PAGE}
+          title={pageTitle}
+        />
       )}
 
       <style jsx>{`

--- a/frontend/components/Dashboard/MyFeed/MyFeed.tsx
+++ b/frontend/components/Dashboard/MyFeed/MyFeed.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
-
+import { useRouter } from 'next/router'
 import PostCard from '../PostCard'
+import Pagination from '../../Pagination'
 import theme from '../../../theme'
 import { User as UserType, Post as PostType } from '../../../generated/graphql'
 
@@ -10,6 +11,10 @@ type Props = {
 }
 
 const MyFeed: React.FC<Props> = ({ posts, currentUser }) => {
+  const { query } = useRouter()
+  const currentPage = query.page ? Math.max(parseInt(query.page as string, 10)) : 1
+  const total = 53
+
   console.log(currentUser)
   return (
     <div className="my-feed-wrapper">
@@ -32,6 +37,9 @@ const MyFeed: React.FC<Props> = ({ posts, currentUser }) => {
           <p>Nothing to see yet...</p>
         )}
       </div>
+
+      <Pagination currentPage={currentPage} total={total} />
+
       <style jsx>{`
         .my-feed-wrapper {
           display: flex;
@@ -81,6 +89,10 @@ const MyFeed: React.FC<Props> = ({ posts, currentUser }) => {
           grid-gap: 20px;
           grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
           margin-top: 50px;
+        }
+
+        :global(.pagination-wrapper) {
+          margin: 40px 0;
         }
       `}</style>
     </div>

--- a/frontend/components/Dashboard/MyFeed/MyFeed.tsx
+++ b/frontend/components/Dashboard/MyFeed/MyFeed.tsx
@@ -12,8 +12,8 @@ type Props = {
 
 const MyFeed: React.FC<Props> = ({ posts, currentUser }) => {
   const { query } = useRouter()
+  const total = posts.length
   const currentPage = query.page ? Math.max(parseInt(query.page as string, 10)) : 1
-  const total = 53
 
   console.log(currentUser)
   return (

--- a/frontend/components/Dashboard/MyFeed/MyFeed.tsx
+++ b/frontend/components/Dashboard/MyFeed/MyFeed.tsx
@@ -10,10 +10,13 @@ type Props = {
   currentUser: UserType
 }
 
+const NUM_POSTS_PER_PAGE = 10
+
 const MyFeed: React.FC<Props> = ({ posts, currentUser }) => {
   const { query } = useRouter()
   const total = posts.length
-  const currentPage = query.page ? Math.max(parseInt(query.page as string, 10)) : 1
+  const currentPage = query.page ? Math.max(1, parseInt(query.page as string, 10)) : 1
+  const showPagination = total > NUM_POSTS_PER_PAGE
 
   console.log(currentUser)
   return (
@@ -38,7 +41,9 @@ const MyFeed: React.FC<Props> = ({ posts, currentUser }) => {
         )}
       </div>
 
-      <Pagination currentPage={currentPage} total={total} />
+      {showPagination && (
+        <Pagination currentPage={currentPage} total={total} numPerPage={NUM_POSTS_PER_PAGE} />
+      )}
 
       <style jsx>{`
         .my-feed-wrapper {

--- a/frontend/components/Pagination/Pagination.tsx
+++ b/frontend/components/Pagination/Pagination.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import Head from 'next/head'
 import Link from 'next/link'
-import theme from '../../theme'
 
 type Props = {
   currentPage: number

--- a/frontend/components/Pagination/Pagination.tsx
+++ b/frontend/components/Pagination/Pagination.tsx
@@ -1,0 +1,79 @@
+import React from 'react'
+import Head from 'next/head'
+import Link from 'next/link'
+import theme from '../../theme'
+
+type Props = {
+  currentPage: number
+  total: number
+  numPerPage?: number
+}
+
+const DEFAULT_NUM_PER_PAGE = 4
+
+const Pagination: React.FC<Props> = ({ currentPage, total, numPerPage = DEFAULT_NUM_PER_PAGE }) => {
+  const pages = Math.ceil(total / numPerPage)
+  let pageTitle = 'My Feed'
+
+  if (pages > 0) {
+    pageTitle = `My Feed | Page ${currentPage} of ${pages}`
+  }
+
+  const adjacentPageUrl = (direction: 1 | -1) => {
+    return {
+      pathname: '/dashboard/my-feed',
+      query: { page: currentPage + direction },
+    }
+  }
+
+  return (
+    <div className="pagination-wrapper">
+      <Head>
+        <title>{pageTitle}</title>
+      </Head>
+      <Link href={adjacentPageUrl(-1)}>
+        <a className="adjacent-page-link" aria-disabled={currentPage <= 1}>
+          &larr; Prev
+        </a>
+      </Link>
+      <p>
+        Page {currentPage} of {pages}
+      </p>
+      <Link href={adjacentPageUrl(1)}>
+        <a className="adjacent-page-link" aria-disabled={currentPage >= pages}>
+          Next &rarr;
+        </a>
+      </Link>
+
+      <style jsx>{`
+        .pagination-wrapper {
+          display: inline-grid;
+          grid-template-columns: repeat(4, auto);
+          align-items: stretch;
+          justify-content: center;
+          align-content: center;
+          border: 1px solid #e1e1e1;
+          border-radius: 10px;
+          text-align: center;
+        }
+
+        .pagination-wrapper > * {
+          margin: 0;
+          padding: 15px 30px;
+          border-right: 1px solid #e1e1e1;
+        }
+
+        .pagination-wrapper > *:last-child {
+          border-right: 0;
+        }
+
+        .pagination-wrapper a[aria-disabled='true'] {
+          color: #808080;
+          pointer-events: none;
+        }
+      `}</style>
+    </div>
+  )
+}
+
+export default Pagination

--- a/frontend/components/Pagination/Pagination.tsx
+++ b/frontend/components/Pagination/Pagination.tsx
@@ -1,35 +1,41 @@
 import React from 'react'
 import Head from 'next/head'
+import { useRouter } from 'next/router'
 import Link from 'next/link'
 
 type Props = {
   currentPage: number
   total: number
   numPerPage?: number
+  title?: string
 }
 
 const DEFAULT_NUM_PER_PAGE = 4
 
-const Pagination: React.FC<Props> = ({ currentPage, total, numPerPage = DEFAULT_NUM_PER_PAGE }) => {
+const Pagination: React.FC<Props> = ({
+  currentPage,
+  total,
+  numPerPage = DEFAULT_NUM_PER_PAGE,
+  title,
+}) => {
+  const { pathname } = useRouter()
   const pages = Math.ceil(total / numPerPage)
-  let pageTitle = 'My Feed'
-
-  if (pages > 0) {
-    pageTitle = `My Feed | Page ${currentPage} of ${pages}`
-  }
 
   const adjacentPageUrl = (direction: 1 | -1) => {
     return {
-      pathname: '/dashboard/my-feed',
+      pathname,
       query: { page: currentPage + direction },
     }
   }
 
   return (
     <div className="pagination-wrapper">
-      <Head>
-        <title>{pageTitle}</title>
-      </Head>
+      {title && pages > 1 && (
+        <Head>
+          <title>{`${title} | Page ${currentPage} of ${pages}`}</title>
+        </Head>
+      )}
+
       <Link href={adjacentPageUrl(-1)}>
         <a className="adjacent-page-link" aria-disabled={currentPage <= 1}>
           &larr; Prev

--- a/frontend/components/Pagination/index.ts
+++ b/frontend/components/Pagination/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Pagination'


### PR DESCRIPTION
## Description

**Issue:** #107 

Add the `Pagination` component and start wiring it up to the My Feed page. Eventually we'll want to get the `total` number of posts from the `useFeedQuery`, but for now, I'm just using `posts.length` for the total. The URL with the page query param looks like `http://localhost:3000/dashboard/my-feed?page=2`. I wasn't sure what to set for the number of posts per page on the My Feed page, so I set it to display 10 per page right now. I also kept the default number of items per page as it was from the Pagination component in the previous repo, which can be overridden by the parent if needed. Happy to change these default values if needed!

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Create the `Pagination` component
- [x] Use it on the My Feed page
- [x] Set some temporary default number of items/post per page
- [x] Make `pathname` and document title dynamic in `Pagination` (some pages could want a different title or no pagination info in the title at all)

## Screenshots

![image](https://user-images.githubusercontent.com/5829188/87372421-58fe6c80-c53c-11ea-896c-3bc733b8ec41.png)

