### PR TITLE
Add Language Badge to PostCards in My Feed 

### DIFF
--- a/frontend/components/Dashboard/PostCard/PostCard.tsx
+++ b/frontend/components/Dashboard/PostCard/PostCard.tsx
@@ -38,6 +38,7 @@ const PostCard: React.FC<Props> = ({
     threads,
     author: { handle, name, profileImage },
     createdAt,
+    language: { name: languageName },
   } = post
   const isDraft = status === PostStatusType.Draft
   const isPublished = status === PostStatusType.Published
@@ -59,14 +60,17 @@ const PostCard: React.FC<Props> = ({
 
             <div className="post-avatar-and-data">
               {avatar && (
-                <div className="post-avatar">
-                  {profileImage ? (
-                    <img className="profile-image" src={profileImage} alt="" />
-                  ) : (
-                    <BlankAvatarIcon size={27} />
-                  )}
+                <div>
+                  <div className="post-avatar">
+                    {profileImage ? (
+                      <img className="profile-image" src={profileImage} alt="" />
+                    ) : (
+                      <BlankAvatarIcon size={27} />
+                    )}
 
-                  <p className="author">{handle || name}</p>
+                    <p className="author">{handle || name}</p>
+                  </div>
+                  <p className="post-language">{languageName}</p>
                 </div>
               )}
 
@@ -192,6 +196,19 @@ const PostCard: React.FC<Props> = ({
 
         .author {
           font-size: 14px;
+        }
+
+        .post-language {
+          line-height: 1;
+          padding: 2px 5px;
+          color: ${theme.colors.charcoal};
+
+          text-transform: uppercase;
+          border: 2px solid ${theme.colors.charcoal};
+          border-radius: 4px;
+          font-weight: 600;
+          font-size: 12px;
+          display: inline-block;
         }
 
         .post-stats {

--- a/frontend/generated/graphql.tsx
+++ b/frontend/generated/graphql.tsx
@@ -502,6 +502,7 @@ export type PostCardFragmentFragment = { __typename?: 'Post' } & Pick<
     likes: Array<{ __typename?: 'PostLike' } & Pick<PostLike, 'id'>>
     threads: Array<{ __typename?: 'Thread' } & Pick<Thread, 'id'>>
     author: { __typename?: 'User' } & AuthorFragmentFragment
+    language: { __typename?: 'Language' } & LanguageFragmentFragment
   }
 
 export type LanguageFragmentFragment = { __typename?: 'Language' } & Pick<
@@ -675,6 +676,13 @@ export const PostFragmentFragmentDoc = gql`
   ${AuthorFragmentFragmentDoc}
   ${ThreadFragmentFragmentDoc}
 `
+export const LanguageFragmentFragmentDoc = gql`
+  fragment LanguageFragment on Language {
+    id
+    name
+    dialect
+  }
+`
 export const PostCardFragmentFragmentDoc = gql`
   fragment PostCardFragment on Post {
     id
@@ -695,15 +703,12 @@ export const PostCardFragmentFragmentDoc = gql`
     author {
       ...AuthorFragment
     }
+    language {
+      ...LanguageFragment
+    }
   }
   ${AuthorFragmentFragmentDoc}
-`
-export const LanguageFragmentFragmentDoc = gql`
-  fragment LanguageFragment on Language {
-    id
-    name
-    dialect
-  }
+  ${LanguageFragmentFragmentDoc}
 `
 export const AddLanguageLearningDocument = gql`
   mutation addLanguageLearning($languageId: Int!) {

--- a/frontend/graphql/fragments.graphql
+++ b/frontend/graphql/fragments.graphql
@@ -67,6 +67,9 @@ fragment PostCardFragment on Post {
   author {
     ...AuthorFragment
   }
+  language {
+    ...LanguageFragment
+  }
 }
 
 fragment LanguageFragment on Language {


### PR DESCRIPTION
## Description

**Issue:** closes #211 

- A number of users have noted that it would be super helpful to have more information on the `PostCard`s in the feed:
  - post language
- This PR adds a language badge underneath the author information on a `PostCard` only when it is in the feed

**NOTE:** There is also a great use case for displaying the language badge in the other scenarios (`!stacked` and on the profile, for example) but it requires restructuring the component quite a bit and after spending over 30 mins just messing with that, I decided this is WAY higher impact so best to merge this in as is and @nlitwin you could work on the other use cases since you're most familiar with that component. We can discuss the visual design.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Update GQL `PostCardFragment`
- [x] Add for `stacked` cards

## Screenshots

### Regular

![image](https://user-images.githubusercontent.com/34203886/89112846-07038500-d41e-11ea-9be1-cb38fd22273c.png)

### Long language name

![image](https://user-images.githubusercontent.com/34203886/89112849-0c60cf80-d41e-11ea-82ed-d6453c3a1651.png)

