### PR TITLE
Don't show modal on new devices/browsers if the user has languages set

### DIFF
--- a/components/Modals/WelcomeModal/WelcomeModal.tsx
+++ b/components/Modals/WelcomeModal/WelcomeModal.tsx
@@ -4,24 +4,35 @@ import WelcomeModalBody from './WelcomeModalBody'
 import Button from '../../../elements/Button'
 import { LanguagesFormDataQuery, useLanguagesFormDataQuery } from '../../../generated/graphql'
 
-type Props = {
-  show: boolean
-  onClose: () => void
-}
+const welcomeModalKey = 'welcome-modal-july-2020'
 
-const WelcomeModal: React.FC<Props> = ({ show, onClose }) => {
+const WelcomeModal: React.FC = () => {
+  const hasSeenModalBefore =
+    typeof window !== 'undefined' ? localStorage.getItem(welcomeModalKey) : false
+  const [shouldShow, setShouldShow] = useState(!hasSeenModalBefore)
   const [delayedShow, setDelayedShow] = useState(false)
   const { loading, data, error, refetch } = useLanguagesFormDataQuery()
 
+  const handleClose = () => {
+    setShouldShow(false)
+    localStorage.setItem(welcomeModalKey, 'seen')
+  }
+
   useEffect(() => {
-    if (show && !loading && !error) {
+    const hasChosenLanguages =
+      data?.currentUser?.languagesNative.length && data?.currentUser?.languagesLearning.length
+
+    // If the user has native and learning languages already, don't show the modal. This also
+    // prevents the modal from showing on new devices and browsers which don't have a stored
+    // local storage value yet.
+    if (shouldShow && !loading && !error && !hasChosenLanguages) {
       setTimeout(() => {
         setDelayedShow(true)
       }, 1000)
     } else {
       setDelayedShow(false)
     }
-  }, [show, loading, error])
+  }, [shouldShow, loading, error])
 
   return delayedShow ? (
     <Modal
@@ -29,8 +40,8 @@ const WelcomeModal: React.FC<Props> = ({ show, onClose }) => {
       body={
         <WelcomeModalBody languageFormData={data as LanguagesFormDataQuery} refetch={refetch} />
       }
-      footer={<Button onClick={onClose}>Done</Button>}
-      onClose={onClose}
+      footer={<Button onClick={handleClose}>Done</Button>}
+      onClose={handleClose}
     />
   ) : null
 }

--- a/pages/dashboard/my-feed.tsx
+++ b/pages/dashboard/my-feed.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { NextPage } from 'next'
 import { withApollo } from '../../lib/apollo'
 import DashboardLayout from '../../components/Layouts/DashboardLayout'
@@ -10,24 +10,13 @@ interface InitialProps {
   namespacesRequired: string[]
 }
 
-const welcomeModalKey = 'welcome-modal-july-2020'
-
 const MyFeedPage: NextPage<InitialProps> = () => {
-  const hasSeenModalBefore =
-    typeof window !== 'undefined' ? localStorage.getItem(welcomeModalKey) : false
-  const [shouldShowWelcomeModal, setShouldShowWelcomeModal] = useState(!hasSeenModalBefore)
-
-  const handleWelcomeModalClose = () => {
-    setShouldShowWelcomeModal(false)
-    localStorage.setItem(welcomeModalKey, 'seen')
-  }
-
   return (
     <AuthGate>
       {(currentUser) => (
         <DashboardLayout>
           <MyFeed currentUser={currentUser} />
-          <WelcomeModal show={shouldShowWelcomeModal} onClose={handleWelcomeModalClose} />
+          <WelcomeModal />
         </DashboardLayout>
       )}
     </AuthGate>


### PR DESCRIPTION
## Description

**Issue:** Closes: #313 

Don't show the modal to existing users who have seen the welcome modal and already have native and learning languages set.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Test with old and new users
- [x] Test different browsers and scenarios
