### PR TITLE
Quick fix for max width on post section

### DIFF
--- a/pages/post/[id]/index.tsx
+++ b/pages/post/[id]/index.tsx
@@ -29,6 +29,11 @@ const PostPage: NextPage = () => {
             <PostAuthorCard author={postData?.postById?.author} />
           </div>
           <style jsx>{`
+            .post-page-wrapper {
+              max-width: 1200px;
+              margin: 0 auto;
+            }
+
             .post-lower-section {
               display: flex;
               flex-direction: column-reverse;


### PR DESCRIPTION
## Description

The new bottom section of the post page can expand wider than the post content. This is a quick hot fix as the feature was just released! 

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Make the fix
