### PR TITLE
Fix Thread Deletion Bug

### DIFF
--- a/nexus/comment.ts
+++ b/nexus/comment.ts
@@ -104,6 +104,7 @@ schema.mutationType({
           },
           include: {
             comments: true,
+            subscriptions: true,
           },
         })
 
@@ -113,6 +114,11 @@ schema.mutationType({
           throw new Error('Cannot delete a thread containing comments.')
         }
 
+        await ctx.db.threadSubscription.deleteMany({
+          where: {
+            threadId: thread.id,
+          },
+        })
         return ctx.db.thread.delete({
           where: {
             id: args.threadId,

--- a/nexus/comment.ts
+++ b/nexus/comment.ts
@@ -104,7 +104,6 @@ schema.mutationType({
           },
           include: {
             comments: true,
-            subscriptions: true,
           },
         })
 


### PR DESCRIPTION
## Description

**Issue:** fixes #331 

Fixes the thread deletion bug so that for the time being we manually delete all associated `threadSubscription`s before deleting the thread itself.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Fix the thang

## Screenshots
