### PR TITLE
Improve Post Sub Title Styles

### DIFF
--- a/frontend/components/PostBodyStyles/PostBodyStyles.tsx
+++ b/frontend/components/PostBodyStyles/PostBodyStyles.tsx
@@ -29,6 +29,7 @@ const PostBodyStyles: React.FC<Props> = ({ parentClassName }: Props) => {
       .${parentClassName} h2 {
         ${theme.typography.headingLG};
         margin: 10px 0;
+        font-weight: 600;
       }
     `}</style>
   )


### PR DESCRIPTION
## Description

Something definitely looked off about the styling of the posts and being hard to differentiate the sub titles from the body text. I think this greatly improves it!

### Before

![image](https://user-images.githubusercontent.com/34203886/88993966-2e324900-d29c-11ea-8909-e6fd558de2b1.png)


### After

![image](https://user-images.githubusercontent.com/34203886/88993950-24104a80-d29c-11ea-9adc-24896ab07117.png)

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Improve font-weight on post h2s
