### PR TITLE
Add empty states to lists of posts

### DIFF
--- a/components/Dashboard/MyPosts/MyPosts.tsx
+++ b/components/Dashboard/MyPosts/MyPosts.tsx
@@ -5,6 +5,8 @@ import {
   User as UserType,
   usePostsQuery,
 } from '../../../generated/graphql'
+import { useTranslation, Trans } from '../../../config/i18n'
+import TranslationLink from '../../TranslationLink'
 import LoadingSpinner from '../../Icons/LoadingSpinner'
 import PostCard from '../PostCard'
 import theme from '../../../theme'
@@ -15,6 +17,7 @@ type Props = {
 }
 
 const MyPosts: React.FC<Props> = ({ currentUser, status }) => {
+  const { t } = useTranslation('my-posts')
   const { loading, data, error } = usePostsQuery({
     variables: {
       status,
@@ -23,18 +26,33 @@ const MyPosts: React.FC<Props> = ({ currentUser, status }) => {
   })
 
   let posts = (data?.posts as PostType[]) || []
+  const showPosts = !loading && posts.length > 0
+  const showEmptyState = !loading && posts.length === 0
 
   return (
     <div className="my-posts-container">
       {error && <p>There was an error retrieving your posts.</p>}
 
-      {loading ? (
-        <LoadingSpinner size={60} />
-      ) : (
+      {loading && <LoadingSpinner size={60} />}
+
+      {showPosts && (
         <div className="my-posts">
-          {posts?.map((post) => (
+          {posts.map((post) => (
             <PostCard key={post.id} post={post} status={status} />
           ))}
+        </div>
+      )}
+
+      {showEmptyState && (
+        <div>
+          {status === PostStatusType.Published ? (
+            <Trans i18nKey="publishedEmptyState">
+              You have no published posts. You can either publish a draft or{' '}
+              <TranslationLink href="/dashboard/new-post">create a new post</TranslationLink>.
+            </Trans>
+          ) : (
+            t('draftEmptyState')
+          )}
         </div>
       )}
 

--- a/components/Dashboard/Profile/PostList.tsx
+++ b/components/Dashboard/Profile/PostList.tsx
@@ -1,24 +1,38 @@
 import React from 'react'
-import { useTranslation } from '../../../config/i18n'
+import { useTranslation, Trans } from '../../../config/i18n'
+import { PostCardFragmentFragment as PostType, User as UserType } from '../../../generated/graphql'
 import { layoutTopBottomPadding, layoutLeftRightPadding } from '../../Dashboard/dashboardConstants'
-import {
-  PostCardFragmentFragment as PostType,
-} from '../../../generated/graphql'
+import TranslationLink from '../../TranslationLink'
 import PostCard from '../PostCard'
 import theme from '../../../theme'
 
 type Props = {
+  isLoggedInUser: boolean
+  user: UserType
   posts: PostType[]
 }
 
-const PostList: React.FC<Props> = ({ posts }) => {
+const PostList: React.FC<Props> = ({ isLoggedInUser, user, posts }) => {
   const { t } = useTranslation(['profile'])
 
   return (
     <div className="post-list">
       <h1 className="posts-title">{t('postsTitle')}</h1>
 
-      { posts.map((post) => <PostCard key={post.id} post={post} />) }
+      {posts.length ? (
+        posts.map((post) => <PostCard key={post.id} post={post} />)
+      ) : (
+        <div className="empty-list">
+          {isLoggedInUser ? (
+            <Trans>
+              You have no recent posts.{' '}
+              <TranslationLink href="/dashboard/new-post">Write a new post</TranslationLink>!
+            </Trans>
+          ) : (
+            t('emptyPosts', { user: user.name || user.handle })
+          )}
+        </div>
+      )}
 
       <style jsx>{`
         .post-list {

--- a/components/Dashboard/Profile/Profile.tsx
+++ b/components/Dashboard/Profile/Profile.tsx
@@ -2,19 +2,23 @@ import React from 'react'
 import ProfileCard from './ProfileCard'
 import PostList from './PostList'
 import { layoutPadding } from '../../Dashboard/dashboardConstants'
-import { User as UserType, PostCardFragmentFragment as PostCardType } from '../../../generated/graphql'
+import {
+  User as UserType,
+  PostCardFragmentFragment as PostCardType,
+} from '../../../generated/graphql'
 import theme from '../../../theme'
 
 type Props = {
-  user: UserType | any
+  isLoggedInUser: boolean
+  user: UserType
   posts: PostCardType[]
 }
 
-const Profile: React.FC<Props> = ({ user, posts }) => {
+const Profile: React.FC<Props> = ({ isLoggedInUser, user, posts }) => {
   return (
     <div className="profile-wrapper">
       <ProfileCard user={user} />
-      <PostList posts={posts} />
+      <PostList isLoggedInUser={isLoggedInUser} user={user} posts={posts} />
 
       <style jsx>{`
         .profile-wrapper {

--- a/components/TranslationLink/TranslationLink.tsx
+++ b/components/TranslationLink/TranslationLink.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import Link, { LinkProps } from 'next/link'
+
+const TranslationLink: React.FC<LinkProps> = ({ href, children, ...props }) => {
+  return (
+    <Link href={href} {...props}>
+      <a className="j-link">{children}</a>
+    </Link>
+  )
+}
+
+export default TranslationLink

--- a/components/TranslationLink/index.ts
+++ b/components/TranslationLink/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TranslationLink'

--- a/docs/1-internationalization.md
+++ b/docs/1-internationalization.md
@@ -41,3 +41,5 @@ export function MyComponent() {
   return <h1>{t('title', { user })}</h1>
 }
 ```
+
+If you have DOM elements within your translation, use the [Trans component](https://react.i18next.com/latest/trans-component). If your translated text uses the Next.js `<Link />` component (or our custom `<NavLink />` component), then you'll have to use `<TranslationLink />` instead, as `<Link />` expects a single child element and the react-i18next [passes the children down as a string](https://github.com/i18next/react-i18next/issues/1090#issuecomment-615426145), causing a rendering error.

--- a/public/static/locales/en/my-posts.json
+++ b/public/static/locales/en/my-posts.json
@@ -1,0 +1,4 @@
+{
+  "publishedEmptyState": "You have no published posts. You can either publish a draft or <1>create a new post</1>.",
+  "draftEmptyState": "You have no drafts."
+}

--- a/public/static/locales/en/profile.json
+++ b/public/static/locales/en/profile.json
@@ -4,5 +4,7 @@
     "learns": "learns",
     "likes": "likes"
   },
-  "postsTitle": "Recent Posts"
+  "postsTitle": "Recent Posts",
+  "emptyPosts": "{{user}} hasn't written any posts yet.",
+  "loggedInUserEmptyPosts": "You have no recent posts. <1>Write a new post</1>!"
 }


### PR DESCRIPTION
## Description

**Issue:** Closes #315 

A few of our lists of posts don't have any empty state. This PR adds an empty state to the list of published posts and drafts on the My Posts page as well as the Recent posts section of the user profile. Additionally, the profile now is aware of whether the profile is being viewed by the logged in user or someone else. This can allow future features like CTA text on the ProfileCard, prompting the logged in user to add missing profile details.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Add empty states for My Posts

## Screenshots

### My Posts

#### Published

<img src="https://user-images.githubusercontent.com/5829188/90994892-171b0a00-e56f-11ea-86b2-c03bd137ac66.png" width="525" />

#### Drafts

<img src="https://user-images.githubusercontent.com/5829188/90994885-11bdbf80-e56f-11ea-9c22-606956fecf5f.png" width="525" />

### Profile Page - Recent Posts

#### Logged in user is viewing someone else's profile

<img src="https://user-images.githubusercontent.com/5829188/90994874-0d91a200-e56f-11ea-9dc6-240d4a7644e5.png" width="525" />

#### Logged in user is viewing their own profile

<img src="https://user-images.githubusercontent.com/5829188/90994867-0bc7de80-e56f-11ea-8226-5a4c95ad2206.png" width="525" />