### PR TITLE
Fix bug

### DIFF
--- a/frontend/components/InlineFeedbackPopover/Comment.tsx
+++ b/frontend/components/InlineFeedbackPopover/Comment.tsx
@@ -111,6 +111,7 @@ const Comment: React.FC<CommentProps> = ({ comment, canEdit, onUpdateComment }) 
         }
 
         .profile-image {
+          border-radius: 50%;
           width: 27px;
           height: 27px;
           object-fit: cover;


### PR DESCRIPTION
## Description

Avatar is square in comments when the user has a profile image.

![image](https://user-images.githubusercontent.com/34203886/89607952-9b0f8b00-d828-11ea-90b3-e91c7ad1f6a4.png)


## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Fix it
