### PR TITLE
🔥 PROD FIX: Author not displaying on posts

### DIFF
--- a/frontend/components/Dashboard/Post/Post.tsx
+++ b/frontend/components/Dashboard/Post/Post.tsx
@@ -361,7 +361,7 @@ const Post: React.FC<IPostProps> = ({ post, currentUser, refetch }: IPostProps) 
     <div className="post-container">
       <Head>
         <title>
-          {post.author.name} | {post.title}
+          {post.author.handle} | {post.title}
         </title>
       </Head>
       <div className="post-content">
@@ -369,7 +369,7 @@ const Post: React.FC<IPostProps> = ({ post, currentUser, refetch }: IPostProps) 
           postTitle={post.title}
           postStatus={post.status}
           publishDate={post.createdAt}
-          authorName={post.author.name}
+          authorName={post.author.handle}
           postImage={
             (post.images || []).find((i: ImageType) => i.imageRole === ImageRole.Headline)
               ?.largeSize || '/images/samples/sample-post-img.jpg'


### PR DESCRIPTION
## Description

🔥 Author isn't displaying in `PostHeader` or page `<Head>` for users who don't have a `name` yet (all of them).
Uses `handle`

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] use `handle

## Screenshots
![image](https://user-images.githubusercontent.com/34203886/89427232-e1ad9a00-d6ef-11ea-905e-c036f37f2aeb.png)
