### PR TITLE
Fix for first selection emptying without reason, and closing of thread popovers

### DIFF
--- a/frontend/components/Dashboard/Post/Post.tsx
+++ b/frontend/components/Dashboard/Post/Post.tsx
@@ -240,7 +240,7 @@ const Post: React.FC<IPostProps> = ({ post, currentUser, refetch }: IPostProps) 
 
       // Get the index of where the comment starts & ends within the preOrderList
       const startElIndex = offsets.filter((offset) => offset <= startIndex).length - 1
-      const endElIndex = offsets.filter((offset) => offset <= endIndex).length - 1
+      const endElIndex = offsets.filter((offset) => offset < endIndex).length - 1
 
       // Construct the range the comment will occupy
       const range = document.createRange()

--- a/frontend/components/InlineFeedbackPopover/index.tsx
+++ b/frontend/components/InlineFeedbackPopover/index.tsx
@@ -18,7 +18,8 @@ type DOMOffsetTarget = {
 }
 
 type PopoverProps = {
-  target: DOMOffsetTarget
+  target: DOMOffsetTarget,
+  children: JSX.Element[] | JSX.Element
 }
 
 type ThreadProps = {
@@ -36,7 +37,7 @@ type InlineFeedbackPopoverProps = {
 
 const VP_PADDING = 20
 
-const Popover: React.FC<PopoverProps> = ({ target, children }) => {
+const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(({ target, children }, ref) => {
   const popoverRoot = document.getElementById('popover-root') as HTMLElement
 
   const ownPosition: CSS.Properties = {}
@@ -71,7 +72,7 @@ const Popover: React.FC<PopoverProps> = ({ target, children }) => {
   }
 
   const popover = (
-    <>
+    <div ref={ref}>
       <div className="popover-container" style={ownPosition}>
         {children}
       </div>
@@ -91,11 +92,11 @@ const Popover: React.FC<PopoverProps> = ({ target, children }) => {
           border-radius: 3px;
         }
       `}</style>
-    </>
+    </div>
   )
 
   return ReactDOM.createPortal(popover, popoverRoot)
-}
+})
 
 const Thread: React.FC<ThreadProps> = ({ thread, onNewComment, currentUser }) => {
   const [commentBody, setCommentBody] = React.useState<string>('')
@@ -223,15 +224,15 @@ const Thread: React.FC<ThreadProps> = ({ thread, onNewComment, currentUser }) =>
   )
 }
 
-const InlineFeedbackPopover: React.FC<InlineFeedbackPopoverProps> = ({
+const InlineFeedbackPopover = React.forwardRef<HTMLDivElement, InlineFeedbackPopoverProps>(({
   target,
   thread,
   onNewComment,
   currentUser,
-}) => (
-  <Popover target={target}>
+}, ref) => (
+  <Popover target={target} ref={ref}>
     <Thread thread={thread} onNewComment={onNewComment} currentUser={currentUser} />
   </Popover>
-)
+))
 
 export default InlineFeedbackPopover


### PR DESCRIPTION
## Description

Changes the way highlight and click-out detection is done to fix issues with empty selections and closing thread popovers.

fixes #221 
