### PR TITLE
Add `as` prop to `<Link>`s that point to dynamic routes to fix prefetching

### DIFF
--- a/components/Dashboard/Nav/NavLinks.tsx
+++ b/components/Dashboard/Nav/NavLinks.tsx
@@ -35,7 +35,7 @@ const NavLinks: React.FC<Props> = ({ onClick, currentUser }) => {
   return (
     <>
       <div className="nav-top">
-        <Link href={`/dashboard/profile/${currentUser.id}`}>
+        <Link href={`/dashboard/profile/[id]`} as={`/dashboard/profile/${currentUser.id}`}>
           <a onClick={onClick} className="profile-image">
             {currentUser.profileImage ? (
               <img src={currentUser.profileImage} alt="" />

--- a/components/Dashboard/Post/PostAuthorCard.tsx
+++ b/components/Dashboard/Post/PostAuthorCard.tsx
@@ -27,7 +27,7 @@ const PostAuthorCard: React.FC<PostAuthorCardProps> = ({ author }) => {
   return (
     <div className="container">
       <div className="author-info-container">
-        <Link href={`/dashboard/profile/${author.id}`}>
+        <Link href={`/dashboard/profile/[id]`} as={`/dashboard/profile/${author.id}`}>
           <a className="author-info">
             {author.profileImage ? (
               <img src={author.profileImage} alt="" />

--- a/components/Dashboard/Post/PostComment.tsx
+++ b/components/Dashboard/Post/PostComment.tsx
@@ -63,7 +63,7 @@ const PostComment: React.FC<PostCommentProps> = ({
     <div className="comment">
       <div className="author-body-container">
         <div className="author-block">
-          <Link href={`/dashboard/profile/${comment.author.id}`}>
+          <Link href={`/dashboard/profile/[id]`} as={`/dashboard/profile/${comment.author.id}`}>
             <a className="author-info">
               {comment.author.profileImage ? (
                 <img className="profile-image" src={comment.author.profileImage} alt="" />

--- a/components/Dashboard/PostCard/PostCard.tsx
+++ b/components/Dashboard/PostCard/PostCard.tsx
@@ -49,7 +49,7 @@ const PostCard: React.FC<Props> = ({
 
   return (
     <>
-      <Link href={`/post/${id}`}>
+      <Link href={'/post/[id]'} as={`/post/${id}`}>
         <a className={postCardStyles}>
           <img className="post-image" src={displayImage} alt={imageAlt} />
 


### PR DESCRIPTION
## Description

Should fix the issue where, in prod, prefetching a link resulted in a request for a non-existent .js file, and improve navigation to/from post and profile pages

https://nextjs.org/docs/api-reference/next/link#dynamic-routes