### PR TITLE
POC: Set up Application State with React Context

### DIFF
--- a/frontend/hooks/useApplicationState.ts
+++ b/frontend/hooks/useApplicationState.ts
@@ -1,0 +1,4 @@
+import { useContext } from 'react'
+import { ApplicationContext } from '../state/ApplicationStateProvider'
+
+export const useApplicationState = () => useContext(ApplicationContext)

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -6,6 +6,7 @@ import { initializeTracking, trackPageView } from '../lib/google-analytics'
 import '../styles/reset.css'
 import '../styles/globalStyles.css'
 import { appWithTranslation } from '../config/i18n'
+import { ApplicationStateProvider } from '../state/ApplicationStateProvider'
 
 initializeTracking()
 
@@ -34,7 +35,9 @@ class JournalyApp extends App {
           <title>Journaly</title>
           <link rel="stylesheet" type="text/css" href="/nprogress.css" />
         </Head>
-        <Component {...pageProps} />
+        <ApplicationStateProvider>
+          <Component {...pageProps} />
+        </ApplicationStateProvider>
       </>
     )
   }

--- a/frontend/pages/dashboard/my-feed.tsx
+++ b/frontend/pages/dashboard/my-feed.tsx
@@ -5,12 +5,15 @@ import MyFeed from '../../components/Dashboard/MyFeed'
 import { useFeedQuery, Post } from '../../generated/graphql'
 import LoadingWrapper from '../../components/LoadingWrapper'
 import AuthGate from '../../components/AuthGate'
+import { useApplicationState } from '../../hooks/useApplicationState'
 
 interface InitialProps {
   namespacesRequired: string[]
 }
 
 const MyFeedPage: NextPage<InitialProps> = () => {
+  const { currentUser } = useApplicationState()
+
   const { loading, error, data } = useFeedQuery({
     variables: {
       published: true,

--- a/frontend/state/ApplicationStateProvider/ApplicationStateProvider.tsx
+++ b/frontend/state/ApplicationStateProvider/ApplicationStateProvider.tsx
@@ -1,0 +1,26 @@
+import { createContext } from 'react'
+import { useCurrentUserQuery, User as UserType } from '../../generated/graphql'
+
+type Props = {
+  children: React.ReactNode
+}
+
+export const ApplicationContext = createContext({
+  currentUser: null as UserType | null,
+})
+
+export const ApplicationStateProvider: React.FC<Props> = ({ children }) => {
+  const { data } = useCurrentUserQuery()
+
+  const currentUser = data?.currentUser as UserType
+
+  return (
+    <ApplicationContext.Provider
+      value={{
+        currentUser,
+      }}
+    >
+      {children}
+    </ApplicationContext.Provider>
+  )
+}

--- a/frontend/state/ApplicationStateProvider/index.ts
+++ b/frontend/state/ApplicationStateProvider/index.ts
@@ -1,0 +1,1 @@
+export * from './ApplicationStateProvider'


### PR DESCRIPTION
## Description

**Issue:** closes #187 

Currently, we do not have a way to manage application-level state and I believe that the `currentUser` is an excellent use case for having an application state context/provider.

This POC creates a React Context for managing application level state which is flexible/composable and enables us to simply wrap the custom `App` in an `ApplicationContext` and then anywhere in the app that needs `currentUser`, in this case, can simply call `useApplicationState()` and destructure the `currentUser` value.

I feel that this is a very clean and simple implementation that drastically simplifies things and enables us to simply load the currently logged in user (or `null`) once at the top level and then access that value from anywhere without having to pass it around through many layers of props which feels brittle and error-prone.

This POC uses the `feed` query an its example since that is what I'm working on in a separate PR and require having this `currentUser` value in a way that is currently not well supported and made quite tricky by the way that `<AuthGate>` currently works.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Set up the `Context`
- [x] Figure out a nice `Context.Provider` implementation
- [x] Figure out an incredibly simple and easy-to-use custom hook implementation
- [ ] Test and fix any remaining TypeScript / Apollo errors
