### PR TITLE
Fix fieldset ::before animation, which fixes LastPass animation

### DIFF
--- a/frontend/components/LoginForm/LoginForm.tsx
+++ b/frontend/components/LoginForm/LoginForm.tsx
@@ -154,7 +154,7 @@ const LoginForm: React.FC = () => {
             background-position: 100% 100%;
           }
         }
-        &[aria-busy='true']::before {
+        fieldset[aria-busy='true']::before {
           background-size: 50% auto;
           animation: loading 0.5s linear infinite;
         }
@@ -178,7 +178,7 @@ const LoginForm: React.FC = () => {
           color: ${theme.colors.red};
           font-style: italic;
         }
-        
+
         :global(.form-error) {
           margin-bottom: 24px;
         }

--- a/frontend/components/SignupForm/SignupForm.tsx
+++ b/frontend/components/SignupForm/SignupForm.tsx
@@ -165,7 +165,7 @@ const SignupForm: React.FC = () => {
             background-position: 100% 100%;
           }
         }
-        &[aria-busy='true']::before {
+        fieldset[aria-busy='true']::before {
           background-size: 50% auto;
           animation: loading 0.5s linear infinite;
         }


### PR DESCRIPTION
## Description

**Issue:** Closes: #207 

The animation for our login and signup form fieldset had an old `&` for SCSS syntax that was probably brought over from the previous repo. Replacing `&` with `fieldset` fixes the animation of the linear gradient in the forms and fixes the scoping of the animation, so that the animation doesn't apply to the LastPass Chrome extension icon.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Fix!

## Screenshots

![form_gradient_animation_lastpass](https://user-images.githubusercontent.com/5829188/89128981-4bd6fc80-d4ae-11ea-9331-d0212fef7da2.gif)

