### PR TITLE
POSTS: Create Post Author Cards!

### DIFF
--- a/components/Dashboard/Post/Post.tsx
+++ b/components/Dashboard/Post/Post.tsx
@@ -20,6 +20,7 @@ import LeaveACommentIcon from '../../Icons/LeaveACommentIcon'
 import InlineFeedbackPopover from '../../InlineFeedbackPopover'
 import { Router, useTranslation } from '../../../config/i18n'
 import PostHeader from '../../PostHeader'
+
 interface IPostProps {
   post: PostType | any
   currentUser: UserType | null | undefined

--- a/components/Dashboard/Post/PostAuthorCard.tsx
+++ b/components/Dashboard/Post/PostAuthorCard.tsx
@@ -42,8 +42,16 @@ const PostAuthorCard: React.FC<PostAuthorCardProps> = ({ author }) => {
         .container {
           background-color: ${theme.colors.white};
           box-shadow: 0 12px 24px 0 rgba(0, 0, 0, 0.09);
-          width: 38%;
+          width: 100%;
           padding: 20px;
+          margin-bottom: 25px;
+        }
+
+        @media (min-width: ${theme.breakpoints.XS}) {
+          .container {
+            width: 38%;
+            margin-bottom: 0;
+          }
         }
 
         .author-info {

--- a/components/Dashboard/Post/PostAuthorCard.tsx
+++ b/components/Dashboard/Post/PostAuthorCard.tsx
@@ -21,7 +21,14 @@ const PostAuthorCard: React.FC<PostAuthorCardProps> = ({ author }) => {
           <p className="author-name">{author.handle}</p>
         </a>
       </Link>
-      <div className="language-info">author</div>
+      <div className="language-info">
+        <p className="author-info-heading">Languages</p>
+        <ul>
+          {author.languagesLearning.map((language) => (
+            <li key={language.language.id}>{language.language.name}</li>
+          ))}
+        </ul>
+      </div>
       <style jsx>{`
         .container {
           background-color: ${theme.colors.white};
@@ -34,6 +41,7 @@ const PostAuthorCard: React.FC<PostAuthorCardProps> = ({ author }) => {
           display: flex;
           align-items: center;
           padding-bottom: 10px;
+          margin-bottom: 5px;
           border-bottom: 1px solid ${theme.colors.gray400};
         }
 
@@ -49,6 +57,11 @@ const PostAuthorCard: React.FC<PostAuthorCardProps> = ({ author }) => {
           border-radius: 50%;
           background-color: ${theme.colors.blueLight};
           margin-right: 10px;
+        }
+
+        .author-info-heading {
+          ${theme.typography.headingSM};
+          font-weight: 600;
         }
       `}</style>
     </div>

--- a/components/Dashboard/Post/PostAuthorCard.tsx
+++ b/components/Dashboard/Post/PostAuthorCard.tsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import Link from 'next/link'
+import theme from '../../../theme'
+import { AuthorWithLanguagesFragmentFragment as Author } from '../../../generated/graphql'
+import BlankAvatarIcon from '../../Icons/BlankAvatarIcon'
+
+type PostAuthorCardProps = {
+  author: Author
+}
+
+const PostAuthorCard: React.FC<PostAuthorCardProps> = ({ author }) => {
+  return (
+    <div className="container">
+      <Link href={`/dashboard/profile/${author.id}`}>
+        <a className="author-info">
+          {author.profileImage ? (
+            <img src={author.profileImage} alt="" />
+          ) : (
+            <BlankAvatarIcon size={60} />
+          )}
+          <p className="author-name">{author.handle}</p>
+        </a>
+      </Link>
+      <div className="language-info">author</div>
+      <style jsx>{`
+        .container {
+          background-color: ${theme.colors.white};
+          box-shadow: 0 12px 24px 0 rgba(0, 0, 0, 0.09);
+          width: 38%;
+          padding: 20px;
+        }
+
+        .author-info {
+          display: flex;
+          align-items: center;
+          padding-bottom: 10px;
+          border-bottom: 1px solid ${theme.colors.gray400};
+        }
+
+        .author-info img {
+          width: 60px;
+          height: 60px;
+          border-radius: 50%;
+          object-fit: cover;
+          margin-right: 10px;
+        }
+
+        .author-info :global(svg) {
+          border-radius: 50%;
+          background-color: ${theme.colors.blueLight};
+          margin-right: 10px;
+        }
+      `}</style>
+    </div>
+  )
+}
+
+export default PostAuthorCard

--- a/components/Dashboard/Post/PostAuthorCard.tsx
+++ b/components/Dashboard/Post/PostAuthorCard.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import Link from 'next/link'
 import theme from '../../../theme'
-import { AuthorWithLanguagesFragmentFragment as Author } from '../../../generated/graphql'
+import { AuthorWithLanguagesFragmentFragment as Author, Language } from '../../../generated/graphql'
 import BlankAvatarIcon from '../../Icons/BlankAvatarIcon'
 
 type PostAuthorCardProps = {
-  author: Author
+  author: Author | any
 }
 
 const PostAuthorCard: React.FC<PostAuthorCardProps> = ({ author }) => {
@@ -24,9 +24,10 @@ const PostAuthorCard: React.FC<PostAuthorCardProps> = ({ author }) => {
       <div className="language-info">
         <p className="author-info-heading">Languages</p>
         <ul>
-          {author.languagesLearning.map((language) => (
-            <li key={language.language.id}>{language.language.name}</li>
-          ))}
+          {author.languagesLearning.map((languageParent: any) => {
+            const language: Language = languageParent.language
+            return <li key={language.id}>{language.name}</li>
+          })}
         </ul>
       </div>
       <style jsx>{`

--- a/components/Dashboard/Post/PostAuthorCard.tsx
+++ b/components/Dashboard/Post/PostAuthorCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import Link from 'next/link'
 import theme from '../../../theme'
-import { AuthorWithLanguagesFragmentFragment as Author, Language } from '../../../generated/graphql'
+import { AuthorWithLanguagesFragmentFragment as Author } from '../../../generated/graphql'
 import BlankAvatarIcon from '../../Icons/BlankAvatarIcon'
 
 type PostAuthorCardProps = {
@@ -9,6 +9,15 @@ type PostAuthorCardProps = {
 }
 
 const PostAuthorCard: React.FC<PostAuthorCardProps> = ({ author }) => {
+  let languages = []
+
+  for (let language of author.languagesLearning) {
+    languages.push(language.language.name)
+  }
+  for (let language of author.languagesNative) {
+    languages.push(language.language.name)
+  }
+
   return (
     <div className="container">
       <Link href={`/dashboard/profile/${author.id}`}>
@@ -24,9 +33,8 @@ const PostAuthorCard: React.FC<PostAuthorCardProps> = ({ author }) => {
       <div className="language-info">
         <p className="author-info-heading">Languages</p>
         <ul>
-          {author.languagesLearning.map((languageParent: any) => {
-            const language: Language = languageParent.language
-            return <li key={language.id}>{language.name}</li>
+          {languages.map((language) => {
+            return <li key={language}>{language}</li>
           })}
         </ul>
       </div>

--- a/components/Dashboard/Post/PostComments.tsx
+++ b/components/Dashboard/Post/PostComments.tsx
@@ -5,17 +5,25 @@ const PostAuthorCard: React.FC = () => {
   return (
     <div className="container">
       <h1>Comments</h1>
+      <p>Coming soon!</p>
       <style jsx>{`
         .container {
           background-color: ${theme.colors.white};
           box-shadow: 0 12px 24px 0 rgba(0, 0, 0, 0.09);
-          width: 58%;
+          width: 100%;
           padding: 20px;
           text-align: center;
         }
 
+        @media (min-width: ${theme.breakpoints.XS}) {
+          .container {
+            width: 58%;
+          }
+        }
+
         h1 {
           ${theme.typography.headingLG};
+          margin-bottom: 20px;
         }
       `}</style>
     </div>

--- a/components/Dashboard/Post/PostComments.tsx
+++ b/components/Dashboard/Post/PostComments.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import theme from '../../../theme'
+
+const PostAuthorCard: React.FC = () => {
+  return (
+    <div className="container">
+      <h1>Comments</h1>
+      <style jsx>{`
+        .container {
+          background-color: ${theme.colors.white};
+          box-shadow: 0 12px 24px 0 rgba(0, 0, 0, 0.09);
+          width: 58%;
+          padding: 20px;
+          text-align: center;
+        }
+
+        h1 {
+          ${theme.typography.headingLG};
+        }
+      `}</style>
+    </div>
+  )
+}
+
+export default PostAuthorCard

--- a/components/InlineFeedbackPopover/Comment.tsx
+++ b/components/InlineFeedbackPopover/Comment.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import Link from 'next/link'
 import {
   useUpdateCommentMutation,
   useDeleteCommentMutation,
@@ -53,11 +54,15 @@ const Comment: React.FC<CommentProps> = ({ comment, canEdit, onUpdateComment }) 
   return (
     <div className="comment">
       <div className="author-block">
-        {comment.author.profileImage ? (
-          <img className="profile-image" src={comment.author.profileImage} alt="" />
-        ) : (
-          <BlankAvatarIcon size={20} />
-        )}
+        <Link href={`/dashboard/profile/${comment.author.id}`}>
+          <a className="author-info">
+            {comment.author.profileImage ? (
+              <img className="profile-image" src={comment.author.profileImage} alt="" />
+            ) : (
+              <BlankAvatarIcon size={20} />
+            )}
+          </a>
+        </Link>
         <span className="author-identifier">
           {comment.author.name
             ? `${comment.author.name} (@${comment.author.handle})`

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -496,6 +496,19 @@ export type AuthorFragmentFragment = { __typename?: 'User' } & Pick<
   'id' | 'name' | 'handle' | 'profileImage'
 >
 
+export type AuthorWithLanguagesFragmentFragment = { __typename?: 'User' } & {
+  languagesLearning: Array<
+    { __typename?: 'LanguageLearning' } & {
+      language: { __typename?: 'Language' } & LanguageFragmentFragment
+    }
+  >
+  languagesNative: Array<
+    { __typename?: 'LanguageNative' } & {
+      language: { __typename?: 'Language' } & LanguageFragmentFragment
+    }
+  >
+} & AuthorFragmentFragment
+
 export type CommentFragmentFragment = { __typename?: 'Comment' } & Pick<
   Comment,
   'id' | 'body' | 'createdAt'
@@ -510,7 +523,7 @@ export type PostFragmentFragment = { __typename?: 'Post' } & Pick<
   Post,
   'id' | 'title' | 'body' | 'status' | 'excerpt' | 'readTime' | 'createdAt' | 'publishedAt'
 > & {
-    author: { __typename?: 'User' } & AuthorFragmentFragment
+    author: { __typename?: 'User' } & AuthorWithLanguagesFragmentFragment
     threads: Array<{ __typename?: 'Thread' } & ThreadFragmentFragment>
     images: Array<{ __typename?: 'Image' } & Pick<Image, 'id' | 'largeSize' | 'imageRole'>>
   }
@@ -698,6 +711,23 @@ export const AuthorFragmentFragmentDoc = gql`
     profileImage
   }
 `
+export const AuthorWithLanguagesFragmentFragmentDoc = gql`
+  fragment AuthorWithLanguagesFragment on User {
+    ...AuthorFragment
+    languagesLearning {
+      language {
+        ...LanguageFragment
+      }
+    }
+    languagesNative {
+      language {
+        ...LanguageFragment
+      }
+    }
+  }
+  ${AuthorFragmentFragmentDoc}
+  ${LanguageFragmentFragmentDoc}
+`
 export const CommentFragmentFragmentDoc = gql`
   fragment CommentFragment on Comment {
     id
@@ -732,7 +762,7 @@ export const PostFragmentFragmentDoc = gql`
     createdAt
     publishedAt
     author {
-      ...AuthorFragment
+      ...AuthorWithLanguagesFragment
     }
     threads {
       ...ThreadFragment
@@ -743,7 +773,7 @@ export const PostFragmentFragmentDoc = gql`
       imageRole
     }
   }
-  ${AuthorFragmentFragmentDoc}
+  ${AuthorWithLanguagesFragmentFragmentDoc}
   ${ThreadFragmentFragmentDoc}
 `
 export const PostCardFragmentFragmentDoc = gql`

--- a/graphql/fragments.graphql
+++ b/graphql/fragments.graphql
@@ -28,6 +28,20 @@ fragment AuthorFragment on User {
   profileImage
 }
 
+fragment AuthorWithLanguagesFragment on User {
+  ...AuthorFragment
+  languagesLearning {
+    language {
+      ...LanguageFragment
+    }
+  }
+  languagesNative {
+    language {
+      ...LanguageFragment
+    }
+  }
+}
+
 fragment CommentFragment on Comment {
   id
   body
@@ -57,7 +71,7 @@ fragment PostFragment on Post {
   createdAt
   publishedAt
   author {
-    ...AuthorFragment
+    ...AuthorWithLanguagesFragment
   }
   threads {
     ...ThreadFragment

--- a/pages/post/[id]/index.tsx
+++ b/pages/post/[id]/index.tsx
@@ -7,6 +7,8 @@ import Post from '../../../components/Dashboard/Post'
 import LoadingWrapper from '../../../components/LoadingWrapper'
 import DashboardLayout from '../../../components/Layouts/DashboardLayout'
 import { useCurrentUserQuery, usePostByIdQuery } from '../../../generated/graphql'
+import PostAuthorCard from '../../../components/Dashboard/Post/PostAuthorCard'
+import PostComments from '../../../components/Dashboard/Post/PostComments'
 
 const PostPage: NextPage = () => {
   const idStr = useRouter().query.id as string
@@ -19,7 +21,19 @@ const PostPage: NextPage = () => {
   return (
     <LoadingWrapper loading={postLoading || userLoading} error={postError || userError}>
       <DashboardLayout>
-        <Post post={postData?.postById} currentUser={userData?.currentUser} refetch={refetch} />
+        <div className="post-page-wrapper">
+          <Post post={postData?.postById} currentUser={userData?.currentUser} refetch={refetch} />
+          <div className="post-lower-section">
+            <PostComments />
+            <PostAuthorCard author={postData?.postById?.author} />
+          </div>
+          <style jsx>{`
+            .post-lower-section {
+              display: flex;
+              justify-content: space-between;
+            }
+          `}</style>
+        </div>
       </DashboardLayout>
     </LoadingWrapper>
   )

--- a/pages/post/[id]/index.tsx
+++ b/pages/post/[id]/index.tsx
@@ -9,6 +9,7 @@ import DashboardLayout from '../../../components/Layouts/DashboardLayout'
 import { useCurrentUserQuery, usePostByIdQuery } from '../../../generated/graphql'
 import PostAuthorCard from '../../../components/Dashboard/Post/PostAuthorCard'
 import PostComments from '../../../components/Dashboard/Post/PostComments'
+import theme from '../../../theme'
 
 const PostPage: NextPage = () => {
   const idStr = useRouter().query.id as string
@@ -30,7 +31,13 @@ const PostPage: NextPage = () => {
           <style jsx>{`
             .post-lower-section {
               display: flex;
+              flex-direction: column-reverse;
               justify-content: space-between;
+            }
+            @media (min-width: ${theme.breakpoints.XS}) {
+              .post-lower-section {
+                flex-direction: row;
+              }
             }
           `}</style>
         </div>


### PR DESCRIPTION
## Description

**Issue:** closes #277 

Currently, posts are quite bare and they feel quite detached from the author who wrote them. We need to make the posts feel a lot more personalized to the author and help readers feel more of a connection and sense of community!

This PR adds the beginnings of a nice author card to the post displaying information and with a link to their profile!
It also adds a placeholder for the post general comments (#278 ) which will be a follow-up ticket.

It also provides the first entry point for viewing another person's profile! 🙌🏼
Finally, with the above point in mind, I also made comment author avatars clickable as well which takes you to their profile 😄

More information will be added to the card this week and it will be made to look much nicer! 😍

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Scaffold everything out
- [x] Update GQL with `AuthorWithLanguagesFragment`
- [x] Add languages to the card

## Full Flow ♥️

![author-card-preview](https://user-images.githubusercontent.com/34203886/89975386-7184a400-dc1a-11ea-9473-c364f92d9ac5.gif)
