### PR TITLE
Fix profile visual bugs

### DIFF
--- a/frontend/components/Dashboard/Profile/PostList.tsx
+++ b/frontend/components/Dashboard/Profile/PostList.tsx
@@ -44,6 +44,8 @@ const PostList: React.FC<Props> = ({ currentUserId }) => {
           justify-content: center;
           align-items: center;
           padding: 0 ${layoutLeftRightPadding} ${layoutTopBottomPadding};
+          background-color: ${theme.colors.white};
+          box-shadow: 0px 8px 10px #00000029;
         }
         @media (min-width: ${theme.breakpoints.MD}) {
           .post-list {

--- a/frontend/components/Dashboard/Profile/Profile.tsx
+++ b/frontend/components/Dashboard/Profile/Profile.tsx
@@ -19,7 +19,7 @@ const Profile: React.FC<Props> = ({ currentUser }) => {
         .profile-wrapper {
           display: flex;
           flex-direction: column;
-          height: 100%;
+          height: 100vh;
         }
         @media (min-width: ${theme.breakpoints.MD}) {
           .profile-wrapper {

--- a/frontend/components/Dashboard/Profile/ProfileCard.tsx
+++ b/frontend/components/Dashboard/Profile/ProfileCard.tsx
@@ -100,6 +100,7 @@ const ProfileCard: React.FC<Props> = ({ currentUser }) => {
           align-items: center;
           padding: 30px 25px;
           color: ${theme.colors.white};
+          box-shadow: 0px 8px 10px #00000029;
         }
         @media (min-width: ${theme.breakpoints.MD}) {
           .profile-card {


### PR DESCRIPTION
## Description

**Issue:** closes #178 

Fixes visual bugs on the profile page:
- Profile should have white background on the right side behind posts
- There should be a box shadow on this profile section
- The height of the profile is not right and gets messed up when the browser is slightly tall. Happens even on laptop but gets really bad on a larger screen

NOTE: Upon testing, there is a minor visual issue even after this PR where the social media icons get messed up if someone makes the window very short but still not mobile breakpoint, but this should be a rare use case and there's no time to handle that for now.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Fix background color issue
- [x] fix height issue
- [x] add box shadow
- [x] test

## Screenshots
**Before:**
![image](https://user-images.githubusercontent.com/34203886/88340656-13d2fb00-ccf1-11ea-9fb6-38d7505aa98a.png)

**After:**
![image](https://user-images.githubusercontent.com/34203886/88340864-69a7a300-ccf1-11ea-8f25-4a314bb34d02.png)
