### PR TITLE
Redirect Logged In Users To Dashboard Automatically

### DIFF
--- a/components/Layouts/LandingPageLayout.tsx
+++ b/components/Layouts/LandingPageLayout.tsx
@@ -1,11 +1,32 @@
+import { useRouter } from 'next/router'
+import LoadingWrapper from '../LoadingWrapper'
+import { useCurrentUserQuery, User as UserType } from '../../generated/graphql'
 import Nav from '../Site/Nav'
 
-const LandingPageLayout: React.FC = ({ children }) => (
-  <div>
-    <Nav />
+const LandingPageLayout: React.FC = ({ children }) => {
+  const router = useRouter()
+  const { data, loading, error } = useCurrentUserQuery()
 
-    {children}
-  </div>
-)
+  const currentUser = data?.currentUser as UserType
+
+  if (loading || error) {
+    return null
+  }
+
+  if (currentUser && typeof window !== 'undefined') {
+    router.push({
+      pathname: '/dashboard/my-feed',
+    })
+
+    return null
+  }
+
+  return (
+    <LoadingWrapper loading={loading} error={error}>
+      <Nav />
+      {children}
+    </LoadingWrapper>
+  )
+}
 
 export default LandingPageLayout


### PR DESCRIPTION
## Description

**Issue:** closes #341 

### Background

- We've had quite a high % of alpha users report pain points around journaly.com not automatically taking them to their dashboard once they're signed up and logged in.
- I discussed this with Lindie and she made the point that once she's signed up and logged in, there's really no reason for her to go back to the landing page.


This PR automatically redirects logged in users to the dashboard.

**NOTE**:
We'll have to think about the blog but I think it's not too important for now.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Do the thang

