### PR TITLE
Clear selection before resetting editor content on new post page

### DIFF
--- a/frontend/components/JournalyEditor/JournalyEditor.tsx
+++ b/frontend/components/JournalyEditor/JournalyEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useCallback } from 'react'
+import React, { useEffect, useMemo, useCallback } from 'react'
 import { createEditor, Editor, Transforms, Node } from 'slate'
 import {
   Slate,
@@ -48,15 +48,21 @@ const LIST_TYPES = ['numbered-list', 'bulleted-list']
 type JournalyEditorProps = {
   value: Node[]
   setValue: (value: Node[]) => void
+  slateRef: React.RefObject<Editor>
 }
 
 const JournalyEditor: React.FC<JournalyEditorProps> = ({
   value,
   setValue,
+  slateRef,
 }: JournalyEditorProps) => {
   const renderElement = useCallback((props) => <Element {...props} />, [])
   const renderLeaf = useCallback((props) => <Leaf {...props} />, [])
   const editor = useMemo(() => withHistory(withReact(createEditor())), [])
+
+  useEffect(() => {
+    (slateRef as React.MutableRefObject<Editor>).current = editor
+  }, [editor])
 
   return (
     <div className="editor-wrapper">

--- a/frontend/pages/post/[id]/edit.tsx
+++ b/frontend/pages/post/[id]/edit.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { NextPage } from 'next'
 import { useRouter } from 'next/router'
-import { Node } from 'slate'
+import { Editor, Node } from 'slate'
 import { withApollo } from '../../../lib/apollo'
 import { useTranslation } from '../../../config/i18n'
 
@@ -35,6 +35,7 @@ const EditPostPage: NextPage = () => {
   const [langId, setLangId] = React.useState<number>(-1)
   const [title, setTitle] = React.useState<string>('')
   const [body, setBody] = React.useState<Node[]>(initialValue)
+  const slateRef = React.useRef<Editor>(null)
 
   React.useEffect(() => {
     if (postById) {
@@ -94,7 +95,7 @@ const EditPostPage: NextPage = () => {
           />
 
           <div className="editor-padding">
-            <JournalyEditor value={body} setValue={setBody} />
+            <JournalyEditor value={body} setValue={setBody} slateRef={slateRef} />
           </div>
 
           <div className="button-container">


### PR DESCRIPTION
Clear selection before resetting editor content on new post page, preventing a crash on submit.