### PR TITLE
Move comment submit buttons below textarea

### DIFF
--- a/components/Dashboard/Post/PostComments.tsx
+++ b/components/Dashboard/Post/PostComments.tsx
@@ -70,6 +70,7 @@ const PostComments: React.FC<PostCommentsProps> = ({
               value={postCommentBody}
               onChange={(e) => setPostCommentBody(e.target.value)}
               disabled={loading}
+              rows={4}
             />
             <Button
               type="submit"
@@ -121,20 +122,18 @@ const PostComments: React.FC<PostCommentsProps> = ({
         }
 
         .new-comment-block {
-          display: flex;
-          flex-direction: row;
           border-top: 1px solid ${theme.colors.gray400};
           margin-top: 5px;
         }
 
         .new-comment-block textarea {
-          flex: 1;
           min-height: 4em;
-          background-color: none;
+          width: 100%;
           padding: 5px;
-          font-family: 'Source Sans Pro', sans-serif;
+          background-color: transparent;
           margin-top: 10px;
           margin-right: 10px;
+          resize: vertical;
         }
 
         .new-comment-block textarea:focus {

--- a/components/InlineFeedbackPopover/index.tsx
+++ b/components/InlineFeedbackPopover/index.tsx
@@ -185,9 +185,6 @@ const Thread: React.FC<ThreadProps> = ({
                     disabled={loading}
                     className="new-comment-btn"
                     variant={ButtonVariant.PrimaryDark}
-                    style={{
-                      marginBottom: '5px',
-                    }}
                   >
                     Submit
                   </Button>
@@ -196,7 +193,6 @@ const Thread: React.FC<ThreadProps> = ({
                       onClick={() => cancelNewComment()}
                       disabled={loading}
                       variant={ButtonVariant.Secondary}
-                      className="new-comment-btn"
                     >
                       Cancel
                     </Button>
@@ -244,20 +240,18 @@ const Thread: React.FC<ThreadProps> = ({
         }
 
         .new-comment-block {
-          display: flex;
-          flex-direction: row;
           border-top: 1px solid ${theme.colors.gray400};
           margin-top: 5px;
           padding-top: 10px;
         }
 
         .new-comment-block textarea {
-          flex: 1;
           min-height: 4em;
-          background-color: #f9f9f9;
+          width: 100%;
+          background-color: transparent;
           padding: 5px 0;
-          font-family: 'Source Sans Pro', sans-serif;
           margin-right: 10px;
+          resize: vertical;
         }
 
         .new-comment-block textarea:focus {
@@ -266,12 +260,11 @@ const Thread: React.FC<ThreadProps> = ({
 
         .btn-container {
           display: flex;
-          flex-direction: column;
-          justify-content: center;
+          align-items: center;
         }
 
         .btn-container :global(.new-comment-btn) {
-          width: 100%;
+          margin-right: 10px;
         }
       `}</style>
     </div>


### PR DESCRIPTION
## Description

**Issue:** Closes: #295, fixes: #262 

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Move general comment Submit button below textarea
- [x] Move Submit button and cancel button below textarea for the thread comment popup
- [x] Add `resize: vertical;` so that the elements don't mess up the layout

## Screenshots

### Vertical resize

![vertical_resize_only](https://user-images.githubusercontent.com/5829188/90709731-b54a5f80-e251-11ea-8cc8-0d80df82c92f.gif)

### Submit and Cancel buttons

<img src="https://user-images.githubusercontent.com/5829188/90709747-bed3c780-e251-11ea-97fe-57aa49781834.png" width="525" />

### Submit button only with previous comments

<img src="https://user-images.githubusercontent.com/5829188/90709763-c72c0280-e251-11ea-9596-84aa9318f321.png" width="525" />

