### PR TITLE
Language Levels - UI

### DIFF
--- a/components/Dashboard/Post/Post.tsx
+++ b/components/Dashboard/Post/Post.tsx
@@ -386,16 +386,12 @@ const Post: React.FC<IPostProps> = ({ post, currentUser, refetch }: IPostProps) 
             (post.images || []).find((i: ImageType) => i.imageRole === ImageRole.Headline)
               ?.largeSize || '/images/samples/sample-post-img.jpg'
           }
+          postTopics={post.postTopics}
+          postLanguage={post.language}
         />
         <div className="post-body selectable-text-area" dir="auto" onClick={onThreadClick}>
           <PostContent body={post.body} ref={selectableRef} />
         </div>
-
-        { post.postTopics.length ? (
-          <span className="topics-list">
-            Topics: {post.postTopics.map(({ topic }) => topic.name).join(', ')}
-          </span>
-        ) : null}
 
         {currentUser && post.author.id === currentUser.id && (
           <div className="post-controls">

--- a/components/Dashboard/Post/PostAuthorCard.tsx
+++ b/components/Dashboard/Post/PostAuthorCard.tsx
@@ -159,6 +159,11 @@ const PostAuthorCard: React.FC<PostAuthorCardProps> = ({ author }) => {
           border-bottom: 1px solid ${theme.colors.gray400};
         }
 
+        .language-list {
+          display: flex;
+          flex-wrap: wrap;
+        }
+
         .language-list li {
           display: inline-block;
           margin-right: 8px;

--- a/components/Dashboard/Post/PostAuthorCard.tsx
+++ b/components/Dashboard/Post/PostAuthorCard.tsx
@@ -6,12 +6,12 @@ import {
   useFollowUserMutation,
   useUnfollowUserMutation,
   useFollowingUsersQuery,
-  LanguageLevel,
 } from '../../../generated/graphql'
 import { useTranslation } from '../../../config/i18n'
 import BlankAvatarIcon from '../../Icons/BlankAvatarIcon'
 import { languageNameWithDialect } from '../../../utils/languages'
 import Button, { ButtonVariant } from '../../../elements/Button'
+import LevelGauge from '../../../elements/LevelGauge'
 
 type PostAuthorCardProps = {
   author: Author
@@ -20,10 +20,6 @@ type PostAuthorCardProps = {
 const PostAuthorCard: React.FC<PostAuthorCardProps> = ({ author }) => {
   const { t } = useTranslation('post-author-card')
   const { languages } = author
-
-  
-  const speaksList = languages.filter((language) => language.level === LanguageLevel.Native)
-  const learnsList = languages.filter((language) => language.level !== LanguageLevel.Native)
 
   const { data: { currentUser } = {}, refetch } = useFollowingUsersQuery()
 
@@ -82,16 +78,15 @@ const PostAuthorCard: React.FC<PostAuthorCardProps> = ({ author }) => {
         )}
       </div>
       <div className="language-info">
-        <p className="author-info-heading">{t('nativeHeader')}</p>
+        <p className="author-info-heading">{t('languagesHeader')}</p>
         <ul className="language-list">
-          {speaksList.map(({ language }) => {
-            return <li key={language.id}>{languageNameWithDialect(language)}</li>
-          })}
-        </ul>
-        <p className="author-info-heading">{t('learningHeader')}</p>
-        <ul className="language-list">
-          {learnsList.map(({ language }) => {
-            return <li key={language.id}>{languageNameWithDialect(language)}</li>
+          {languages.map((language) => {
+            return (
+              <div>
+                <li key={language.language.id}>{languageNameWithDialect(language.language)}</li>
+                <LevelGauge level={language.level} />
+              </div>
+            )
           })}
         </ul>
       </div>

--- a/components/Dashboard/PostCard/PostCard.tsx
+++ b/components/Dashboard/PostCard/PostCard.tsx
@@ -6,6 +6,7 @@ import { formatShortDate } from '../../../utils/date'
 import {
   PostStatus as PostStatusType,
   PostCardFragmentFragment as PostCardType,
+  LanguageLevel,
 } from '../../../generated/graphql'
 import LineClamp from '../../../elements/LineClamp'
 import LikeIcon from '../../Icons/LikeIcon'
@@ -37,17 +38,18 @@ const PostCard: React.FC<Props> = ({
     images,
     likes,
     commentCount,
-    author: { handle, name, profileImage },
+    author: { handle, name, profileImage, languages: authorLanguages },
     createdAt,
     publishedAt,
-    language: { name: languageName },
+    language: { id: postLanguageId, name: languageName },
   } = post
   const isDraft = status === PostStatusType.Draft
   const isPublished = status === PostStatusType.Published
   const displayImage = images.length ? images[0].smallSize : '/images/samples/sample-post-img.jpg'
   const imageAlt = images.length === 0 ? 'Typewriter on an old wooden desk' : ''
   const postCardStyles = classNames('post-card-container', { stacked })
-
+  const authorLanguageLevel = authorLanguages.filter(({ language }) => language.id === postLanguageId)[0]?.level || LanguageLevel.Beginner
+  
   return (
     <>
       <Link href={'/post/[id]'} as={`/post/${id}`}>
@@ -76,7 +78,10 @@ const PostCard: React.FC<Props> = ({
 
                     <p className="author">{handle || name}</p>
                   </div>
-                  <p className="post-language">{languageName}</p>
+                  <div className="language-level-container">
+                    <p className="post-language">{languageName}</p>
+                    <p className="post-language">{authorLanguageLevel}</p>
+                  </div>
                 </div>
               )}
 
@@ -266,6 +271,10 @@ const PostCard: React.FC<Props> = ({
             color: ${theme.colors.blue};
             text-transform: uppercase;
           }
+        }
+
+        .language-level-container p:first-child {
+          margin-right: 5px;
         }
       `}</style>
     </>

--- a/components/Dashboard/Profile/PostList.tsx
+++ b/components/Dashboard/Profile/PostList.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useTranslation, Trans } from '../../../config/i18n'
-import { PostCardFragmentFragment as PostType, User as UserType } from '../../../generated/graphql'
+import { PostCardFragmentFragment as PostType, UserWithLanguagesFragmentFragment as UserType } from '../../../generated/graphql'
 import { layoutTopBottomPadding, layoutLeftRightPadding } from '../../Dashboard/dashboardConstants'
 import TranslationLink from '../../TranslationLink'
 import PostCard from '../PostCard'

--- a/components/Dashboard/Profile/Profile.tsx
+++ b/components/Dashboard/Profile/Profile.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import ProfileCard from './ProfileCard'
 import PostList from './PostList'
-import { layoutPadding } from '../../Dashboard/dashboardConstants'
 import {
   User as UserType,
   PostCardFragmentFragment as PostCardType,
@@ -24,12 +23,12 @@ const Profile: React.FC<Props> = ({ isLoggedInUser, user, posts }) => {
         .profile-wrapper {
           display: flex;
           flex-direction: column;
-          height: 100%;
+          height: 100vh;
         }
         @media (min-width: ${theme.breakpoints.MD}) {
           .profile-wrapper {
             flex-direction: row;
-            padding: ${layoutPadding};
+            padding: 25px;
           }
 
           .profile-wrapper > :global(div) {

--- a/components/Dashboard/Profile/Profile.tsx
+++ b/components/Dashboard/Profile/Profile.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import ProfileCard from './ProfileCard'
 import PostList from './PostList'
 import {
-  User as UserType,
+  UserWithLanguagesFragmentFragment as UserType,
   PostCardFragmentFragment as PostCardType,
 } from '../../../generated/graphql'
 import theme from '../../../theme'

--- a/components/Dashboard/Profile/ProfileCard.tsx
+++ b/components/Dashboard/Profile/ProfileCard.tsx
@@ -8,7 +8,7 @@ import ExternalLink from '../../../elements/ExternalLink'
 import { sanitize } from '../../../utils'
 import { languageNameWithDialect } from '../../../utils/languages'
 import theme from '../../../theme'
-import { User as UserType, LanguageLevel } from '../../../generated/graphql'
+import { UserWithLanguagesFragmentFragment as UserType, LanguageLevel } from '../../../generated/graphql'
 import BlankAvatarIcon from '../../Icons/BlankAvatarIcon'
 
 type Props = {
@@ -17,7 +17,7 @@ type Props = {
 
 const ProfileCard: React.FC<Props> = ({ user }) => {
   const { t } = useTranslation('profile')
-
+  
   const sampleUser = {
     likes: ['cooking, reading, movies, design'],
     location: 'San Francisco, United States',

--- a/components/Dashboard/Profile/ProfileCard.tsx
+++ b/components/Dashboard/Profile/ProfileCard.tsx
@@ -56,9 +56,14 @@ const ProfileCard: React.FC<Props> = ({ user }) => {
           <p>
             <span>{t('card.learns')}:</span> {learns.join(', ')}
           </p>
-          {sampleUser.likes.length && (
+          {/* {sampleUser.likes.length && (
             <p>
               <span>{t('card.likes')}:</span> {sampleUser.likes.join(', ')}
+            </p>
+          )} */}
+          {sampleUser.likes.length && (
+            <p>
+              <span>{t('card.likes')}:</span> languages, journaling
             </p>
           )}
         </div>

--- a/components/Dashboard/Settings/DetailsForm.tsx
+++ b/components/Dashboard/Settings/DetailsForm.tsx
@@ -149,6 +149,7 @@ const DetailsForm: React.FC<DetailsFormProps> = ({ currentUser }) => {
                   id="location"
                   name="location"
                   className="j-field"
+                  placeholder="Coming soon..."
                   ref={register()}
                   disabled={true}
                 />

--- a/components/Dashboard/Settings/InterestsForm.tsx
+++ b/components/Dashboard/Settings/InterestsForm.tsx
@@ -27,6 +27,8 @@ const InterestsForm: React.FC = () => {
               name="interests"
               className="j-field"
               ref={register()}
+              placeholder="Coming soon..."
+              disabled={true}
             />
           </div>
 
@@ -34,6 +36,7 @@ const InterestsForm: React.FC = () => {
             type="submit"
             className="settings-submit-button"
             variant={ButtonVariant.Secondary}
+            disabled={true}
           >
             {t('updateButton')}
           </Button>

--- a/components/Dashboard/Settings/SocialForm.tsx
+++ b/components/Dashboard/Settings/SocialForm.tsx
@@ -28,7 +28,9 @@ const SocialForm: React.FC = () => {
               <input
                 type="text"
                 name="facebook"
-                placeholder={t('profile.social.facebookPlaceholder')}
+                // placeholder={t('profile.social.facebookPlaceholder')}
+                placeholder="Coming soon..."
+                disabled={true}
                 className="j-field"
                 ref={register()}
               />
@@ -38,7 +40,9 @@ const SocialForm: React.FC = () => {
               <input
                 type="text"
                 name="instagram"
-                placeholder={t('profile.social.instagramPlaceholder')}
+                // placeholder={t('profile.social.instagramPlaceholder')}
+                placeholder="Coming soon..."
+                disabled={true}
                 className="j-field"
                 ref={register()}
               />
@@ -48,7 +52,9 @@ const SocialForm: React.FC = () => {
               <input
                 type="text"
                 name="youtube"
-                placeholder={t('profile.social.youtubePlaceholder')}
+                // placeholder={t('profile.social.youtubePlaceholder')}
+                placeholder="Coming soon..."
+                disabled={true}
                 className="j-field"
                 ref={register()}
               />
@@ -58,7 +64,9 @@ const SocialForm: React.FC = () => {
               <input
                 type="text"
                 name="personal-website"
-                placeholder={t('profile.social.personalWebsitePlaceholder')}
+                // placeholder={t('profile.social.personalWebsitePlaceholder')}
+                placeholder="Coming soon..."
+                disabled={true}
                 className="j-field"
                 ref={register()}
               />
@@ -69,6 +77,7 @@ const SocialForm: React.FC = () => {
             type="submit"
             className="settings-submit-button"
             variant={ButtonVariant.Secondary}
+            disabled={true}
           >
             {t('updateButton')}
           </Button>

--- a/components/PostEditor/PostEditor.tsx
+++ b/components/PostEditor/PostEditor.tsx
@@ -177,7 +177,8 @@ const PostEditor: React.FC<PostEditorProps> = ({
         selectedOptionValues={selectedTopics}
         onAdd={addTopic}
         onRemove={removeTopic}
-        placeholder="Select a topic"
+        placeholder="Select up to five topics"
+        disabled={selectedTopics.length >= 5}
       />
 
       <div className="header-preview-container">

--- a/components/PostHeader/PostHeader.tsx
+++ b/components/PostHeader/PostHeader.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { PostStatus } from '../../generated/graphql'
+import { PostStatus, PostTopicFragmentFragment as PostTopicType, LanguageFragmentFragment as LanguageType } from '../../generated/graphql'
 import { useTranslation } from '../../config/i18n'
 import { formatLongDate } from '../../utils'
 
@@ -12,6 +12,8 @@ type PostHeaderProps = {
   publishDate: string
   authorName: string
   postImage: string
+  postTopics?: PostTopicType[]
+  postLanguage?: LanguageType
   children?: React.ReactNode
 }
 
@@ -22,6 +24,8 @@ const PostHeader: React.FC<PostHeaderProps> = ({
   authorName,
   publishDate,
   postImage,
+  postTopics,
+  postLanguage,
 }) => {
   const { t } = useTranslation('post')
   return (
@@ -35,7 +39,13 @@ const PostHeader: React.FC<PostHeaderProps> = ({
         </p>
         <p>{formatLongDate(publishDate)}</p>
       </div>
-      {postStatus === 'DRAFT' && <div className="draft-badge">{t('draft')}</div>}
+      <div className="language badge">{postLanguage?.name}</div>
+      {postStatus === 'DRAFT' && <div className="draft badge">{t('draft')}</div>}
+      <div className="topics-container">
+        {postTopics?.map(({ topic }) => (
+          <div className="topic-badge" key={topic.id}>{topic.name}</div>
+        ))}
+      </div>
       {children}
       <style jsx>{`
         .post-header {
@@ -46,10 +56,8 @@ const PostHeader: React.FC<PostHeaderProps> = ({
           margin-bottom: 40px;
         }
 
-        .draft-badge {
+        .badge {
           position: absolute;
-          top: 10px;
-          right: 10px;
 
           line-height: 1;
           padding: 2px 5px;
@@ -60,6 +68,42 @@ const PostHeader: React.FC<PostHeaderProps> = ({
           border-radius: 4px;
           font-weight: bold;
           font-size: 12px;
+        }
+
+        .draft {
+          top: 10px;
+          right: 10px;
+        }
+
+        .language {
+          top: 10px;
+          left: 10px;
+        }
+
+        .topics-container {
+          position: absolute;
+          bottom: 10px;
+          left: 50%;
+          transform: translate(-50%);
+          display: flex;
+          flex: 1;
+          width: 100%;
+          justify-content: center;
+          flex-wrap: wrap;
+        }
+
+        .topic-badge {
+          line-height: 1;
+          padding: 2px 5px;
+          margin-right: 5px;
+          color: white;
+
+          text-transform: uppercase;
+          border: 2px solid white;
+          border-radius: 4px;
+          font-weight: bold;
+          font-size: 12px;
+          margin-bottom: 5px;
         }
 
         img {

--- a/elements/LevelGauge/LevelGauge.tsx
+++ b/elements/LevelGauge/LevelGauge.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import { LanguageLevel } from '../../generated/graphql'
+import {languageLevelToNumber} from '../../utils/languages'
+import theme from '../../theme'
+
+type Props = {
+  level: LanguageLevel
+}
+
+const LevelGauge: React.FC<Props> = ({ level }) => {
+  const levelNum = languageLevelToNumber(level) + 1
+  
+  return (
+    <div>
+      <span />
+      <span />
+      <span />
+      <span />
+      <style jsx>{`
+        div {
+          display: flex;
+          margin-left: 2px;
+        } 
+        span {
+          height: 10px;
+          width: 2px;
+          background: ${theme.colors.gray400};
+          border-radius: 1px;
+          margin-right: 4px;
+        }
+
+        span:nth-child(-n+${levelNum}) {
+          background: ${theme.colors.blueLight}
+        }
+      `}
+      </style>
+    </div>
+  )
+}
+
+export default LevelGauge

--- a/elements/LevelGauge/index.tsx
+++ b/elements/LevelGauge/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './LevelGauge'

--- a/elements/MultiSelect/MultiSelect.tsx
+++ b/elements/MultiSelect/MultiSelect.tsx
@@ -14,6 +14,7 @@ type Props<T extends OptionValue> = {
   loading?: boolean
   onAdd?: (value: T) => void
   onRemove?: (value: T) => void
+  disabled: boolean
 }
 
 /*
@@ -57,6 +58,7 @@ const MultiSelect = <T extends OptionValue>({
   loading = false,
   onAdd = () => {},
   onRemove = () => {},
+  disabled = false,
 }: Props<T>) => {
   const availableOptions: Option<T>[] = []
   const selectedOptions: Option<T>[] = []
@@ -107,6 +109,7 @@ const MultiSelect = <T extends OptionValue>({
         id={id}
         className="select-field"
         onChange={(value) => onAdd(value)}
+        disabled={disabled}
       />
 
       <style jsx>{`

--- a/elements/MultiSelect/MultiSelect.tsx
+++ b/elements/MultiSelect/MultiSelect.tsx
@@ -14,7 +14,7 @@ type Props<T extends OptionValue> = {
   loading?: boolean
   onAdd?: (value: T) => void
   onRemove?: (value: T) => void
-  disabled: boolean
+  disabled?: boolean
 }
 
 /*

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -714,7 +714,7 @@ export type PostCardFragmentFragment = { __typename?: 'Post' } & Pick<
 > & {
     images: Array<{ __typename?: 'Image' } & Pick<Image, 'smallSize'>>
     likes: Array<{ __typename?: 'PostLike' } & Pick<PostLike, 'id'>>
-    author: { __typename?: 'User' } & AuthorFragmentFragment
+    author: { __typename?: 'User' } & AuthorWithLanguagesFragmentFragment
     language: { __typename?: 'Language' } & LanguageFragmentFragment
   }
 
@@ -965,7 +965,7 @@ export type SettingsFormDataQuery = { __typename?: 'Query' } & {
   currentUser?: Maybe<
     { __typename?: 'User' } & Pick<User, 'bio'> & {
         languages: Array<
-          { __typename?: 'LanguageRelation' } & Pick<LanguageRelation, 'id'> & {
+          { __typename?: 'LanguageRelation' } & Pick<LanguageRelation, 'id' | 'level'> & {
               language: { __typename?: 'Language' } & LanguageFragmentFragment
             }
         >
@@ -1198,13 +1198,13 @@ export const PostCardFragmentFragmentDoc = gql`
       id
     }
     author {
-      ...AuthorFragment
+      ...AuthorWithLanguagesFragment
     }
     language {
       ...LanguageFragment
     }
   }
-  ${AuthorFragmentFragmentDoc}
+  ${AuthorWithLanguagesFragmentFragmentDoc}
   ${LanguageFragmentFragmentDoc}
 `
 export const LanguageWithPostCountFragmentFragmentDoc = gql`
@@ -2767,6 +2767,7 @@ export const SettingsFormDataDocument = gql`
       bio
       languages {
         id
+        level
         language {
           ...LanguageFragment
         }

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -703,9 +703,8 @@ export type PostFragmentFragment = { __typename?: 'Post' } & Pick<
   }
 
 export type PostWithTopicsFragmentFragment = { __typename?: 'Post' } & {
-  postTopics: Array<
-    { __typename?: 'PostTopic' } & { topic: { __typename?: 'Topic' } & TopicFragmentFragment }
-  >
+  postTopics: Array<{ __typename?: 'PostTopic' } & PostTopicFragmentFragment>
+  language: { __typename?: 'Language' } & Pick<Language, 'id' | 'name' | 'dialect'>
 } & PostFragmentFragment
 
 export type PostCardFragmentFragment = { __typename?: 'Post' } & Pick<
@@ -730,6 +729,10 @@ export type LanguageWithPostCountFragmentFragment = { __typename?: 'Language' } 
   LanguageFragmentFragment
 
 export type TopicFragmentFragment = { __typename?: 'Topic' } & Pick<Topic, 'id' | 'name'>
+
+export type PostTopicFragmentFragment = { __typename?: 'PostTopic' } & {
+  topic: { __typename?: 'Topic' } & TopicFragmentFragment
+}
 
 export type AddLanguageRelationMutationVariables = {
   languageId: Scalars['Int']
@@ -1169,17 +1172,28 @@ export const TopicFragmentFragmentDoc = gql`
     name(uiLanguage: $uiLanguage)
   }
 `
+export const PostTopicFragmentFragmentDoc = gql`
+  fragment PostTopicFragment on PostTopic {
+    topic {
+      ...TopicFragment
+    }
+  }
+  ${TopicFragmentFragmentDoc}
+`
 export const PostWithTopicsFragmentFragmentDoc = gql`
   fragment PostWithTopicsFragment on Post {
     ...PostFragment
     postTopics {
-      topic {
-        ...TopicFragment
-      }
+      ...PostTopicFragment
+    }
+    language {
+      id
+      name
+      dialect
     }
   }
   ${PostFragmentFragmentDoc}
-  ${TopicFragmentFragmentDoc}
+  ${PostTopicFragmentFragmentDoc}
 `
 export const PostCardFragmentFragmentDoc = gql`
   fragment PostCardFragment on Post {

--- a/graphql/fragments.graphql
+++ b/graphql/fragments.graphql
@@ -121,9 +121,12 @@ fragment PostFragment on Post {
 fragment PostWithTopicsFragment on Post {
   ...PostFragment
   postTopics {
-    topic {
-      ...TopicFragment
-    }
+    ...PostTopicFragment
+  }
+  language {
+    id
+    name
+    dialect
   }
 }
 
@@ -164,4 +167,10 @@ fragment LanguageWithPostCountFragment on Language {
 fragment TopicFragment on Topic {
   id
   name(uiLanguage: $uiLanguage)
+}
+
+fragment PostTopicFragment on PostTopic {
+  topic {
+    ...TopicFragment
+  }
 }

--- a/graphql/fragments.graphql
+++ b/graphql/fragments.graphql
@@ -143,7 +143,7 @@ fragment PostCardFragment on Post {
     id
   }
   author {
-    ...AuthorFragment
+    ...AuthorWithLanguagesFragment
   }
   language {
     ...LanguageFragment

--- a/pages/dashboard/profile/[id]/index.tsx
+++ b/pages/dashboard/profile/[id]/index.tsx
@@ -30,7 +30,7 @@ const ProfilePage: NextPage<InitialProps> = () => {
 
   const isLoading = loadingCurrentUser || loadingProfile
   const hasError = currentUserError || profileError
-
+  console.log(profileData)
   return (
     <LoadingWrapper loading={isLoading} error={hasError}>
       <DashboardLayout withPadding={false}>

--- a/pages/dashboard/profile/[id]/index.tsx
+++ b/pages/dashboard/profile/[id]/index.tsx
@@ -8,8 +8,6 @@ import DashboardLayout from '../../../../components/Layouts/DashboardLayout'
 import {
   useProfileQuery,
   useCurrentUserQuery,
-  User as UserType,
-  Post as PostType,
 } from '../../../../generated/graphql'
 import Profile from '../../../../components/Dashboard/Profile'
 
@@ -36,11 +34,13 @@ const ProfilePage: NextPage<InitialProps> = () => {
   return (
     <LoadingWrapper loading={isLoading} error={hasError}>
       <DashboardLayout withPadding={false}>
-        <Profile
-          isLoggedInUser={userData?.currentUser?.id === userId}
-          user={profileData?.userById as UserType}
-          posts={profileData?.posts as PostType[]}
-        />
+        {profileData?.userById && profileData?.posts && (
+          <Profile
+            isLoggedInUser={userData?.currentUser?.id === userId}
+            user={profileData.userById}
+            posts={profileData.posts}
+          />
+        )}
       </DashboardLayout>
     </LoadingWrapper>
   )

--- a/pages/dashboard/settings/account.tsx
+++ b/pages/dashboard/settings/account.tsx
@@ -45,6 +45,8 @@ const Account: NextPage = () => {
                     name="old-password"
                     className="j-field"
                     ref={register({ required: t('accountForm.oldPasswordError') as string })}
+                    placeholder="Coming soon..."
+                    disabled={true}
                   />
                 </div>
 
@@ -56,6 +58,8 @@ const Account: NextPage = () => {
                     type="text"
                     id="new-password"
                     name="new-password"
+                    placeholder="Coming soon..."
+                    disabled={true}
                     className="j-field"
                     ref={register({ required: t('accountForm.newPasswordError') as string })}
                   />
@@ -70,6 +74,8 @@ const Account: NextPage = () => {
                     id="confirm-new-password"
                     name="confirm-new-password"
                     className="j-field"
+                    placeholder="Coming soon..."
+                    disabled={true}
                     ref={register({
                       required: t('accountForm.confirmNewPasswordError') as string,
                       validate: (value) =>

--- a/public/static/locales/en/post-author-card.json
+++ b/public/static/locales/en/post-author-card.json
@@ -1,6 +1,7 @@
 {
   "nativeHeader": "Native",
   "learningHeader": "Learning",
+  "languagesHeader": "Languages",
   "hasWritten": "Has written",
   "postsWrittenCountSingular": "post",
   "postsWrittenCountPlural": "posts",

--- a/utils/languages.ts
+++ b/utils/languages.ts
@@ -1,3 +1,5 @@
+import {LanguageLevel} from '../generated/graphql'
+
 type LanguageName = {
   name: string
   dialect?: string | null
@@ -6,3 +8,19 @@ type LanguageName = {
 export function languageNameWithDialect({ name, dialect }: LanguageName): string {
   return dialect ? `${name} (${dialect})` : name
 }
+
+export function languageLevelToNumber(level: LanguageLevel) {
+  switch (level) {
+    case LanguageLevel.Beginner:
+      return 0
+    case LanguageLevel.Intermediate:
+      return 1
+    case LanguageLevel.Advanced:
+      return 2
+    case LanguageLevel.Native:
+      return 3
+    default:
+      return 0    
+  }
+}
+


### PR DESCRIPTION
## Description

**Issue:** #352 

Builds out UI things for our language level feature along with a couple of other UI improvements around topics.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] add a five-topic limit on posts
- [x] create a number mapping with `LanguageLevel` enum
- [x] add a language level badge on `PostCard` inside the feed
- [x] add UI for displaying post authors level for each language in `PostAuthorCard`
- [x] partially fix the issue with the profile page height
- [x] disable form things that don't work and put placeholders
- [x] revamp `PostHeader` with language and topics!

## Screenshots

<img width="906" alt="language-level-badges-preview" src="https://user-images.githubusercontent.com/34203886/97791057-a22a0900-1b8b-11eb-9ae5-4cd6ee0279af.png">

<img width="906" src="https://user-images.githubusercontent.com/34203886/97796444-6749c480-1bcf-11eb-88af-c85b3e3867a2.png">

<img width="400" src="https://user-images.githubusercontent.com/34203886/97795241-0d420280-1bc1-11eb-8436-81e8af25466d.png">

<img width="400" src="https://user-images.githubusercontent.com/34203886/97796458-88aab080-1bcf-11eb-9888-f4131ad05e34.png">
