### PR TITLE
THREADS: Proposal for deleting empty threads

### DIFF
--- a/nexus/graphql.ts
+++ b/nexus/graphql.ts
@@ -77,6 +77,34 @@ schema.mutationType({
         })
       },
     })
+    t.field('deleteThread', {
+      type: 'Thread',
+      args: {
+        threadId: intArg({ required: true }),
+      },
+      resolve: async (_parent, args, ctx) => {
+        const thread = await ctx.db.thread.findOne({
+          where: {
+            id: args.threadId,
+          },
+          include: {
+            comments: true,
+          },
+        })
+
+        if (!thread) throw new Error('Thread not found.')
+
+        if (thread.comments.length !== 0) {
+          throw new Error('Cannot delete a thread containing comments.')
+        }
+
+        return ctx.db.thread.delete({
+          where: {
+            id: args.threadId,
+          },
+        })
+      },
+    })
     t.field('createComment', {
       type: 'Comment',
       args: {


### PR DESCRIPTION
## Description

**Issue:** closes #210 

This is a proposal for a simple (perhaps temporary) solution to removing empty threads. Rather than deferring the DB `save` operation of a thread until after a comment is created, we could simply have a `deleteThread` mutation and when a user closes a thread, we quickly check the length of comments and if it is 0, delete the thread.

## Subtasks

- [ ] I have added this PR to the Journaly Kanban project ✅
- [ ] ...

## Screenshots
