### PR TITLE
Add number of thanks for each comment

### DIFF
--- a/components/InlineFeedbackPopover/Comment.tsx
+++ b/components/InlineFeedbackPopover/Comment.tsx
@@ -36,6 +36,8 @@ const Comment: React.FC<CommentProps> = ({ comment, canEdit, onUpdateComment, cu
   const hasThankedComment =
     comment.thanks.find((thanks) => thanks.author.id === currentUserId) !== undefined
 
+  const numThanks = comment.thanks.length
+
   const [updateComment, { loading }] = useUpdateCommentMutation({
     onCompleted: () => {
       onUpdateComment()
@@ -189,6 +191,7 @@ const Comment: React.FC<CommentProps> = ({ comment, canEdit, onUpdateComment, cu
           >
             <LikeIcon filled={hasThankedComment} />
           </span>
+          <span className="thanks-count">{numThanks}</span>
         </div>
       )}
       <style jsx>{`
@@ -276,6 +279,10 @@ const Comment: React.FC<CommentProps> = ({ comment, canEdit, onUpdateComment, cu
         }
         .like-btn :global(svg:hover) {
           cursor: pointer;
+        }
+
+        .thanks-count {
+          color: ${theme.colors.gray600};
         }
 
         textarea {


### PR DESCRIPTION
## Description

**Issue:** #348 

I think it will really help to add another really nice extra touch of community sentiment by displaying how many people have shown thanks for a certain comment/piece of feedback 🙂

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Add thanks count

## Screenshots

![thanks-count-preview-2](https://user-images.githubusercontent.com/34203886/94761208-4cc6c600-0359-11eb-9d1c-7a9d7993cb0e.gif)

