### PR TITLE
Restore styling for h2 in Posts

### DIFF
--- a/frontend/components/PostBodyStyles/PostBodyStyles.tsx
+++ b/frontend/components/PostBodyStyles/PostBodyStyles.tsx
@@ -25,6 +25,10 @@ const PostBodyStyles: React.FC<Props> = ({ parentClassName }: Props) => {
         list-style-type: decimal;
         list-style-position: inside;
       }
+
+      .${parentClassName} h2 {
+        ${theme.typography.headingLG};
+      }
     `}</style>
   )
 }


### PR DESCRIPTION
## Description

**Issue:** #175 

When the design system/theme was implemented, many styles were not properly updated around the app. I tried to fix most of these in a few previous PRs but the 'T' (title/h2) button in the Journaly Editor still wasn't restored. This PR fixes that.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Try to figure out how the styles are working now
- [ ] Get these new styles to work

## Screenshots
