### PR TITLE
Update My Feed to 9 posts per page

### DIFF
--- a/frontend/components/Dashboard/MyFeed/MyFeed.tsx
+++ b/frontend/components/Dashboard/MyFeed/MyFeed.tsx
@@ -12,7 +12,7 @@ type Props = {
   currentUser: UserType
 }
 
-const NUM_POSTS_PER_PAGE = 10
+const NUM_POSTS_PER_PAGE = 9
 
 const MyFeed: React.FC<Props> = ({ currentUser }) => {
   // Pull query params off the router instance


### PR DESCRIPTION
## Description

As suggested by some testers, since the ideal page layout is 3 posts per row (or 3 columns), it feels right to have 9 posts per page.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Update to 9 posts per page

