### PR TITLE
Fix nav transitions 🥳

### DIFF
--- a/frontend/components/Dashboard/Nav/NavLinks.tsx
+++ b/frontend/components/Dashboard/Nav/NavLinks.tsx
@@ -163,6 +163,7 @@ const NavLinks: React.FC<Props> = ({ onClick, currentUser }) => {
           margin-top: 10px;
           margin-bottom: 10px;
           border: 1px solid white;
+          transition: width ${navConstants.transitionDuration}ms linear;
         }
 
         :global(.expanded) .nav-bottom hr {
@@ -185,6 +186,8 @@ const NavLinks: React.FC<Props> = ({ onClick, currentUser }) => {
           height: 70px;
           font-size: 16px;
           color: ${theme.colors.white};
+          transition: padding-left ${navConstants.transitionDuration}ms linear,
+            padding-right ${navConstants.transitionDuration}ms linear;
         }
 
         :global(.expanded) .nav-link {
@@ -215,6 +218,7 @@ const NavLinks: React.FC<Props> = ({ onClick, currentUser }) => {
         .nav-link-text {
           margin-left: 0;
           font-size: 10px;
+          transition: margin-left ${navConstants.transitionDuration}ms linear;
         }
 
         :global(.expanded) .nav-link-text {

--- a/frontend/components/Layouts/DashboardLayout.tsx
+++ b/frontend/components/Layouts/DashboardLayout.tsx
@@ -31,7 +31,7 @@ const DashboardLayout: React.FC<Props> = ({ children, withPadding = true }) => {
 
     return false
   }
-  const [navExpanded, setNavExpanded] = useState(false)
+  const [navExpanded, setNavExpanded] = useState(shouldNavBeExpanded())
 
   const dashboardContainerStyles = classNames('dashboard-container', {
     'settings-page': router.pathname.includes('/settings/'),


### PR DESCRIPTION
## Description

**Issue:** #144 

Fixes the regression with nav transitions

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Prevent nav transition jump when navigating from page to page
- [x] Add transitions to the `.nav-link` elements so that the children don't transition bigger and faster than the container

## Screenshots

![nav_transition_fixes](https://user-images.githubusercontent.com/5829188/87446112-bb438580-c5ad-11ea-896e-7432cc78a7c0.gif)