### PR TITLE
Remove locale subpaths

### DIFF
--- a/components/Icons/FlagDEIcon.tsx
+++ b/components/Icons/FlagDEIcon.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react'
+interface SVGRProps {
+  title?: string;
+  titleId?: string;
+}
+
+function FlagDEIcon({ title, titleId, ...props }: React.SVGProps<SVGSVGElement> & SVGRProps) {
+  return (
+    <svg viewBox="0 0 5 3" aria-labelledby={titleId} {...props}>
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path d="M0 0h5v3H0z" />
+      <path fill="#D00" d="M0 1h5v2H0z" />
+      <path fill="#FFCE00" d="M0 2h5v1H0z" />
+    </svg>
+  )
+}
+
+export default FlagDEIcon

--- a/components/Icons/FlagUSIcon.tsx
+++ b/components/Icons/FlagUSIcon.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react'
+interface SVGRProps {
+  title?: string;
+  titleId?: string;
+}
+
+function FlagUSIcon({ title, titleId, ...props }: React.SVGProps<SVGSVGElement> & SVGRProps) {
+  return (
+    <svg viewBox="0 0 7410 3900" aria-labelledby={titleId}
+      xmlns="http://www.w3.org/2000/svg"
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="#b22234" d="M0 0h7410v3900H0z" />
+      <path
+        d="M0 450h7410m0 600H0m0 600h7410m0 600H0m0 600h7410m0 600H0"
+        stroke="#fff"
+        strokeWidth={300}
+      />
+      <path fill="#3c3b6e" d="M0 0h2964v2100H0z" />
+      <g fill="#fff">
+        <g id="usf_d">
+          <g id="usf_c">
+            <g id="usf_e">
+              <g id="usf_b">
+                <path
+                  id="usf_s"
+                  d="M247 90l70.534 217.082-184.66-134.164h228.253L176.466 307.082z"
+                />
+                <use xlinkHref="#usf_s" y={420} />
+                <use xlinkHref="#usf_s" y={840} />
+                <use xlinkHref="#usf_s" y={1260} />
+              </g>
+              <use xlinkHref="#usf_s" y={1680} />
+            </g>
+            <use xlinkHref="#usf_b" x={247} y={210} />
+          </g>
+          <use xlinkHref="#usf_c" x={494} />
+        </g>
+        <use xlinkHref="#usf_d" x={988} />
+        <use xlinkHref="#usf_c" x={1976} />
+        <use xlinkHref="#usf_e" x={2470} />
+      </g>
+    </svg>
+  )
+}
+
+export default FlagUSIcon

--- a/components/UILanguageSelect/UILanguageSelect.tsx
+++ b/components/UILanguageSelect/UILanguageSelect.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { I18nContext } from 'next-i18next'
+import { I18nContext } from 'react-i18next'
 import { i18n } from '../../config/i18n'
 
 import Button, { ButtonVariant } from '../../elements/Button'

--- a/components/UILanguageSelect/UILanguageSelect.tsx
+++ b/components/UILanguageSelect/UILanguageSelect.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import { I18nContext } from 'next-i18next'
+import { i18n } from '../../config/i18n'
+
+import Button, { ButtonVariant } from '../../elements/Button'
+
+import FlagUSIcon from '../Icons/FlagUSIcon'
+import FlagDEIcon from '../Icons/FlagDEIcon'
+
+const UILanguageSelect = () => {
+  const { i18n: { language } } = React.useContext(I18nContext)
+  const uiLangData = [
+    { Icon: FlagUSIcon, code: 'en' },
+    { Icon: FlagDEIcon, code: 'de' },
+  ]
+
+  return (
+    <>
+      <ul className="flag-list">
+        { uiLangData.map(({ Icon, code }) => (
+          <li key={code} className={code === language ? 'selected': ''}>
+            <Button
+              variant={ButtonVariant.Icon}
+              onClick={() => i18n.changeLanguage(code)}
+            >
+              <Icon width={30} />
+            </Button>
+          </li>
+        ))}
+      </ul>
+
+      <style jsx>{`
+        .flag-list {
+          display: flex;
+          align-items: center;
+        }
+
+        .flag-list > li {
+          margin-right: 5px;
+        }
+
+        .flag-list > li.selected {
+          box-shadow: 2px 2px 3px rgba(0,0,0,.5);
+        }
+      `}</style>
+    </>
+  )
+}
+export default UILanguageSelect

--- a/components/UILanguageSelect/index.ts
+++ b/components/UILanguageSelect/index.ts
@@ -1,0 +1,1 @@
+export { default } from './UILanguageSelect'

--- a/config/i18n.js
+++ b/config/i18n.js
@@ -9,9 +9,6 @@ module.exports = new NextI18Next({
   fallbackLng: process.env.NODE_ENV === 'production' ? 'en' : 'dev',
   // Help nexti18next figure out how to load in a serverless env
   localePath: path.resolve('./public/static/locales'),
-  localeSubpaths: {
-    de: 'de',
-  },
   ns: [
     'common',
     'post',

--- a/pages/dashboard/settings/profile.tsx
+++ b/pages/dashboard/settings/profile.tsx
@@ -9,6 +9,7 @@ import BioForm from '../../../components/Dashboard/Settings/BioForm'
 import InterestsForm from '../../../components/Dashboard/Settings/InterestsForm'
 import SocialForm from '../../../components/Dashboard/Settings/SocialForm'
 import AuthGate from '../../../components/AuthGate'
+import UILanguageSelect from '../../../components/UILanguageSelect'
 import {
   useSettingsFormDataQuery,
 } from '../../../generated/graphql'
@@ -36,6 +37,7 @@ const ProfileInfo: NextPage = () => {
                   <BioForm bio={data?.currentUser?.bio || ''} />
                   <InterestsForm />
                   <SocialForm />
+                  <UILanguageSelect />
                 </>
               )}
             </div>


### PR DESCRIPTION
## Description

Fixes issue with users with a german browser setting not being able to edit posts. Does this by disabling locale subpaths functionality with next-i18next (dynamic routes and locale subpaths don't work together, apparently. I liked locale subpaths, so I'm sad to see them go, but if they don't work then they just don't work.

Also added a little widget to the profile page to let you change languages for testing purposes. Probably doesn't belong here long term, but it seemed alright for now.

## Screenshots

![Screen Shot 2020-11-04 at 4 45 32 PM](https://user-images.githubusercontent.com/2343714/98176184-afadfe80-1ebd-11eb-8f57-f72079f5bbb6.png)
