### PR TITLE
Add edit post functionality

### DIFF
--- a/frontend/components/Dashboard/Post/Post.tsx
+++ b/frontend/components/Dashboard/Post/Post.tsx
@@ -15,7 +15,7 @@ import theme from '../../../theme'
 import PostBodyStyles from '../../PostBodyStyles'
 import LeaveACommentIcon from '../../Icons/LeaveACommentIcon'
 import InlineFeedbackPopover from '../../InlineFeedbackPopover'
-import { useTranslation } from '../../../config/i18n'
+import { Router, useTranslation } from '../../../config/i18n'
 
 // TODO: Remove any when Types are fixed with PR #17
 interface IPostProps {
@@ -336,13 +336,22 @@ const Post: React.FC<IPostProps> = ({ post, currentUser, refetch }: IPostProps) 
         {currentUser && post.author.id === currentUser.id && (
           <div className="post-controls">
             {post.status === 'DRAFT' && (
-              <Button
-                type="button"
-                variant={ButtonVariant.Secondary}
-                onClick={setPostStatus(PostStatus.Published)}
-              >
-                {t('publishDraft')}
-              </Button>
+              <>
+                <Button
+                  type="button"
+                  variant={ButtonVariant.Secondary}
+                  onClick={() => { Router.push(`/post/${post.id}/edit`) }}
+                >
+                  {t('editPostAction')}
+                </Button>
+                <Button
+                  type="button"
+                  variant={ButtonVariant.Secondary}
+                  onClick={setPostStatus(PostStatus.Published)}
+                >
+                  {t('publishDraft')}
+                </Button>
+              </>
             )}
           </div>
         )}

--- a/frontend/components/Dashboard/Post/Post.tsx
+++ b/frontend/components/Dashboard/Post/Post.tsx
@@ -463,6 +463,12 @@ const Post: React.FC<IPostProps> = ({ post, currentUser, refetch }: IPostProps) 
           align-self: end;
           justify-self: end;
           margin-bottom: 20px;
+
+          display: flex;
+        }
+
+        .post-controls > :global(button) {
+          margin-left: 5px;
         }
       `}</style>
     </div>

--- a/frontend/components/Dashboard/Post/Post.tsx
+++ b/frontend/components/Dashboard/Post/Post.tsx
@@ -448,6 +448,13 @@ const Post: React.FC<IPostProps> = ({ post, currentUser, refetch }: IPostProps) 
         .post-body p {
           margin: 20px 0;
         }
+
+        .post-controls {
+          grid-column: 2;
+          align-self: end;
+          justify-self: end;
+          margin-bottom: 20px;
+        }
       `}</style>
     </div>
   )

--- a/frontend/generated/graphql.tsx
+++ b/frontend/generated/graphql.tsx
@@ -138,6 +138,7 @@ export type MutationCreatePostArgs = {
 export type MutationUpdatePostArgs = {
   postId: Scalars['Int']
   title?: Maybe<Scalars['String']>
+  languageId?: Maybe<Scalars['Int']>
   body?: Maybe<Array<EditorNode>>
   status?: Maybe<PostStatus>
 }
@@ -425,7 +426,11 @@ export type EditPostQueryVariables = {
 }
 
 export type EditPostQuery = { __typename?: 'Query' } & {
-  postById?: Maybe<{ __typename?: 'Post' } & Pick<Post, 'title' | 'bodySrc'>>
+  postById?: Maybe<
+    { __typename?: 'Post' } & Pick<Post, 'title' | 'bodySrc'> & {
+        language: { __typename?: 'Language' } & Pick<Language, 'id'>
+      }
+  >
   currentUser?: Maybe<
     { __typename?: 'User' } & {
       languagesLearning: Array<
@@ -577,6 +582,7 @@ export type UpdateCommentMutation = { __typename?: 'Mutation' } & {
 export type UpdatePostMutationVariables = {
   postId: Scalars['Int']
   title?: Maybe<Scalars['String']>
+  languageId?: Maybe<Scalars['Int']>
   body?: Maybe<Array<EditorNode>>
   status?: Maybe<PostStatus>
 }
@@ -1112,6 +1118,9 @@ export const EditPostDocument = gql`
     postById(id: $id) {
       title
       bodySrc
+      language {
+        id
+      }
     }
     currentUser {
       languagesLearning {
@@ -1638,8 +1647,20 @@ export type UpdateCommentMutationOptions = ApolloReactCommon.BaseMutationOptions
   UpdateCommentMutationVariables
 >
 export const UpdatePostDocument = gql`
-  mutation updatePost($postId: Int!, $title: String, $body: [EditorNode!], $status: PostStatus) {
-    updatePost(body: $body, title: $title, status: $status, postId: $postId) {
+  mutation updatePost(
+    $postId: Int!
+    $title: String
+    $languageId: Int
+    $body: [EditorNode!]
+    $status: PostStatus
+  ) {
+    updatePost(
+      body: $body
+      title: $title
+      languageId: $languageId
+      status: $status
+      postId: $postId
+    ) {
       ...PostFragment
     }
   }
@@ -1665,6 +1686,7 @@ export type UpdatePostMutationFn = ApolloReactCommon.MutationFunction<
  *   variables: {
  *      postId: // value for 'postId'
  *      title: // value for 'title'
+ *      languageId: // value for 'languageId'
  *      body: // value for 'body'
  *      status: // value for 'status'
  *   },

--- a/frontend/generated/graphql.tsx
+++ b/frontend/generated/graphql.tsx
@@ -183,6 +183,7 @@ export type Post = {
   threads: Array<Thread>
   language: Language
   createdAt: Scalars['DateTime']
+  bodySrc: Scalars['String']
 }
 
 export type PostImagesArgs = {
@@ -417,6 +418,28 @@ export type DeleteCommentMutationVariables = {
 
 export type DeleteCommentMutation = { __typename?: 'Mutation' } & {
   deleteComment?: Maybe<{ __typename?: 'Comment' } & Pick<Comment, 'id'>>
+}
+
+export type EditPostQueryVariables = {
+  id: Scalars['Int']
+}
+
+export type EditPostQuery = { __typename?: 'Query' } & {
+  postById?: Maybe<{ __typename?: 'Post' } & Pick<Post, 'title' | 'bodySrc'>>
+  currentUser?: Maybe<
+    { __typename?: 'User' } & {
+      languagesLearning: Array<
+        { __typename?: 'LanguageLearning' } & {
+          language: { __typename?: 'Language' } & LanguageFragmentFragment
+        }
+      >
+      languagesNative: Array<
+        { __typename?: 'LanguageNative' } & {
+          language: { __typename?: 'Language' } & LanguageFragmentFragment
+        }
+      >
+    }
+  >
 }
 
 export type FeedQueryVariables = {}
@@ -1083,6 +1106,66 @@ export type DeleteCommentMutationResult = ApolloReactCommon.MutationResult<Delet
 export type DeleteCommentMutationOptions = ApolloReactCommon.BaseMutationOptions<
   DeleteCommentMutation,
   DeleteCommentMutationVariables
+>
+export const EditPostDocument = gql`
+  query editPost($id: Int!) {
+    postById(id: $id) {
+      title
+      bodySrc
+    }
+    currentUser {
+      languagesLearning {
+        language {
+          ...LanguageFragment
+        }
+      }
+      languagesNative {
+        language {
+          ...LanguageFragment
+        }
+      }
+    }
+  }
+  ${LanguageFragmentFragmentDoc}
+`
+
+/**
+ * __useEditPostQuery__
+ *
+ * To run a query within a React component, call `useEditPostQuery` and pass it any options that fit your needs.
+ * When your component renders, `useEditPostQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useEditPostQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useEditPostQuery(
+  baseOptions?: ApolloReactHooks.QueryHookOptions<EditPostQuery, EditPostQueryVariables>,
+) {
+  return ApolloReactHooks.useQuery<EditPostQuery, EditPostQueryVariables>(
+    EditPostDocument,
+    baseOptions,
+  )
+}
+export function useEditPostLazyQuery(
+  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<EditPostQuery, EditPostQueryVariables>,
+) {
+  return ApolloReactHooks.useLazyQuery<EditPostQuery, EditPostQueryVariables>(
+    EditPostDocument,
+    baseOptions,
+  )
+}
+export type EditPostQueryHookResult = ReturnType<typeof useEditPostQuery>
+export type EditPostLazyQueryHookResult = ReturnType<typeof useEditPostLazyQuery>
+export type EditPostQueryResult = ApolloReactCommon.QueryResult<
+  EditPostQuery,
+  EditPostQueryVariables
 >
 export const FeedDocument = gql`
   query feed {

--- a/frontend/graphql/editPost.graphql
+++ b/frontend/graphql/editPost.graphql
@@ -2,6 +2,9 @@ query editPost($id: Int!) {
   postById(id: $id) {
     title
     bodySrc
+    language {
+      id
+    }
   }
   currentUser {
     languagesLearning {

--- a/frontend/graphql/editPost.graphql
+++ b/frontend/graphql/editPost.graphql
@@ -1,0 +1,18 @@
+query editPost($id: Int!) {
+  postById(id: $id) {
+    title
+    bodySrc
+  }
+  currentUser {
+    languagesLearning {
+      language {
+        ...LanguageFragment
+      }
+    }
+    languagesNative {
+      language {
+        ...LanguageFragment
+      }
+    }
+  }
+}

--- a/frontend/graphql/updatePost.graphql
+++ b/frontend/graphql/updatePost.graphql
@@ -1,5 +1,5 @@
-mutation updatePost($postId: Int!, $title: String, $body: [EditorNode!], $status: PostStatus) {
-  updatePost(body: $body, title: $title, status: $status, postId: $postId) {
+mutation updatePost($postId: Int!, $title: String, $languageId: Int, $body: [EditorNode!], $status: PostStatus) {
+  updatePost(body: $body, title: $title, languageId: $languageId, status: $status, postId: $postId) {
     ...PostFragment
   }
 }

--- a/frontend/nexus/post.ts
+++ b/frontend/nexus/post.ts
@@ -19,6 +19,7 @@ schema.objectType({
     t.model.threads()
     t.model.language({ type: 'Language' })
     t.model.createdAt()
+    t.model.bodySrc()
   },
 })
 
@@ -29,16 +30,16 @@ schema.objectType({
 const EditorNode = schema.inputObjectType({
   name: 'EditorNode',
   definition(t) {
-    t.string('type', { nullable: true }),
-      t.string('text', { nullable: true }),
-      t.boolean('italic', { nullable: true }),
-      t.boolean('bold', { nullable: true }),
-      t.boolean('underline', { nullable: true }),
-      t.field('children', {
-        type: EditorNode,
-        list: true,
-        nullable: true,
-      })
+    t.string('type', { nullable: true })
+    t.string('text', { nullable: true })
+    t.boolean('italic', { nullable: true })
+    t.boolean('bold', { nullable: true })
+    t.boolean('underline', { nullable: true })
+    t.field('children', {
+      type: EditorNode,
+      list: true,
+      nullable: true,
+    })
   },
 })
 

--- a/frontend/nexus/post.ts
+++ b/frontend/nexus/post.ts
@@ -179,6 +179,7 @@ schema.extendType({
       args: {
         postId: schema.intArg({ required: true }),
         title: schema.stringArg({ required: false }),
+        languageId: schema.intArg({ required: false }),
         body: EditorNode.asArg({ list: true, required: false }),
         status: schema.arg({ type: 'PostStatus', required: false }),
       },
@@ -209,6 +210,10 @@ schema.extendType({
         let data: PostUpdateInput = {}
         if (args.title) {
           data.title = args.title
+        }
+
+        if (args.languageId) {
+          data.language = { connect: {id: args.languageId } }
         }
 
         if (args.status) {

--- a/frontend/pages/dashboard/new-post.tsx
+++ b/frontend/pages/dashboard/new-post.tsx
@@ -29,10 +29,13 @@ const NewPostPage: NextPage = () => {
   const { languagesLearning = [], languagesNative = [] } = currentUser || {}
 
   const router = useRouter()
-  const [title, setTitle] = React.useState<string>('')
   const [langId, setLangId] = React.useState<number>(-1)
+  const [title, setTitle, resetTitle] = useAutosavedState<string>('', {
+    key: 'new-post:title',
+    debounceTime: 1000,
+  })
   const [body, setBody, resetBody] = useAutosavedState<Node[]>(initialValue, {
-    key: 'new-post',
+    key: 'new-post:body',
     debounceTime: 1000,
   })
 
@@ -42,6 +45,7 @@ const NewPostPage: NextPage = () => {
         return
       }
 
+      resetTitle()
       resetBody()
       router.push({ pathname: `/post/${createPost.id}` })
     },

--- a/frontend/pages/post/[id]/edit.tsx
+++ b/frontend/pages/post/[id]/edit.tsx
@@ -60,7 +60,7 @@ const EditPostPage: NextPage = () => {
       },
     })
 
-    if (!data.updatePost) {
+    if (!data || !data.updatePost) {
       return
     }
 

--- a/frontend/pages/post/[id]/edit.tsx
+++ b/frontend/pages/post/[id]/edit.tsx
@@ -1,0 +1,156 @@
+import React from 'react'
+import { NextPage } from 'next'
+import { useRouter } from 'next/router'
+import { Node } from 'slate'
+import { withApollo } from '../../../lib/apollo'
+
+import DashboardLayout from '../../../components/Layouts/DashboardLayout'
+import JournalyEditor from '../../../components/JournalyEditor'
+import LanguageSelect from '../../../components/LanguageSelect'
+import theme from '../../../theme'
+import Button, { ButtonVariant } from '../../../elements/Button'
+import {
+  useEditPostQuery,
+  useCreatePostMutation,
+  PostStatus as PostStatusType,
+} from '../../../generated/graphql'
+import AuthGate from '../../../components/AuthGate'
+
+const initialValue = [
+  {
+    type: 'paragraph',
+    children: [{ text: '' }],
+  },
+]
+
+const EditPostPage: NextPage = () => {
+  const idStr = useRouter().query.id as string
+  const id = parseInt(idStr, 10)
+
+  const { data: { currentUser, postById } = {} } = useEditPostQuery({ variables: { id } })
+  const { languagesLearning = [], languagesNative = [] } = currentUser || {}
+
+  const router = useRouter()
+  const [langId, setLangId] = React.useState<number>(-1)
+  const [title, setTitle] = React.useState<string>('')
+  const [body, setBody] = React.useState<Node[]>(initialValue)
+
+  React.useEffect(() => {
+    if (postById) {
+      setTitle(postById.title)
+      setBody(JSON.parse(postById.bodySrc) as Node[])
+    }
+  }, [postById])
+
+  const [createPost] = useCreatePostMutation({
+    onCompleted: ({ createPost }) => {
+      if (!createPost) {
+        return
+      }
+
+      router.push({ pathname: `/post/${createPost.id}` })
+    },
+  })
+
+  const userLanguages = languagesLearning
+    .map((x) => x.language)
+    .concat(languagesNative.map((x) => x.language))
+
+  const createNewPost = (status: PostStatusType) => {
+    createPost({
+      variables: { title, body, status, languageId: langId },
+    })
+  }
+
+  return (
+    <AuthGate>
+      <DashboardLayout>
+        <form id="edit-post">
+          <h1>Let's write a post</h1>
+
+          <label htmlFor="post-title">Title</label>
+          <input
+            className="j-field"
+            id="post-title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            type="text"
+            name="title"
+            placeholder="The Greatest Story Never Told..."
+            autoComplete="off"
+          />
+
+          <label htmlFor="post-language">Language</label>
+          <LanguageSelect
+            id="language"
+            languages={userLanguages}
+            value={langId}
+            onChange={setLangId}
+          />
+
+          <div className="editor-padding">
+            <JournalyEditor value={body} setValue={setBody} />
+          </div>
+
+          <div className="button-container">
+            <Button
+              type="submit"
+              disabled={!title || langId === -1}
+              variant={ButtonVariant.Primary}
+              data-test="post-submit"
+              onClick={(e: React.MouseEvent) => {
+                e.preventDefault()
+                createNewPost(PostStatusType.Published)
+              }}
+            >
+              Publish!
+            </Button>
+            <Button
+              type="submit"
+              disabled={!title || langId === -1}
+              variant={ButtonVariant.Secondary}
+              data-test="post-draft"
+              onClick={(e: React.MouseEvent) => {
+                e.preventDefault()
+                createNewPost(PostStatusType.Draft)
+              }}
+            >
+              Save Draft
+            </Button>
+          </div>
+          <style jsx>{`
+            display: flex;
+            flex-direction: column;
+
+            h1 {
+              margin: 50px auto;
+              text-align: center;
+              ${theme.typography.headingXL};
+            }
+
+            .button-container {
+              display: flex;
+              flex-direction: row;
+              margin: 0 auto;
+              width: 200px;
+              justify-content: space-between;
+            }
+
+            #new-post {
+              display: flex;
+              flex-direction: column;
+              background-color: white;
+              padding: 25px;
+              box-shadow: 0 0 5px 3px rgba(0, 0, 0, 0.05);
+            }
+            .editor-padding {
+              padding: 25px 0;
+            }
+          `}</style>
+        </form>
+      </DashboardLayout>
+    </AuthGate>
+  )
+}
+
+export default withApollo(EditPostPage)

--- a/frontend/pages/post/[id]/index.tsx
+++ b/frontend/pages/post/[id]/index.tsx
@@ -2,11 +2,11 @@ import React from 'react'
 import { NextPage } from 'next'
 import { useRouter } from 'next/router'
 
-import { withApollo } from '../../lib/apollo'
-import Post from '../../components/Dashboard/Post'
-import LoadingWrapper from '../../components/LoadingWrapper'
-import DashboardLayout from '../../components/Layouts/DashboardLayout'
-import { useCurrentUserQuery, usePostByIdQuery } from '../../generated/graphql'
+import { withApollo } from '../../../lib/apollo'
+import Post from '../../../components/Dashboard/Post'
+import LoadingWrapper from '../../../components/LoadingWrapper'
+import DashboardLayout from '../../../components/Layouts/DashboardLayout'
+import { useCurrentUserQuery, usePostByIdQuery } from '../../../generated/graphql'
 
 const PostPage: NextPage = () => {
   const idStr = useRouter().query.id as string

--- a/frontend/public/static/locales/en/post.json
+++ b/frontend/public/static/locales/en/post.json
@@ -3,5 +3,10 @@
   "publishDraft": "Publish Draft",
   "readTime": "{{minutes}} min. read",
   "readAction": "Read post",
+  "editPost": "Edit Post",
+  "editPostAction": "Edit Post",
+  "titleLabel": "Title",
+  "languageLabel": "Language",
+  "save": "Save",
   "finishAction": "Finish post"
 }


### PR DESCRIPTION
## Description

closes #174 

Post authors can now edit their drafts. Chose not to give this functionality on published posts as we don't have a solid plan for managing comments/threads across edits

Also made titles on edit pages auto-save in the same way as post bodies, and moved "publish draft" button to the right place.