### PR TITLE
Fix comment count on post cards and issue where comments would be clipped off by post container

### DIFF
--- a/frontend/components/Dashboard/Post/Post.tsx
+++ b/frontend/components/Dashboard/Post/Post.tsx
@@ -415,7 +415,6 @@ const Post: React.FC<IPostProps> = ({ post, currentUser, refetch }: IPostProps) 
         position={commentButtonPosition}
         display={displayCommentButton && !!currentUser}
       />
-      <div id="popover-root" />
       {activeThread && (
         <InlineFeedbackPopover
           thread={activeThread}

--- a/frontend/components/Dashboard/PostCard/PostCard.tsx
+++ b/frontend/components/Dashboard/PostCard/PostCard.tsx
@@ -35,7 +35,7 @@ const PostCard: React.FC<Props> = ({
     readTime,
     images,
     likes,
-    threads,
+    commentCount,
     author: { handle, name, profileImage },
     createdAt,
     publishedAt,
@@ -84,7 +84,7 @@ const PostCard: React.FC<Props> = ({
                     </div>
                     <div className="post-stat">
                       <CommentIcon />
-                      <span>{threads.length}</span>
+                      <span>{commentCount}</span>
                     </div>
                   </div>
                 )}

--- a/frontend/generated/graphql.tsx
+++ b/frontend/generated/graphql.tsx
@@ -208,6 +208,7 @@ export type Post = {
   bodySrc: Scalars['String']
   images: Array<Image>
   publishedAt?: Maybe<Scalars['DateTime']>
+  commentCount?: Maybe<Scalars['Int']>
 }
 
 export type PostLikesArgs = {
@@ -511,11 +512,10 @@ export type PostFragmentFragment = { __typename?: 'Post' } & Pick<
 
 export type PostCardFragmentFragment = { __typename?: 'Post' } & Pick<
   Post,
-  'id' | 'title' | 'body' | 'excerpt' | 'readTime' | 'createdAt' | 'publishedAt'
+  'id' | 'title' | 'body' | 'excerpt' | 'readTime' | 'createdAt' | 'publishedAt' | 'commentCount'
 > & {
     images: Array<{ __typename?: 'Image' } & Pick<Image, 'smallSize'>>
     likes: Array<{ __typename?: 'PostLike' } & Pick<PostLike, 'id'>>
-    threads: Array<{ __typename?: 'Thread' } & Pick<Thread, 'id'>>
     author: { __typename?: 'User' } & AuthorFragmentFragment
     language: { __typename?: 'Language' } & LanguageFragmentFragment
   }
@@ -742,13 +742,11 @@ export const PostCardFragmentFragmentDoc = gql`
     readTime
     createdAt
     publishedAt
+    commentCount
     images {
       smallSize
     }
     likes {
-      id
-    }
-    threads {
       id
     }
     author {

--- a/frontend/graphql/fragments.graphql
+++ b/frontend/graphql/fragments.graphql
@@ -77,13 +77,11 @@ fragment PostCardFragment on Post {
   readTime
   createdAt
   publishedAt
+  commentCount
   images {
     smallSize
   }
   likes {
-    id
-  }
-  threads {
     id
   }
   author {

--- a/frontend/nexus/post.ts
+++ b/frontend/nexus/post.ts
@@ -22,6 +22,17 @@ schema.objectType({
     t.model.bodySrc()
     t.model.images()
     t.model.publishedAt()
+    t.int('commentCount', {
+      resolve(parent, args, ctx, info) {
+        return ctx.db.comment.count({
+          where: {
+            thread: {
+              postId: parent.id
+            }
+          }
+        })
+      }
+    })
   },
 })
 

--- a/frontend/nexus/post.ts
+++ b/frontend/nexus/post.ts
@@ -23,7 +23,7 @@ schema.objectType({
     t.model.images()
     t.model.publishedAt()
     t.int('commentCount', {
-      resolve(parent, args, ctx, info) {
+      resolve(parent, _args, ctx, _info) {
         return ctx.db.comment.count({
           where: {
             thread: {

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -41,6 +41,7 @@ class JournalyApp extends App {
         </Head>
         <Component {...pageProps} />
         <ToastContainer />
+        <div id="popover-root" />
       </>
     )
   }


### PR DESCRIPTION
## Description

Resolves #271 

Previously `PostCard`s displayed the thread count, I believe it seemed off because of the empty selection threads issue where there wouldn't be a visible thread on the post but they would exist in the DB. Now we use the count of comments on the post (still possible off if there is a comment in a empty selection thread) but it should be correct going forward as the empty selection thread issue shouldn't happen anymore.

Also addresses issue where the comment popover (near the bottom of a post, especially on short posts where the post container is less than half the vertical height of the screen) could be clipped off by the post container.