### PR TITLE
Fix some cross browser issues with popover positioning.

### DIFF
--- a/styles/globalStyles.css
+++ b/styles/globalStyles.css
@@ -5,6 +5,7 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   background-color: #efefef;
+  position: relative;
 }
 
 body.modal-open {


### PR DESCRIPTION
Fixes issue where FF (and maybe brave?) positioned popovers incorrectly. Gives `body` tag `position: relative` so popovers are positioned relative to it, rather than doc root, which apparent browsers size differently based on default UA stylesheets