### PR TITLE
Clear currentUser cache on logout.

### DIFF
--- a/components/Dashboard/Nav/NavLinks.tsx
+++ b/components/Dashboard/Nav/NavLinks.tsx
@@ -5,7 +5,11 @@ import FeedIcon from '../../Icons/FeedIcon'
 import BlankAvatarIcon from '../../Icons/BlankAvatarIcon'
 import { navConstants } from './nav-constants'
 import { Router, useTranslation } from '../../../config/i18n'
-import { useLogoutMutation, User as UserType } from '../../../generated/graphql'
+import {
+  useLogoutMutation,
+  useCurrentUserQuery,
+  User as UserType,
+} from '../../../generated/graphql'
 import theme from '../../../theme'
 
 interface Props {
@@ -16,9 +20,15 @@ interface Props {
 const NavLinks: React.FC<Props> = ({ onClick, currentUser }) => {
   const { t } = useTranslation()
   const [logout] = useLogoutMutation()
+  const { refetch } = useCurrentUserQuery()
   const handleLogOut = (): void => {
     onClick()
     logout()
+
+    // Clear the current user Cache
+    refetch()
+
+    // Redirect to home page
     Router.push('/')
   }
 


### PR DESCRIPTION
Fixes issue where logging out would leave you with the "dashboard" link on the main page until the next refresh.