### PR TITLE
Put back removed withPadding={false}

### DIFF
--- a/pages/dashboard/profile/[id]/index.tsx
+++ b/pages/dashboard/profile/[id]/index.tsx
@@ -35,7 +35,7 @@ const ProfilePage: NextPage<InitialProps> = () => {
 
   return (
     <LoadingWrapper loading={isLoading} error={hasError}>
-      <DashboardLayout>
+      <DashboardLayout withPadding={false}>
         <Profile
           isLoggedInUser={userData?.currentUser?.id === userId}
           user={profileData?.userById as UserType}


### PR DESCRIPTION
## Description

**Issue:** Closes: #321 

In #273, a new profile page was created that uses the id of the user in the URL. The old profile page was using `withPadding={false}` on the `<DashboardLayout />` because the profile page is full width on mobile and needs to override the default padding that's used on all the other pages and set by `DashboardLayout`. This PR simply puts back that removed prop.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Put back the removed `withPadding={false}`

## Screenshots

![image](https://user-images.githubusercontent.com/5829188/91461222-95accb80-e83d-11ea-95bd-4c324d7f87c1.png)


![image](https://user-images.githubusercontent.com/5829188/91461224-97768f00-e83d-11ea-904c-b4b1f2b95452.png)

