### PR TITLE
Add update some lines and add notes for Windows users

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,16 @@ The data model/DB schema lives in `prisma/schema`, server side code and some uti
 
 #### Setting Up Your Local DB Instance
 
-1. Install Postgres with Homebrew
+1. Install Postgres
+- Mac/Linux users should use Homebrew
    _Note that this set your Postgres DB to run when your computer starts up and will stay running in the background_.
 
    ```bash
    $ brew install postgres
    $ brew services start postgresql
    ```
+
+- Windows users should download and install Postgres from [postgresql.org](https://www.postgresql.org/download/windows/).
 
 1. Start up your Postgres shell and create your user
 
@@ -54,9 +57,9 @@ The data model/DB schema lives in `prisma/schema`, server side code and some uti
    $ alter user <your_username> with superuser;
    ```
 
-1. If you haven't created a `prisma/.env` file yet, copy and paste `prisma/.env.example` into the new `.env` file. Then, replace the placeholders with your new postgres username & password.
+1. If you haven't created a `prisma/.env` file yet, copy and paste `prisma/.env.example` into `prisma/.env`. Then, replace the placeholders in both `prisma/.env` and the `.env` file in the root of the project with your new postgres username & password.
 
-1. Finally, from the `backend` directory, apply database migrations to your new database instance:
+1. Finally, from the `prisma` directory, apply database migrations to your new database instance:
 
    ```bash
    $ npm run migrate:up


### PR DESCRIPTION
## Notes

I don't seem to be able to add Notes to the Kanban, so I am unable to follow the normal workflow for this PR. I created an issue for this (after the PR) #364 but am unsure how to get it on the Kanban.

## Description

closes #364 

### Changes
These are changes I needed to make to the `Readme.md` file in order to try and get Journaly running locally on my Windows machine.

1. I updated the section Postgres installation to include how one installs it on Windows.
1. I fixed what I believe as a typo, referencing the `backend` directory when it was supposed to be the `prisma` directory.
1. I made additions to where we have to make changes to `.env.example`, as there are two instances of that file. This may be incorrect, and it is working for me now, but I'm unsure if I have superfluous files at the moment (I am not familiar with Prisma yet).

### Items left unchanged
1. `npm run reseed-db` will not work on Windows because `source` (called by `empty-db`) isn't available. I was able to run the sub-scripts manually, but am unsure the best way to compile that into a new script. I'd recommend making another issue to handle that.
1. The bottom of the readme references `localhost:3000/api/playground` for GraphQL. When I load that I get the error that I cannot connect to the server. This may be due to changes in configuration, or due to something I didn't replicate properly in my setup, so I didn't want to change it. I did want to get someone's eyes on it who is familiar with the setup to make sure if it needs to be updated.

## PR Boilerplate
**Issue:** #364 

- [ ] I have added this PR to the Journaly Kanban project ✅ <-- I am unable to do this
