### PR TITLE
Implement a way to get to the dashboard from landing page when logged in

### DIFF
--- a/frontend/components/Site/Nav/Nav.tsx
+++ b/frontend/components/Site/Nav/Nav.tsx
@@ -1,63 +1,77 @@
 import { width, darkGrey } from '../../../utils'
 import NavLink from '../../NavLink'
 import Logo from '../../Logo'
+import { useCurrentUserQuery, User as UserType } from '../../../generated/graphql'
 
-const navItems = [
-  { name: 'About', path: '/about' },
-  { name: 'Blog', path: '/blog/introducing-journaly' },
-  { name: 'Log in', path: '/dashboard/login' },
-  { name: 'Sign up', path: '/dashboard/signup' },
-]
+const Nav = () => {
+  const { data } = useCurrentUserQuery()
+  const currentUser = data?.currentUser as UserType
 
-const Nav = () => (
-  <div>
-    <div className="header-container">
-      <Logo />
+  return (
+    <div>
+      <div className="header-container">
+        <Logo />
 
-      <ul className="nav-items">
-        {navItems.map((navItem) => (
-          <NavLink href={navItem.path} key={navItem.name}>
-            <a className="nav-link">{navItem.name}</a>
+        <ul className="nav-items">
+          <NavLink href="/about" key="About">
+            <a className="nav-link">About</a>
           </NavLink>
-        ))}
-      </ul>
+          <NavLink href="/blog/introducing-journaly" key="Blog">
+            <a className="nav-link">Blog</a>
+          </NavLink>
+          {currentUser ? (
+            <NavLink href="/dashboard/my-feed" key="Dashboard">
+              <a className="nav-link">Dashboard</a>
+            </NavLink>
+          ) : (
+            <>
+              <NavLink href="/dashboard/login" key="Log in">
+                <a className="nav-link">Log in</a>
+              </NavLink>
+              <NavLink href="/dashboard/signup" key="Sign up">
+                <a className="nav-link">Sign up</a>
+              </NavLink>
+            </>
+          )}
+        </ul>
+      </div>
+      <style jsx>{`
+        background-color: black;
+
+        .header-container {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          height: 72px;
+          max-width: ${width.desktopHD}px;
+          margin: 0 auto;
+          padding: 0 20px;
+        }
+
+        .nav-items {
+          display: flex;
+          align-items: center;
+          height: 100%;
+        }
+
+        .nav-link {
+          display: flex;
+          align-items: center;
+          height: 100%;
+          padding: 0 10px;
+          color: #ffffff;
+        }
+
+        .nav-link.active {
+          background-color: ${darkGrey};
+        }
+
+        .nav-link:last-child {
+          margin-right: 0;
+        }
+      `}</style>
     </div>
-    <style jsx>{`
-      background-color: black;
-
-      .header-container {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        height: 72px;
-        max-width: ${width.desktopHD}px;
-        margin: 0 auto;
-        padding: 0 20px;
-      }
-
-      .nav-items {
-        display: flex;
-        align-items: center;
-        height: 100%;
-      }
-
-      .nav-link {
-        display: flex;
-        align-items: center;
-        height: 100%;
-        padding: 0 10px;
-        color: #ffffff;
-      }
-
-      .nav-link.active {
-        background-color: ${darkGrey};
-      }
-
-      .nav-link:last-child {
-        margin-right: 0;
-      }
-    `}</style>
-  </div>
-)
+  )
+}
 
 export default Nav

--- a/frontend/components/Site/Nav/Nav.tsx
+++ b/frontend/components/Site/Nav/Nav.tsx
@@ -13,22 +13,22 @@ const Nav = () => {
         <Logo />
 
         <ul className="nav-items">
-          <NavLink href="/about" key="About">
+          <NavLink href="/about">
             <a className="nav-link">About</a>
           </NavLink>
-          <NavLink href="/blog/introducing-journaly" key="Blog">
+          <NavLink href="/blog/introducing-journaly">
             <a className="nav-link">Blog</a>
           </NavLink>
           {currentUser ? (
-            <NavLink href="/dashboard/my-feed" key="Dashboard">
+            <NavLink href="/dashboard/my-feed">
               <a className="nav-link">Dashboard</a>
             </NavLink>
           ) : (
             <>
-              <NavLink href="/dashboard/login" key="Log in">
+              <NavLink href="/dashboard/login">
                 <a className="nav-link">Log in</a>
               </NavLink>
-              <NavLink href="/dashboard/signup" key="Sign up">
+              <NavLink href="/dashboard/signup">
                 <a className="nav-link">Sign up</a>
               </NavLink>
             </>


### PR DESCRIPTION
## Description

Users are very likely to come to Journaly via `journaly.com` but currently it's very confusing as there's no clear path to get to the dashboard unless you know the exact url path to the dashboard. This PR allows for conditionally rendering a dashboard link in the site nav.

![image](https://user-images.githubusercontent.com/34203886/88987325-692b8100-d28a-11ea-8306-017d203d7a98.png)


## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Implement
