### PR TITLE
LineClamp the PostCard title and excerpt

### DIFF
--- a/components/Dashboard/PostCard/PostCard.tsx
+++ b/components/Dashboard/PostCard/PostCard.tsx
@@ -176,7 +176,12 @@ const PostCard: React.FC<Props> = ({
           display: flex;
           align-items: center;
           justify-content: space-between;
-          margin-top: 14px;
+          margin-top: 24px;
+        }
+        @media (min-width: ${theme.breakpoints.MD}) {
+          .post-avatar-and-data:not(.stacked) {
+            margin-top: 14px;
+          }
         }
 
         .stacked .post-avatar-and-data {

--- a/components/Dashboard/PostCard/PostCard.tsx
+++ b/components/Dashboard/PostCard/PostCard.tsx
@@ -7,6 +7,7 @@ import {
   PostStatus as PostStatusType,
   PostCardFragmentFragment as PostCardType,
 } from '../../../generated/graphql'
+import LineClamp from '../../../elements/LineClamp'
 import LikeIcon from '../../Icons/LikeIcon'
 import CommentIcon from '../../Icons/CommentIcon'
 import theme from '../../../theme'
@@ -55,8 +56,12 @@ const PostCard: React.FC<Props> = ({
 
           <div className="post-card-details">
             <div className="post-text" dir="auto">
-              <h1 className="post-title">{title}</h1>
-              <p className="post-excerpt">{excerpt}</p>
+              <h1 className="post-title">
+                <LineClamp lines={1} text={title} />
+              </h1>
+              <p className="post-excerpt">
+                <LineClamp lines={2} text={excerpt} />
+              </p>
             </div>
 
             <div className="post-avatar-and-data">
@@ -171,7 +176,7 @@ const PostCard: React.FC<Props> = ({
           display: flex;
           align-items: center;
           justify-content: space-between;
-          margin-top: 12px;
+          margin-top: 14px;
         }
 
         .stacked .post-avatar-and-data {

--- a/elements/LineClamp/LineClamp.tsx
+++ b/elements/LineClamp/LineClamp.tsx
@@ -17,6 +17,7 @@ const LineClamp: React.FC<Props> = ({ lines, text }) => {
           overflow: hidden;
           display: -webkit-box;
           text-overflow: ellipsis;
+          word-break: break-all;
         }
       `}</style>
     </div>

--- a/elements/LineClamp/LineClamp.tsx
+++ b/elements/LineClamp/LineClamp.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+
+type Props = {
+  lines: number
+  text: string
+}
+
+const LineClamp: React.FC<Props> = ({ lines, text }) => {
+  return (
+    <div className="text-wrapper">
+      <div className="text-to-clamp">{text}</div>
+
+      <style jsx>{`
+        .text-to-clamp {
+          -webkit-line-clamp: ${lines};
+          -webkit-box-orient: vertical;
+          overflow: hidden;
+          display: -webkit-box;
+          text-overflow: ellipsis;
+        }
+      `}</style>
+    </div>
+  )
+}
+
+export default LineClamp

--- a/elements/LineClamp/index.ts
+++ b/elements/LineClamp/index.ts
@@ -1,0 +1,1 @@
+export { default } from './LineClamp'


### PR DESCRIPTION
## Description

**Issue:** Closes #322 

Exploratory PR to see if line clamping the `PostCard` title and excerpt looks good and is something that we want to do. Right now, the excerpts on each `PostCard` can be a different number of lines, so the `PostCard` content isn't able to line up nicely with the accompanying image.

🚨 Note: 🚨 we can have a custom number of lines clamped, for example on the My Feed page. See screenshots below labeled "Custom number of lines clamped"

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Create `<LineClamp />` for clamping any text to a specific amount of lines
- [x] Align margin-top for stacked `PostCard`s
  - The My Feed page uses the `stacked` prop on the `PostCard`, which ensures that the `PostCard` always has the image on top and that the horizontal layout (image on the left, content on the right) is never shown. With the stacked prop, the `margin-top` between the post excerpt and the post stats is 24px. When not using the `stacked` prop, the `PostCard` still appears as "stacked" for small screens, but it was using 14px `margin-top`. Now whenever the `PostCard` is "stacked", whether from the prop or just naturally appearing that way because of responsiveness, they will have `margin-top: 24px;` and look exactly the same.
- [x] Check that other languages like Chinese, Japanese, and Korean look correct with the ellipsis
  - [x] Chinese
  - [x] Japanese
  - [x] Korean
- [x] Check that it works on various browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari

## Screenshots

### New change vs in production

#### New change

![image](https://user-images.githubusercontent.com/5829188/91379988-bb53b980-e7d8-11ea-8949-a94514f01b19.png)

#### Currently in production

![image](https://user-images.githubusercontent.com/5829188/91379991-bdb61380-e7d8-11ea-991e-3f488a490b2c.png)

#### New change

![image](https://user-images.githubusercontent.com/5829188/91379999-c3abf480-e7d8-11ea-879a-7a6947024e23.png)

#### Currently in production

![image](https://user-images.githubusercontent.com/5829188/91380004-c60e4e80-e7d8-11ea-95ef-9cc1d532b7ec.png)

#### Custom number of lines clamped

![image](https://user-images.githubusercontent.com/5829188/91380424-c824dd00-e7d9-11ea-96bf-a6e1d9791a60.png)

### My Feed

![image](https://user-images.githubusercontent.com/5829188/91379495-b3dfe080-e7d7-11ea-9deb-a85a5e127fcc.png)

### Profile

![image](https://user-images.githubusercontent.com/5829188/91379555-ce19be80-e7d7-11ea-83eb-0abbadce1e0b.png)

### My Posts

![image](https://user-images.githubusercontent.com/5829188/91379576-dffb6180-e7d7-11ea-8414-cd2c4637476e.png)

### Custom number of lines clamped

![image](https://user-images.githubusercontent.com/5829188/91380434-ce1abe00-e7d9-11ea-862f-ce519323dc6a.png)
