### PR TITLE
🚨 Sign up broken: Revert changes to signup form regex

### DIFF
--- a/components/SignupForm/SignupForm.tsx
+++ b/components/SignupForm/SignupForm.tsx
@@ -78,7 +78,7 @@ const SignupForm: React.FC = () => {
             ref={register({
               required: `${t('emailRequiredErrorMessage')}`,
               pattern: {
-                value: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[A-Z]{2,}$/,
+                value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
                 message: `${t('emailValidationErrorMessage')}`,
               },
             })}


### PR DESCRIPTION
## Description

**Issue:** fixes #344 

Sign up is broken in production, reported to a new Patreon supporter who was trying to sign up today. This PR reverts the last changes we made to the regex validating the email input in the signup form.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Revert regex

## Screenshots

![image](https://user-images.githubusercontent.com/34203886/94329503-6e4a3b00-ff70-11ea-907a-3dbb768223fa.png)
