### PR TITLE
Prevent PostCards from shrinking

### DIFF
--- a/components/Dashboard/PostCard/PostCard.tsx
+++ b/components/Dashboard/PostCard/PostCard.tsx
@@ -105,6 +105,7 @@ const PostCard: React.FC<Props> = ({
 
       <style jsx>{`
         .post-card-container {
+          flex-shrink: 0;
           display: flex;
           flex-direction: column;
           background-color: ${theme.colors.white};


### PR DESCRIPTION
## Description

Safari was shrinking flex items where other browsers were not. Adding `flex-shrink: 0` prevents this from happening

## Screenshots

## Before

![image](https://user-images.githubusercontent.com/5829188/90090554-27aec300-dcd9-11ea-9649-d9a5cc79e46b.png)

## After

![image](https://user-images.githubusercontent.com/5829188/90090516-11086c00-dcd9-11ea-9a55-29a625eb78bd.png)
