### PR TITLE
Allow profile sections to take up more height

### DIFF
--- a/frontend/components/Dashboard/Profile/PostList.tsx
+++ b/frontend/components/Dashboard/Profile/PostList.tsx
@@ -41,7 +41,6 @@ const PostList: React.FC<Props> = ({ currentUserId }) => {
         .post-list {
           display: flex;
           flex-direction: column;
-          justify-content: center;
           align-items: center;
           padding: 0 ${layoutLeftRightPadding} ${layoutTopBottomPadding};
           background-color: ${theme.colors.white};
@@ -57,11 +56,6 @@ const PostList: React.FC<Props> = ({ currentUserId }) => {
         .posts-title {
           margin: 40px 0;
           ${theme.typography.headingLG};
-        }
-        @media (min-width: ${theme.breakpoints.MD}) {
-          .posts-title {
-            display: none;
-          }
         }
 
         .post-list :global(.post-card-container) {

--- a/frontend/components/Dashboard/Profile/PostList.tsx
+++ b/frontend/components/Dashboard/Profile/PostList.tsx
@@ -57,6 +57,11 @@ const PostList: React.FC<Props> = ({ currentUserId }) => {
           margin: 40px 0;
           ${theme.typography.headingLG};
         }
+        @media (min-width: ${theme.breakpoints.MD}) {
+          .posts-title {
+            margin: 5px 0 40px;
+          }
+        }
 
         .post-list :global(.post-card-container) {
           margin-bottom: 50px;

--- a/frontend/components/Dashboard/Profile/PostList.tsx
+++ b/frontend/components/Dashboard/Profile/PostList.tsx
@@ -50,6 +50,7 @@ const PostList: React.FC<Props> = ({ currentUserId }) => {
           .post-list {
             padding: 25px;
             border-top: 0;
+            overflow: auto;
           }
         }
 

--- a/frontend/components/Dashboard/Profile/Profile.tsx
+++ b/frontend/components/Dashboard/Profile/Profile.tsx
@@ -29,7 +29,7 @@ const Profile: React.FC<Props> = ({ currentUser }) => {
 
           .profile-wrapper > :global(div) {
             flex-basis: 50%;
-            min-height: 850px;
+            max-height: 850px;
           }
         }
       `}</style>

--- a/frontend/components/Dashboard/Profile/Profile.tsx
+++ b/frontend/components/Dashboard/Profile/Profile.tsx
@@ -19,7 +19,7 @@ const Profile: React.FC<Props> = ({ currentUser }) => {
         .profile-wrapper {
           display: flex;
           flex-direction: column;
-          height: 100vh;
+          height: 100%;
         }
         @media (min-width: ${theme.breakpoints.MD}) {
           .profile-wrapper {
@@ -29,6 +29,7 @@ const Profile: React.FC<Props> = ({ currentUser }) => {
 
           .profile-wrapper > :global(div) {
             flex-basis: 50%;
+            min-height: 850px;
           }
         }
       `}</style>


### PR DESCRIPTION
## Description

**Issue:** Closes: #223 

Fixes this described in the issue above: 

<img src="https://user-images.githubusercontent.com/5829188/89127787-517c1480-d4a5-11ea-9f2b-c9976d69dbe9.png" width="500" />

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Make profile details and recent posts take up the height they need to not have their content spill over
- [x] Show `Recent Posts` title on desktop too

## Screenshots

![2020-08-02 10 38 24](https://user-images.githubusercontent.com/5829188/89128701-68723500-d4ac-11ea-9c37-80e1b5fef283.gif)
