### PR TITLE
Stop logging current user on Feed

### DIFF
--- a/frontend/components/Dashboard/MyFeed/MyFeed.tsx
+++ b/frontend/components/Dashboard/MyFeed/MyFeed.tsx
@@ -32,9 +32,6 @@ const MyFeed: React.FC<Props> = () => {
   const showPagination = count > NUM_POSTS_PER_PAGE
   const pageTitle = 'My Feed'
 
-  console.log(count)
-
-  // TODO will likley be used for event logging
   return (
     <div className="my-feed-wrapper">
       <Head>

--- a/frontend/components/Dashboard/MyFeed/MyFeed.tsx
+++ b/frontend/components/Dashboard/MyFeed/MyFeed.tsx
@@ -14,7 +14,7 @@ type Props = {
 
 const NUM_POSTS_PER_PAGE = 9
 
-const MyFeed: React.FC<Props> = ({ currentUser }) => {
+const MyFeed: React.FC<Props> = () => {
   // Pull query params off the router instance
   const { query } = useRouter()
   const currentPage = query.page ? Math.max(1, parseInt(query.page as string, 10)) : 1
@@ -32,8 +32,9 @@ const MyFeed: React.FC<Props> = ({ currentUser }) => {
   const showPagination = count > NUM_POSTS_PER_PAGE
   const pageTitle = 'My Feed'
 
+  console.log(count)
+
   // TODO will likley be used for event logging
-  console.log(currentUser)
   return (
     <div className="my-feed-wrapper">
       <Head>


### PR DESCRIPTION
## Description

We should stop console logging the current user in the browser on the my feed page. It will be simple to bring `currentUser` back when we start using it.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Clean up
