### PR TITLE
View and update bio

### DIFF
--- a/components/Dashboard/Profile/ProfileCard.tsx
+++ b/components/Dashboard/Profile/ProfileCard.tsx
@@ -5,6 +5,7 @@ import InstagramIcon from '../../../components/Icons/InstagramIcon'
 import YoutubeIcon from '../../../components/Icons/YoutubeIcon'
 import GlobeIcon from '../../../components/Icons/GlobeIcon'
 import ExternalLink from '../../../elements/ExternalLink'
+import { sanitize } from '../../../utils'
 import { languageNameWithDialect } from '../../../utils/languages'
 import theme from '../../../theme'
 import { User as UserType } from '../../../generated/graphql'
@@ -66,7 +67,7 @@ const ProfileCard: React.FC<Props> = ({ user }) => {
           <BlankAvatarIcon className="blank-avatar-desktop" size={130} />
         )}
 
-        {user.bio && <p className="bio">{user.bio}</p>}
+        {user.bio && <p className="bio">{sanitize(user.bio)}</p>}
       </div>
 
       <div className="profile-footer">

--- a/components/Dashboard/Profile/ProfileCard.tsx
+++ b/components/Dashboard/Profile/ProfileCard.tsx
@@ -5,6 +5,7 @@ import InstagramIcon from '../../../components/Icons/InstagramIcon'
 import YoutubeIcon from '../../../components/Icons/YoutubeIcon'
 import GlobeIcon from '../../../components/Icons/GlobeIcon'
 import ExternalLink from '../../../elements/ExternalLink'
+import { languageNameWithDialect } from '../../../utils/languages'
 import theme from '../../../theme'
 import { User as UserType } from '../../../generated/graphql'
 import BlankAvatarIcon from '../../Icons/BlankAvatarIcon'
@@ -29,15 +30,8 @@ const ProfileCard: React.FC<Props> = ({ user }) => {
   const showSeparator =
     sampleUser.facebook || sampleUser.instagram || sampleUser.youtube || sampleUser.website
   const profileImage = user.profileImage
-  const speaks = []
-  const learns = []
-
-  for (let language of user.languagesNative) {
-    speaks.push(language.language.name)
-  }
-  for (let language of user.languagesLearning) {
-    learns.push(language.language.name)
-  }
+  const speaks = user.languagesNative.map(({ language }) => languageNameWithDialect(language))
+  const learns = user.languagesLearning.map(({ language }) => languageNameWithDialect(language))
 
   return (
     <div className="profile-card">

--- a/components/Dashboard/Profile/ProfileCard.tsx
+++ b/components/Dashboard/Profile/ProfileCard.tsx
@@ -18,8 +18,6 @@ const ProfileCard: React.FC<Props> = ({ user }) => {
 
   const sampleUser = {
     likes: ['cooking, reading, movies, design'],
-    bio:
-      'Praesent commodo a quis at dui taciti sagittis senectus inceptos nascetur, dictumst accumsan quam tortor dictum in ultrices natoque sodales, venenatis et iaculis aliquet blandit mi mauris faucibus molestie. Libero suspendisse urna placerat elit non est metus vivamus justo, duis nam ridiculus mattis eu gravida tellus curae, maecenas nisi pellentesque elementum imperdiet mus ac varius.',
     location: 'San Francisco, United States',
     facebook: 'https://www.facebook.com/robinmacpherson.co',
     instagram: 'https://instagram.com/my-link',
@@ -74,7 +72,7 @@ const ProfileCard: React.FC<Props> = ({ user }) => {
           <BlankAvatarIcon className="blank-avatar-desktop" size={130} />
         )}
 
-        {sampleUser.bio && <p className="bio">{sampleUser.bio}</p>}
+        {user.bio && <p className="bio">{user.bio}</p>}
       </div>
 
       <div className="profile-footer">

--- a/components/Dashboard/Settings/BioForm.tsx
+++ b/components/Dashboard/Settings/BioForm.tsx
@@ -16,6 +16,8 @@ type FormValues = {
   bio: string
 }
 
+const BIO_MAX_LENGTH = 400
+
 const BioForm: React.FC<Props> = ({ bio }) => {
   const { t } = useTranslation('settings')
   const [updateUser, { loading }] = useUpdateUserMutation({
@@ -35,7 +37,7 @@ const BioForm: React.FC<Props> = ({ bio }) => {
     if (!loading) {
       updateUser({
         variables: {
-          bio: sanitize(data.bio),
+          bio: sanitize(data.bio.trim().slice(0, BIO_MAX_LENGTH)),
         },
       })
     }
@@ -49,13 +51,14 @@ const BioForm: React.FC<Props> = ({ bio }) => {
             <label className="settings-label" htmlFor="bio">
               {t('profile.bio.bioLabel')}
             </label>
-            {/* TODO: add native maxlength attribute when we know how long this field can be */}
+
             <textarea
               rows={4}
               id="bio"
               name="bio"
               className="j-textarea"
               defaultValue={sanitize(bio)}
+              maxLength={BIO_MAX_LENGTH}
               ref={register()}
             />
           </div>

--- a/components/Dashboard/Settings/BioForm.tsx
+++ b/components/Dashboard/Settings/BioForm.tsx
@@ -4,15 +4,33 @@ import { useTranslation } from '../../../config/i18n'
 import SettingsForm from '../../../components/Dashboard/Settings/SettingsForm'
 import SettingsFieldset from '../../../components/Dashboard/Settings/SettingsFieldset'
 import Button, { ButtonVariant } from '../../../elements/Button'
+import { useUpdateUserMutation } from '../../../generated/graphql'
 
-const BioForm: React.FC = () => {
+type Props = {
+  bio: string
+}
+
+type FormValues = {
+  bio: string
+}
+
+const BioForm: React.FC<Props> = ({ bio }) => {
   const { t } = useTranslation('settings')
-  const { handleSubmit, register } = useForm({
+  const [updateUser, { loading }] = useUpdateUserMutation()
+  const { handleSubmit, register } = useForm<FormValues>({
     mode: 'onSubmit',
     reValidateMode: 'onBlur',
   })
 
-  const handleBioSubmit = (): void => {}
+  const handleBioSubmit = ({ bio }: FormValues): void => {
+    if (!loading) {
+      updateUser({
+        variables: {
+          bio,
+        },
+      })
+    }
+  }
 
   return (
     <SettingsForm onSubmit={handleSubmit(handleBioSubmit)}>
@@ -23,13 +41,21 @@ const BioForm: React.FC = () => {
               {t('profile.bio.bioLabel')}
             </label>
             {/* TODO: add native maxlength attribute when we know how long this field can be */}
-            <textarea rows={4} id="bio" name="bio" className="j-textarea" ref={register()} />
+            <textarea
+              rows={4}
+              id="bio"
+              name="bio"
+              className="j-textarea"
+              defaultValue={bio}
+              ref={register()}
+            />
           </div>
 
           <Button
             type="submit"
             className="settings-submit-button"
             variant={ButtonVariant.Secondary}
+            loading={loading}
           >
             {t('updateButton')}
           </Button>

--- a/components/Dashboard/Settings/BioForm.tsx
+++ b/components/Dashboard/Settings/BioForm.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { useForm } from 'react-hook-form'
+import { sanitize } from '../../../utils'
 import { useTranslation } from '../../../config/i18n'
 import SettingsForm from '../../../components/Dashboard/Settings/SettingsForm'
 import SettingsFieldset from '../../../components/Dashboard/Settings/SettingsFieldset'
@@ -22,11 +23,11 @@ const BioForm: React.FC<Props> = ({ bio }) => {
     reValidateMode: 'onBlur',
   })
 
-  const handleBioSubmit = ({ bio }: FormValues): void => {
+  const handleBioSubmit = (data: FormValues): void => {
     if (!loading) {
       updateUser({
         variables: {
-          bio,
+          bio: sanitize(data.bio),
         },
       })
     }
@@ -46,7 +47,7 @@ const BioForm: React.FC<Props> = ({ bio }) => {
               id="bio"
               name="bio"
               className="j-textarea"
-              defaultValue={bio}
+              defaultValue={sanitize(bio)}
               ref={register()}
             />
           </div>

--- a/components/Dashboard/Settings/BioForm.tsx
+++ b/components/Dashboard/Settings/BioForm.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { useForm } from 'react-hook-form'
+import { toast } from 'react-toastify'
 import { sanitize } from '../../../utils'
 import { useTranslation } from '../../../config/i18n'
 import SettingsForm from '../../../components/Dashboard/Settings/SettingsForm'
@@ -17,7 +18,14 @@ type FormValues = {
 
 const BioForm: React.FC<Props> = ({ bio }) => {
   const { t } = useTranslation('settings')
-  const [updateUser, { loading }] = useUpdateUserMutation()
+  const [updateUser, { loading }] = useUpdateUserMutation({
+    onCompleted: () => {
+      toast.success(t('profile.bio.bioSuccess'))
+    },
+    onError: () => {
+      toast.error(t('profile.error.updateError'))
+    },
+  })
   const { handleSubmit, register } = useForm<FormValues>({
     mode: 'onSubmit',
     reValidateMode: 'onBlur',

--- a/components/Dashboard/Settings/LanguagesForm.tsx
+++ b/components/Dashboard/Settings/LanguagesForm.tsx
@@ -29,7 +29,7 @@ const LanguagesForm: React.FC<Props> = ({
   const { t } = useTranslation('settings')
 
   return (
-    <SettingsForm onSubmit={() => undefined}>
+    <SettingsForm>
       <SettingsFieldset legend={t('profile.languages.legend')}>
         <div className="languages-wrapper">
           <div className="languages-form-fields">

--- a/components/Dashboard/Settings/SettingsForm.tsx
+++ b/components/Dashboard/Settings/SettingsForm.tsx
@@ -5,7 +5,7 @@ import theme from '../../../theme'
 type Props = {
   className?: string
   children: React.ReactNode
-  onSubmit: () => void
+  onSubmit?: (event: React.FormEvent<HTMLFormElement>) => void
   errorInputName?: string
 }
 

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -190,6 +190,7 @@ export type MutationUpdateUserArgs = {
   email?: Maybe<Scalars['String']>
   name?: Maybe<Scalars['String']>
   profileImage?: Maybe<Scalars['String']>
+  bio?: Maybe<Scalars['String']>
 }
 
 export type MutationLoginUserArgs = {
@@ -483,7 +484,7 @@ export type UpdatePostCommentMutation = { __typename?: 'Mutation' } & {
 
 export type UserFragmentFragment = { __typename?: 'User' } & Pick<
   User,
-  'id' | 'name' | 'handle' | 'email' | 'userRole' | 'profileImage'
+  'id' | 'name' | 'handle' | 'email' | 'bio' | 'userRole' | 'profileImage'
 >
 
 export type UserWithLanguagesFragmentFragment = { __typename?: 'User' } & {
@@ -741,18 +742,18 @@ export type SettingsFormDataQueryVariables = {}
 export type SettingsFormDataQuery = { __typename?: 'Query' } & {
   languages?: Maybe<Array<{ __typename?: 'Language' } & LanguageFragmentFragment>>
   currentUser?: Maybe<
-    { __typename?: 'User' } & {
-      languagesLearning: Array<
-        { __typename?: 'LanguageLearning' } & Pick<LanguageLearning, 'id'> & {
-            language: { __typename?: 'Language' } & LanguageFragmentFragment
-          }
-      >
-      languagesNative: Array<
-        { __typename?: 'LanguageNative' } & Pick<LanguageNative, 'id'> & {
-            language: { __typename?: 'Language' } & LanguageFragmentFragment
-          }
-      >
-    }
+    { __typename?: 'User' } & Pick<User, 'bio'> & {
+        languagesLearning: Array<
+          { __typename?: 'LanguageLearning' } & Pick<LanguageLearning, 'id'> & {
+              language: { __typename?: 'Language' } & LanguageFragmentFragment
+            }
+        >
+        languagesNative: Array<
+          { __typename?: 'LanguageNative' } & Pick<LanguageNative, 'id'> & {
+              language: { __typename?: 'Language' } & LanguageFragmentFragment
+            }
+        >
+      }
   >
 }
 
@@ -760,6 +761,7 @@ export type UpdateUserMutationVariables = {
   email?: Maybe<Scalars['String']>
   name?: Maybe<Scalars['String']>
   profileImage?: Maybe<Scalars['String']>
+  bio?: Maybe<Scalars['String']>
 }
 
 export type UpdateUserMutation = { __typename?: 'Mutation' } & {
@@ -792,6 +794,7 @@ export const UserFragmentFragmentDoc = gql`
     name
     handle
     email
+    bio
     userRole
     profileImage
   }
@@ -2208,6 +2211,7 @@ export const SettingsFormDataDocument = gql`
       ...LanguageFragment
     }
     currentUser {
+      bio
       languagesLearning {
         id
         language {
@@ -2269,8 +2273,8 @@ export type SettingsFormDataQueryResult = ApolloReactCommon.QueryResult<
   SettingsFormDataQueryVariables
 >
 export const UpdateUserDocument = gql`
-  mutation updateUser($email: String, $name: String, $profileImage: String) {
-    updateUser(email: $email, name: $name, profileImage: $profileImage) {
+  mutation updateUser($email: String, $name: String, $profileImage: String, $bio: String) {
+    updateUser(email: $email, name: $name, profileImage: $profileImage, bio: $bio) {
       ...UserFragment
     }
   }
@@ -2297,6 +2301,7 @@ export type UpdateUserMutationFn = ApolloReactCommon.MutationFunction<
  *      email: // value for 'email'
  *      name: // value for 'name'
  *      profileImage: // value for 'profileImage'
+ *      bio: // value for 'bio'
  *   },
  * });
  */

--- a/graphql/fragments.graphql
+++ b/graphql/fragments.graphql
@@ -3,6 +3,7 @@ fragment UserFragment on User {
   name
   handle
   email
+  bio
   userRole
   profileImage
 }

--- a/graphql/user/settingsFormData.graphql
+++ b/graphql/user/settingsFormData.graphql
@@ -3,6 +3,7 @@ query settingsFormData {
     ...LanguageFragment
   }
   currentUser {
+    bio
     languagesLearning {
       id
       language {

--- a/graphql/user/updateUser.graphql
+++ b/graphql/user/updateUser.graphql
@@ -1,5 +1,5 @@
-mutation updateUser($email: String, $name: String, $profileImage: String) {
-  updateUser(email: $email, name: $name, profileImage: $profileImage) {
+mutation updateUser($email: String, $name: String, $profileImage: String, $bio: String) {
+  updateUser(email: $email, name: $name, profileImage: $profileImage, bio: $bio) {
     ...UserFragment
   }
 }

--- a/nexus/user.ts
+++ b/nexus/user.ts
@@ -114,6 +114,7 @@ schema.extendType({
         email: schema.stringArg({ required: false }),
         name: schema.stringArg({ required: false }),
         profileImage: schema.stringArg({ required: false }),
+        bio: schema.stringArg({ required: false }),
       },
       resolve: async (_parent, args, ctx: any) => {
         const { userId } = ctx.request

--- a/pages/dashboard/settings/profile.tsx
+++ b/pages/dashboard/settings/profile.tsx
@@ -35,7 +35,7 @@ const ProfileInfo: NextPage = () => {
                   learningLanguages={data?.currentUser?.languagesLearning as LanguageLearningType[]}
                   refetch={refetch}
                 />
-                <BioForm />
+                <BioForm bio={data?.currentUser?.bio || ''} />
                 <InterestsForm />
                 <SocialForm />
               </>

--- a/public/static/locales/en/settings.json
+++ b/public/static/locales/en/settings.json
@@ -27,7 +27,8 @@
     },
     "bio": {
       "legend": "Bio",
-      "bioLabel": "Tell us about yourself!"
+      "bioLabel": "Tell us about yourself!",
+      "bioSuccess": "Bio successfully updated."
     },
     "interests": {
       "legend": "Interests",
@@ -40,6 +41,9 @@
       "youtubePlaceholder": "youtube.com/c/YourChannel",
       "instagramPlaceholder": "instagram.com/YourPage",
       "personalWebsitePlaceholder": "Do you have a website?"
+    },
+    "error": {
+      "updateError": "There was an error updating your profile."
     }
   },
   "accountForm": {

--- a/public/static/locales/en/settings.json
+++ b/public/static/locales/en/settings.json
@@ -28,6 +28,8 @@
     "bio": {
       "legend": "Bio",
       "bioLabel": "Tell us about yourself!",
+      "bioError": "Your bio must be {{characters}} characters or less",
+      "bioInputDescription": "Maximum {{characters}} characters",
       "bioSuccess": "Bio successfully updated."
     },
     "interests": {


### PR DESCRIPTION
## Description

**Issue:** Part of #172 

This PR allows a user to view and update their bio 🙌🏼 It also adds minor things like displaying the dialect of languages on the `ProfileCard` and a toast success message after updating the bio. When submitting the bio form, it updates so fast that it's easy to not see the loading state of the button, so the toast message should help with that. If that pattern looks good, we can add toast success messages for the rest of the settings page updates, since it's a similar situation of updating fast and not being 100% sure if it worked or not.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Prefill bio in the bio form on the settings page and wire up the form for updating it
- [x] Show bio on the `ProfileCard`
- [x] Display dialect with languages on the `ProfileCard`
- [x] Show success and error toast messages after updating bio 

## Screenshots

### Updating your bio

![updating_bio](https://user-images.githubusercontent.com/5829188/90337105-2d383180-df95-11ea-8e43-3be0363ac6f7.gif)

### Displaying dialects on the `ProfileCard`

<img src="https://user-images.githubusercontent.com/5829188/90337111-388b5d00-df95-11ea-986d-03cd334a7435.png" width="380" />

### Showing the user's bio on the `ProfileCard`

<img src="https://user-images.githubusercontent.com/5829188/90337115-417c2e80-df95-11ea-8667-38d5adcf29b6.png" width="440" />
