### PR TITLE
Use dir="auto" to format RTL languages

### DIFF
--- a/frontend/components/Dashboard/Post/Post.tsx
+++ b/frontend/components/Dashboard/Post/Post.tsx
@@ -375,7 +375,7 @@ const Post: React.FC<IPostProps> = ({ post, currentUser, refetch }: IPostProps) 
               ?.largeSize || '/images/samples/sample-post-img.jpg'
           }
         />
-        <div className="post-body selectable-text-area" onClick={onThreadClick}>
+        <div className="post-body selectable-text-area" dir="auto" onClick={onThreadClick}>
           <PostContent body={post.body} ref={selectableRef} />
         </div>
 

--- a/frontend/components/Dashboard/PostCard/PostCard.tsx
+++ b/frontend/components/Dashboard/PostCard/PostCard.tsx
@@ -54,7 +54,7 @@ const PostCard: React.FC<Props> = ({
           <img className="post-image" src={displayImage} alt={imageAlt} />
 
           <div className="post-card-details">
-            <div className="post-text">
+            <div className="post-text" dir="auto">
               <h1 className="post-title">{title}</h1>
               <p className="post-excerpt">{excerpt}</p>
             </div>

--- a/frontend/components/PostHeader/index.tsx
+++ b/frontend/components/PostHeader/index.tsx
@@ -25,7 +25,7 @@ const PostHeader: React.FC<PostHeaderProps> = ({
   return (
     <div className="post-header">
       <img src={postImage} alt={postTitle} />
-      <div className="post-header-info">
+      <div className="post-header-info" dir="auto">
         <h1>{postTitle}</h1>
         <p> &mdash; </p>
         <p>

--- a/frontend/pages/dashboard/new-post.tsx
+++ b/frontend/pages/dashboard/new-post.tsx
@@ -129,6 +129,7 @@ const NewPostPage: NextPage = () => {
             name="title"
             placeholder="The Greatest Story Never Told..."
             autoComplete="off"
+            dir="auto"
           />
 
           <input


### PR DESCRIPTION
## Description

**Issue:** #265 

Display right-to-left languages correctly on PostCards and the Post page

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Display rtl!

## Screenshots

![image](https://user-images.githubusercontent.com/5829188/89700612-5fd29200-d8e4-11ea-80c3-229096143797.png)
![image](https://user-images.githubusercontent.com/5829188/89700643-b0e28600-d8e4-11ea-8d70-0663b325134c.png)
