### PR TITLE
Alias `/dashboard` to /`dashboard/my-feed`

### DIFF
--- a/frontend/pages/dashboard/index.tsx
+++ b/frontend/pages/dashboard/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './my-feed'


### PR DESCRIPTION
## Description

Currently, `/dashboard` returns a 404. This PR aliases `/dashboard` to /`dashboard/my-feed`.


## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Do it
