### PR TITLE
Add basic toast message and style overrides

### DIFF
--- a/frontend/components/Dashboard/Post/Post.tsx
+++ b/frontend/components/Dashboard/Post/Post.tsx
@@ -216,7 +216,7 @@ const Post: React.FC<IPostProps> = ({ post, currentUser, refetch }: IPostProps) 
   const [updatePost] = useUpdatePostMutation({
     onCompleted: () => {
       refetch()
-      toast.success('Your draft has been published.')
+      toast.success(t('draftPublishedSuccess'))
     },
   })
 

--- a/frontend/components/Dashboard/Post/Post.tsx
+++ b/frontend/components/Dashboard/Post/Post.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import Head from 'next/head'
-import { sanitize } from '../../../utils'
+import { toast } from 'react-toastify'
 
+import { sanitize } from '../../../utils'
 import {
   Post as PostType,
   UserFragmentFragment as UserType,
@@ -212,7 +213,12 @@ const Post: React.FC<IPostProps> = ({ post, currentUser, refetch }: IPostProps) 
       setActiveThreadId(createThread.id)
     },
   })
-  const [updatePost] = useUpdatePostMutation({ onCompleted: refetch })
+  const [updatePost] = useUpdatePostMutation({
+    onCompleted: () => {
+      refetch()
+      toast.success('Your draft has been published.')
+    },
+  })
 
   React.useEffect(() => {
     if (!selectableRef.current) {

--- a/frontend/components/InlineFeedbackPopover/Comment.tsx
+++ b/frontend/components/InlineFeedbackPopover/Comment.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { toast } from 'react-toastify'
 import {
   useUpdateCommentMutation,
   useDeleteCommentMutation,
@@ -33,6 +34,7 @@ const Comment: React.FC<CommentProps> = ({ comment, canEdit, onUpdateComment }) 
       },
     })
     setIsEditMode(false)
+    toast.success('Your comment has been updated.')
   }
 
   const [deleteComment, { loading: deleteLoading }] = useDeleteCommentMutation({

--- a/frontend/components/InlineFeedbackPopover/Comment.tsx
+++ b/frontend/components/InlineFeedbackPopover/Comment.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react'
-import { toast } from 'react-toastify'
 import {
   useUpdateCommentMutation,
   useDeleteCommentMutation,
@@ -34,7 +33,6 @@ const Comment: React.FC<CommentProps> = ({ comment, canEdit, onUpdateComment }) 
       },
     })
     setIsEditMode(false)
-    toast.success('Your comment has been updated.')
   }
 
   const [deleteComment, { loading: deleteLoading }] = useDeleteCommentMutation({

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6624,6 +6624,22 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-helpers": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.0.tgz",
+      "integrity": "sha512-Ru5o9+V8CpunKnz5LGgWXkmrH/20cGKwcHwS4m73zIvs54CN9epEmT/HLqFJW3kXpakAFkEdzgy1hzlJe3E4OQ==",
+      "requires": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.2.tgz",
+          "integrity": "sha512-ofovWglpqoqbfLNOTBNZLSbMuGrblAf1efvvArGKOZMBrIoJeu5UsAipQolkijtyQx5MtAzT/J9IHj/CEY1mJw=="
+        }
+      }
+    },
     "dom-serializer": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
@@ -13352,6 +13368,27 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "react-toastify": {
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-6.0.8.tgz",
+      "integrity": "sha512-NSqCNwv+C4IfR+c92PFZiNyeBwOJvigrP2bcRi2f6Hg3WqcHhEHOknbSQOs9QDFuqUjmK3SOrdvScQ3z63ifXg==",
+      "requires": {
+        "classnames": "^2.2.6",
+        "prop-types": "^15.7.2",
+        "react-transition-group": "^4.4.1"
+      }
+    },
+    "react-transition-group": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
+      "integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      }
     },
     "read-pkg": {
       "version": "5.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,6 +59,7 @@
     "react-dom": "^16.13.0",
     "react-ga": "^2.7.0",
     "react-hook-form": "^5.7.2",
+    "react-toastify": "^6.0.8",
     "slate": "^0.57.1",
     "slate-history": "^0.57.1",
     "slate-react": "^0.57.1",

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -2,10 +2,15 @@ import App from 'next/app'
 import Head from 'next/head'
 import Router, { withRouter } from 'next/router'
 import NProgress from 'nprogress'
+import { ToastContainer } from 'react-toastify'
+
 import { initializeTracking, trackPageView } from '../lib/google-analytics'
+import { appWithTranslation } from '../config/i18n'
+
 import '../styles/reset.css'
 import '../styles/globalStyles.css'
-import { appWithTranslation } from '../config/i18n'
+import 'react-toastify/dist/ReactToastify.css'
+import '../styles/react-toastify-overrides.css'
 
 initializeTracking()
 
@@ -35,6 +40,7 @@ class JournalyApp extends App {
           <link rel="stylesheet" type="text/css" href="/nprogress.css" />
         </Head>
         <Component {...pageProps} />
+        <ToastContainer />
       </>
     )
   }

--- a/frontend/public/static/locales/en/post.json
+++ b/frontend/public/static/locales/en/post.json
@@ -9,5 +9,5 @@
   "languageLabel": "Language",
   "save": "Save",
   "finishAction": "Finish post",
-  "draftPublishedSuccess": "Your post has been successfully published!"
+  "draftPublishedSuccess": "Post successfully published!"
 }

--- a/frontend/public/static/locales/en/post.json
+++ b/frontend/public/static/locales/en/post.json
@@ -8,5 +8,6 @@
   "titleLabel": "Title",
   "languageLabel": "Language",
   "save": "Save",
-  "finishAction": "Finish post"
+  "finishAction": "Finish post",
+  "draftPublishedSuccess": "Your post has been successfully published!"
 }

--- a/frontend/styles/react-toastify-overrides.css
+++ b/frontend/styles/react-toastify-overrides.css
@@ -1,0 +1,13 @@
+/*
+ * Docs for overriding default react-toastify styles
+ * https://fkhadra.github.io/react-toastify/how-to-style/
+ */
+@media (min-width: 481px) {
+  .Toastify__toast {
+    border-radius: 5px;
+  }
+}
+
+.Toastify__toast--success {
+  background-color: #4391c9;
+}

--- a/frontend/styles/react-toastify-overrides.css
+++ b/frontend/styles/react-toastify-overrides.css
@@ -2,10 +2,18 @@
  * Docs for overriding default react-toastify styles
  * https://fkhadra.github.io/react-toastify/how-to-style/
  */
+
+.Toastify__toast {
+  padding: 12px;
+}
 @media (min-width: 481px) {
   .Toastify__toast {
     border-radius: 5px;
   }
+}
+
+.Toastify__toast-body {
+  font-family: 'Source Sans Pro', sans-serif;
 }
 
 .Toastify__toast--success {


### PR DESCRIPTION
## Description

**Issue:** Closes #251 

This PR introduces toast messages with the [react-toastify](https://github.com/fkhadra/react-toastify) library. It's lightweight and very customizable. I've only added the libary, basic style overrides for the "success" toast message, and one example. If we like it, I can add more overrides for other toast message variations, e.g. `info`, `error`, etc. and more usages of it throughout the app

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Get basic working version

## Screenshots

<img src="https://user-images.githubusercontent.com/5829188/89724186-a1327280-d9b4-11ea-918f-6584bdff0f3a.png" width="550" />

<img src="https://user-images.githubusercontent.com/5829188/89722349-7c7ed080-d99d-11ea-90ed-3d2f517f0f3a.gif" width="550" />