### PR TITLE
🔥 FIRE: Drafts are showing in `My Feed` page and causing server errors and user concern/confusion

### DIFF
--- a/frontend/nexus/post.ts
+++ b/frontend/nexus/post.ts
@@ -156,6 +156,9 @@ schema.extendType({
         const postQuery = ctx.db.post.findMany({
           where: {
             AND: filterClauses,
+            status: {
+              not: 'DRAFT',
+            },
           },
           skip: args.skip,
           first: args.first,


### PR DESCRIPTION
## Description

Adds extra condition to `feed` query so that drafts do not show on My Feed page

...

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Test locally

