### PR TITLE
call pagination reset from filters

### DIFF
--- a/components/Dashboard/MyFeed/MyFeed.tsx
+++ b/components/Dashboard/MyFeed/MyFeed.tsx
@@ -23,7 +23,7 @@ import { greetings } from './greetings'
 import useToggle from '../../../hooks/useToggle'
 import Select from '../../../elements/Select'
 
-const NUM_POSTS_PER_PAGE = 9
+const NUM_POSTS_PER_PAGE = 2
 
 type Props = {
   currentUser: UserType
@@ -76,8 +76,8 @@ const MyFeed: React.FC<Props> = ({ currentUser }) => {
    * Pagination handling
    */
   // Pull query params off the router instance
-  const { query } = useRouter()
-  const currentPage = query.page ? Math.max(1, parseInt(query.page as string, 10)) : 1
+  const router = useRouter()
+  const currentPage = router.query.page ? Math.max(1, parseInt(router.query.page as string, 10)) : 1
 
   // fetch posts for the feed!
   const { loading, error, data } = useFeedQuery({
@@ -99,6 +99,17 @@ const MyFeed: React.FC<Props> = ({ currentUser }) => {
   if (currentUser.languages.length === 1) {
     greetingLanguage = currentUser.languages[0].language.name
   }
+
+  const resetPagination = () => {
+    // filter out page key to reset the url
+    router.push({...router, query: Object.keys(router.query).reduce((newQuery, key) => {
+      if (key !== 'page') {
+        newQuery[key] = router.query[key]
+      }
+      return newQuery
+    }, {})})
+  }
+
 
   const learningLanguages = currentUser.languages.filter(({ level }) => level !== LanguageLevel.Native)
   if (learningLanguages.length > 0) {
@@ -152,12 +163,16 @@ const MyFeed: React.FC<Props> = ({ currentUser }) => {
             options={languageOptions}
             selectedOptionValues={selectedLanguageFilters}
             placeholder="Languages"
-            onAdd={(id) => setSelectedLanguageFilters([...selectedLanguageFilters, id])}
-            onRemove={(id) =>
+            onAdd={(id) => {
+              setSelectedLanguageFilters([...selectedLanguageFilters, id])
+              resetPagination()
+            }}
+            onRemove={(id) => {
               setSelectedLanguageFilters(
-                selectedLanguageFilters.filter((languageId) => languageId !== id),
+                selectedLanguageFilters.filter((languageId) => languageId !== id)
               )
-            }
+              resetPagination()
+            }}
           />
           <div className="filter-actions">
             <Button

--- a/components/Dashboard/MyFeed/MyFeed.tsx
+++ b/components/Dashboard/MyFeed/MyFeed.tsx
@@ -23,7 +23,7 @@ import { greetings } from './greetings'
 import useToggle from '../../../hooks/useToggle'
 import Select from '../../../elements/Select'
 
-const NUM_POSTS_PER_PAGE = 2
+const NUM_POSTS_PER_PAGE = 9
 
 type Props = {
   currentUser: UserType

--- a/components/Dashboard/MyFeed/MyFeed.tsx
+++ b/components/Dashboard/MyFeed/MyFeed.tsx
@@ -102,12 +102,9 @@ const MyFeed: React.FC<Props> = ({ currentUser }) => {
 
   const resetPagination = () => {
     // filter out page key to reset the url
-    router.push({...router, query: Object.keys(router.query).reduce((newQuery, key) => {
-      if (key !== 'page') {
-        newQuery[key] = router.query[key]
-      }
-      return newQuery
-    }, {})})
+    const newQuery = {...query}
+    delete newQuery.page
+    router.push({...router, query: newQuery })
   }
 
 

--- a/components/Dashboard/MyFeed/MyFeed.tsx
+++ b/components/Dashboard/MyFeed/MyFeed.tsx
@@ -102,7 +102,7 @@ const MyFeed: React.FC<Props> = ({ currentUser }) => {
 
   const resetPagination = () => {
     // filter out page key to reset the url
-    const newQuery = {...query}
+    const newQuery = {...router.query}
     delete newQuery.page
     router.push({...router, query: newQuery })
   }

--- a/docs/contributing-guide.md
+++ b/docs/contributing-guide.md
@@ -35,4 +35,6 @@ We use _Milestones_ to keep track of our progress at a high level. These are sim
 This repo uses `prettier` for formatting and `typescript-eslint` for linting TypeScript. Until precommit hooks are set up to auto format, we recommend using `prettier` on your code before submitting a PR.
 You can do this by running `npm run format`
 
+It's recommended that you also run `npm run build` before submitting your PR to ensure that the build will be clean.
+
 If you use VS Code, install the [Prettier - Code formatter](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) extension.


### PR DESCRIPTION
## Description

**Issue:** closes #346 

I don't mean to compet with @robin-macpherson's solution in #347 but it seems like that has been hanging for a while, and a lot of issues appear to be assigned but maybe on hold. So I grabbed what appeared to be something I could tackle

Essentially, my fix creates a new function to reset the pagination when the filters are edited. I use the [router.push()](https://nextjs.org/docs/api-reference/next/router#routerpush) method to adhere to single responsibility principles and ensuring that all intended "side effects" are taken care of (such as the url updating properly).

I would love someone to look this over and give me feedback. There are a few items in particular I was curious about (being new to the codebase) and would love some eyes on:

1. I am currently using a spread notation to rebuild the `router` object because I am unsure how you all prefer to handle immutability. I see there is `lodash` installed, so I might want to take a swing at using their `cloneDeep` or `omit` since this isn't a resource intensive context.
1. I wasn't sure if there was a reasonable `util/` folder, or similar place, to put this `resetPagination` function. Is there any reason for this to be called outside of this component? If that's not a concern right now, then maybe the question is moot. I just wanted to check.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Chosen immutability method for `router` has been approved for style ✅
- [x] Verified the location off the `resetPagination` function is good ✅