### PR TITLE
Fix broken `/about` and `/blog/introducing-journaly` pages

### DIFF
--- a/frontend/pages/about.tsx
+++ b/frontend/pages/about.tsx
@@ -1,6 +1,7 @@
 import { NextPage } from 'next'
 import LandingPageLayout from '../components/Layouts/LandingPageLayout'
 import About from '../components/Site/About'
+import { withApollo } from '../lib/apollo'
 
 const AboutPage: NextPage = () => (
   <LandingPageLayout>
@@ -12,4 +13,4 @@ AboutPage.getInitialProps = async () => ({
   namespacesRequired: [],
 })
 
-export default AboutPage
+export default withApollo(AboutPage)

--- a/frontend/pages/blog/introducing-journaly.tsx
+++ b/frontend/pages/blog/introducing-journaly.tsx
@@ -3,6 +3,7 @@ import LandingPageLayout from '../../components/Layouts/LandingPageLayout'
 import BlogPageLayout from '../../components/Layouts/BlogPageLayout'
 import ExternalLink from '../../elements/ExternalLink'
 import { brandBlue } from '../../utils'
+import { withApollo } from '../../lib/apollo'
 
 const IntroducingJournalyBlogPost: NextPage = () => (
   <LandingPageLayout>
@@ -270,4 +271,4 @@ IntroducingJournalyBlogPost.getInitialProps = async () => ({
   namespacesRequired: [],
 })
 
-export default IntroducingJournalyBlogPost
+export default withApollo(IntroducingJournalyBlogPost)


### PR DESCRIPTION
## Description

**Issue:** `/about` and `blog/introducing-journaly` pages are currently broken due to throwing Apollo errors

Satisfies those errors for now.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] fix `/about`
- [x] fix `/blog/introducing-journaly`

