### PR TITLE
Add Welcome Modal to the My Feed page

### DIFF
--- a/frontend/components/Modal/Modal.tsx
+++ b/frontend/components/Modal/Modal.tsx
@@ -7,16 +7,30 @@ import modalConstants from './modalConstants'
 import useFocusTrap from '../../hooks/useFocusTrap'
 import { white } from '../../utils'
 
-interface Props {
+type Props = {
   onClose: () => void
   title: React.ReactNode
   body: React.ReactNode
+  onFormSubmit?: (event: React.FormEvent<HTMLFormElement>) => void
   footer?: React.ReactNode
   ariaLabelledBy?: string
   ariaDescribedBy?: string
   triggerElementId?: string
   maxWidth?: string
   maxHeight?: string
+}
+
+type ModalContentProps = {
+  children: React.ReactNode
+  className: string
+  role: string
+  type: 'form' | 'div'
+  onClick: (event: React.MouseEvent) => void
+  onSubmit?: Props['onFormSubmit']
+}
+
+const ModalContent: React.FC<ModalContentProps> = ({ type, children, ...otherProps }) => {
+  return React.createElement(type, otherProps, children)
 }
 
 const Modal: React.FC<Props> = (props) => {
@@ -27,6 +41,7 @@ const Modal: React.FC<Props> = (props) => {
     title,
     body,
     footer,
+    onFormSubmit,
     ariaLabelledBy,
     ariaDescribedBy,
     triggerElementId = '',
@@ -42,31 +57,30 @@ const Modal: React.FC<Props> = (props) => {
   })
 
   const handleModalBodyScroll = (event: Event): void => {
-    if ((event.target as Element)?.scrollTop > 28) {
-      setShouldFadeInTitle(true)
-      return
-    }
-    setShouldFadeInTitle(false)
+    const shouldFade = (event.target as Element)?.scrollTop > 28
+    setShouldFadeInTitle(shouldFade)
   }
 
   return ReactDOM.createPortal(
     <div className="modal-container" onClick={onClose}>
       <div className="modal-wrapper">
-        <div
+        <ModalContent
+          type={onFormSubmit ? 'form' : 'div'}
           className="modal-content"
           role="dialog"
           aria-modal="true"
           aria-labelledby={ariaLabelledBy}
           aria-describedby={ariaDescribedBy}
           data-test="modal"
-          onClick={(event) => event.stopPropagation()}
+          onClick={(event: React.MouseEvent) => event.stopPropagation()}
+          onSubmit={onFormSubmit}
         >
           <ModalHeader title={title} onClose={onClose} showTitle={shouldFadeInTitle} />
           <ModalBody ariaLabelledBy={ariaLabelledBy} title={title} onScroll={handleModalBodyScroll}>
             {body}
           </ModalBody>
           {footer && <ModalFooter>{footer}</ModalFooter>}
-        </div>
+        </ModalContent>
       </div>
       <style jsx>{`
         @keyframes enterFromBottom {
@@ -113,7 +127,7 @@ const Modal: React.FC<Props> = (props) => {
             padding: 64px 0;
           }
         }
-        .modal-content {
+        :global(.modal-content) {
           flex-grow: 1;
           display: flex;
           flex-direction: column;
@@ -122,12 +136,12 @@ const Modal: React.FC<Props> = (props) => {
           background-color: ${white};
         }
         @media (min-width: ${modalConstants.modalBreakpoint}) {
-          .modal-content {
+          :global(.modal-content) {
             flex-grow: 0;
             max-height: ${maxHeight};
             border-radius: 8px;
           }
-          .modal-content .modal-body {
+          :global(.modal-content) .modal-body {
             ${Boolean(footer) && `padding-bottom: 48px;`};
           }
         }

--- a/frontend/components/Modal/ModalBody.tsx
+++ b/frontend/components/Modal/ModalBody.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react'
 import modalConstants from './modalConstants'
+import theme from '../../theme'
 
 interface Props {
   title: React.ReactNode
@@ -43,9 +44,7 @@ const ModalBody: React.FC<Props> = (props) => {
 
         h1 {
           margin-bottom: 16px;
-          font-size: 24px;
-          line-height: 32px;
-          font-weight: 500;
+          ${theme.typography.headingXL};
         }
       `}</style>
     </div>

--- a/frontend/components/Modal/ModalHeader.tsx
+++ b/frontend/components/Modal/ModalHeader.tsx
@@ -32,17 +32,17 @@ const ModalHeader: React.FC<Props> = ({ onClose, title, showTitle }) => {
           }
         }
 
-        :global(.modal-close-button) {
+        .modal-header :global(.modal-close-button) {
           position: absolute;
           top: 8px;
           right: 16px;
           border-radius: 8px;
         }
-        :global(.modal-close-button):hover {
+        .modal-header :global(.modal-close-button):hover {
           background-color: ${lightGrey};
         }
         @media (min-width: ${modalConstants.modalBreakpoint}) {
-          :global(.modal-close-button) {
+          .modal-header :global(.modal-close-button) {
             top: 16px;
           }
         }

--- a/frontend/components/Modals/WelcomeModal.tsx
+++ b/frontend/components/Modals/WelcomeModal.tsx
@@ -1,0 +1,27 @@
+import React, { useState, useEffect } from 'react'
+import Modal from '../../components/Modal'
+
+type Props = {
+  show: boolean
+  onClose: () => void
+}
+
+const WelcomeModal: React.FC<Props> = ({ show, onClose }) => {
+  const [delayedShow, setDelayedShow] = useState(false)
+
+  useEffect(() => {
+    if (show) {
+      setTimeout(() => {
+        setDelayedShow(true)
+      }, 3000)
+    } else {
+      setDelayedShow(false)
+    }
+  }, [show])
+
+  return delayedShow ? (
+    <Modal title="Welcome to Journaly!" body={<div>Welcome, yo!</div>} onClose={onClose} />
+  ) : null
+}
+
+export default WelcomeModal

--- a/frontend/components/Modals/WelcomeModal/WelcomeModal.tsx
+++ b/frontend/components/Modals/WelcomeModal/WelcomeModal.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react'
-import Modal from '../../components/Modal'
+import Modal from '../../../components/Modal'
+import WelcomeModalBody from './WelcomeModalBody'
+import Button from '../../../elements/Button'
 
 type Props = {
   show: boolean
@@ -13,14 +15,19 @@ const WelcomeModal: React.FC<Props> = ({ show, onClose }) => {
     if (show) {
       setTimeout(() => {
         setDelayedShow(true)
-      }, 3000)
+      }, 5000)
     } else {
       setDelayedShow(false)
     }
   }, [show])
 
   return delayedShow ? (
-    <Modal title="Welcome to Journaly!" body={<div>Welcome, yo!</div>} onClose={onClose} />
+    <Modal
+      title="Welcome to Journaly!"
+      body={<WelcomeModalBody />}
+      footer={<Button onClick={onClose}>Done</Button>}
+      onClose={onClose}
+    />
   ) : null
 }
 

--- a/frontend/components/Modals/WelcomeModal/WelcomeModalBody.tsx
+++ b/frontend/components/Modals/WelcomeModal/WelcomeModalBody.tsx
@@ -1,0 +1,92 @@
+import React from 'react'
+import { useTranslation } from '../../../config/i18n'
+import {
+  useLanguagesFormDataQuery,
+  useAddLanguageLearningMutation,
+  useAddLanguageNativeMutation,
+  useRemoveLanguageLearningMutation,
+  useRemoveLanguageNativeMutation,
+} from '../../../generated/graphql'
+import LanguageMultiSelect from '../../../components/LanguageMultiSelect'
+
+type LanguageMutationType = (arg: { variables: { languageId: number } }) => Promise<any>
+
+const WelcomeModalBody: React.FC = () => {
+  const { t } = useTranslation('settings')
+  const { data, refetch } = useLanguagesFormDataQuery()
+  const [addLearningLanguage] = useAddLanguageLearningMutation()
+  const [addNativeLanguage] = useAddLanguageNativeMutation()
+  const [removeLearningLanguage] = useRemoveLanguageLearningMutation()
+  const [removeNativeLanguage] = useRemoveLanguageNativeMutation()
+
+  const mutateLanguageM2M = (mutation: LanguageMutationType) => async (languageId: number) => {
+    await mutation({ variables: { languageId } })
+    refetch()
+  }
+
+  const learningLanguages = (data?.currentUser?.languagesLearning || []).map((x) => x.language.id)
+  const nativeLanguages = (data?.currentUser?.languagesNative || []).map((x) => x.language.id)
+
+  const onLearningAdd = mutateLanguageM2M(addLearningLanguage)
+  const onNativeAdd = mutateLanguageM2M(addNativeLanguage)
+  const onLearningRemove = mutateLanguageM2M(removeLearningLanguage)
+  const onNativeRemove = mutateLanguageM2M(removeNativeLanguage)
+
+  return (
+    <div>
+      <p className="welcome-description">
+        Let's get started by adding the languages you speak and are learning. This helps us find
+        relevant content for you as well as let other users know a bit more about you. If you ever
+        need to update your languages or profile information, you can do so on the settings page.
+      </p>
+
+      <div className="languages-form-field">
+        <label className="language-label" htmlFor="native-languages">
+          {t('profile.languages.nativeLanguagesLabel')}
+        </label>
+        <LanguageMultiSelect
+          languages={data?.languages || []}
+          value={nativeLanguages}
+          onAdd={onNativeAdd}
+          onRemove={onNativeRemove}
+        />
+      </div>
+      <div className="languages-form-field">
+        <label className="language-label" htmlFor="learning-languages">
+          {t('profile.languages.learningLanguagesLabel')}
+        </label>
+        <LanguageMultiSelect
+          languages={data?.languages || []}
+          value={learningLanguages}
+          onAdd={onLearningAdd}
+          onRemove={onLearningRemove}
+        />
+      </div>
+
+      <style jsx>{`
+        .welcome-description {
+          margin-bottom: 30px;
+        }
+
+        .languages-form-field {
+          display: flex;
+          flex-direction: column;
+        }
+
+        .languages-form-field {
+          margin-bottom: 24px;
+        }
+
+        .languages-form-field:last-child {
+          margin-bottom: 0;
+        }
+
+        .language-label {
+          margin-bottom: 4px;
+        }
+      `}</style>
+    </div>
+  )
+}
+
+export default WelcomeModalBody

--- a/frontend/components/Modals/WelcomeModal/WelcomeModalBody.tsx
+++ b/frontend/components/Modals/WelcomeModal/WelcomeModalBody.tsx
@@ -36,8 +36,8 @@ const WelcomeModalBody: React.FC = () => {
     <div>
       <p className="welcome-description">
         Let's get started by adding the languages you speak and are learning. This helps us find
-        relevant content for you as well as let other users know a bit more about you. If you ever
-        need to update your languages or profile information, you can do so on the settings page.
+        relevant content for you as well as let other users know a bit more about you. If you want
+        to add your languages later, you can always update them on the settings page.
       </p>
 
       <div className="languages-form-field">

--- a/frontend/components/Modals/WelcomeModal/index.ts
+++ b/frontend/components/Modals/WelcomeModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './WelcomeModal'

--- a/frontend/pages/dashboard/my-feed.tsx
+++ b/frontend/pages/dashboard/my-feed.tsx
@@ -1,3 +1,4 @@
+import React, { useState } from 'react'
 import { NextPage } from 'next'
 import { withApollo } from '../../lib/apollo'
 import DashboardLayout from '../../components/Layouts/DashboardLayout'
@@ -5,17 +6,28 @@ import MyFeed from '../../components/Dashboard/MyFeed'
 import { useFeedQuery, Post } from '../../generated/graphql'
 import LoadingWrapper from '../../components/LoadingWrapper'
 import AuthGate from '../../components/AuthGate'
+import WelcomeModal from '../../components/Modals/WelcomeModal'
 
 interface InitialProps {
   namespacesRequired: string[]
 }
 
+const welcomeModalKey = 'welcome-modal-july-2020'
+
 const MyFeedPage: NextPage<InitialProps> = () => {
+  const hasSeenModalBefore =
+    typeof window !== 'undefined' ? localStorage.getItem(welcomeModalKey) : false
+  const [shouldShowWelcomeModal, setShouldShowWelcomeModal] = useState(!hasSeenModalBefore)
   const { loading, error, data } = useFeedQuery({
     variables: {
       published: true,
     },
   })
+
+  const handleWelcomeModalClose = () => {
+    setShouldShowWelcomeModal(false)
+    localStorage.setItem(welcomeModalKey, 'seen')
+  }
 
   const posts = data?.feed
 
@@ -26,6 +38,8 @@ const MyFeedPage: NextPage<InitialProps> = () => {
           <LoadingWrapper loading={loading} error={error}>
             <MyFeed posts={posts as Post[]} currentUser={currentUser} />
           </LoadingWrapper>
+
+          <WelcomeModal show={shouldShowWelcomeModal} onClose={handleWelcomeModalClose} />
         </DashboardLayout>
       )}
     </AuthGate>

--- a/frontend/pages/dashboard/my-feed.tsx
+++ b/frontend/pages/dashboard/my-feed.tsx
@@ -47,7 +47,7 @@ const MyFeedPage: NextPage<InitialProps> = () => {
 }
 
 MyFeedPage.getInitialProps = async () => ({
-  namespacesRequired: ['common'],
+  namespacesRequired: ['common', 'settings'],
 })
 
 export default withApollo(MyFeedPage)


### PR DESCRIPTION
## Description

**Issue:** Closes #173 

This PR adds a welcome modal that appears when a user first lands on the My Feed page. It appears after 5 seconds of landing on the page for now, but we can update this value. The user is presented with text indicating how adding languages is useful and that they can add languages later or update them on the settings page. Right now, the welcome modal is using the languages form as is it is on the settings page.

In a follow-up PR, I'll be working on:

- moving the language fields / form into a reusable component so that we don't have to duplicate them
- updating the styles
- updating the profile page to use language information from the `currentUser`

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Create Welcome Modal
- [x] Use language form logic from the settings page
- [x] Use `localStorage` with the `welcome-modal-july-2020` key for now to dynamically show the modal

## Screenshots

### Desktop

<img src="https://user-images.githubusercontent.com/5829188/88484941-3baba400-cf27-11ea-8948-85036372a6d0.png" width="550px" />

### Mobile

<img src="https://user-images.githubusercontent.com/5829188/88484942-3f3f2b00-cf27-11ea-92c0-e1be14e4eb46.png" width="400px" />

### Local Storage key

<img src="https://user-images.githubusercontent.com/5829188/88484944-42d2b200-cf27-11ea-9d0d-5aded94ec96a.png" width="350px" />
