### PR TITLE
My Feed page should sort by newest posts first

### DIFF
--- a/frontend/nexus/post.ts
+++ b/frontend/nexus/post.ts
@@ -162,6 +162,9 @@ schema.extendType({
           },
           skip: args.skip,
           first: args.first,
+          orderBy: {
+            createdAt: 'desc',
+          },
         })
 
         const [count, posts] = await Promise.all([countQuery, postQuery])


### PR DESCRIPTION
## Description

**Issue:** fixes #219 

Fixes the feed page so that it sorts posts by `createdAt: `DESC` / newest posts first.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Add `orderBy` statement to query

