### PR TITLE
Order languages alphabetically

### DIFF
--- a/nexus/language.ts
+++ b/nexus/language.ts
@@ -141,7 +141,12 @@ schema.extendType({
           filter = undefined
         }
 
-        return ctx.db.language.findMany({ where: filter })
+        return ctx.db.language.findMany({
+          where: filter,
+          orderBy: {
+            name: 'asc',
+          },
+        })
       },
     })
   },


### PR DESCRIPTION
## Description

**Issue:** closes #317 

Currently the ordering of languages in the dropdowns is random and now we have a lot of languages in there.
This PR orders them alphabetically.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] add `orderBy` clause to `languages` query

## Screenshots
