### PR TITLE
Include PostComments in commentCount on PostCards

### DIFF
--- a/nexus/post.ts
+++ b/nexus/post.ts
@@ -104,18 +104,20 @@ schema.objectType({
     t.model.publishedAt()
     t.int('commentCount', {
       resolve: async (parent, _args, ctx, _info) => {
-        const threadCommentCount = await ctx.db.comment.count({
-          where: {
-            thread: {
-              postId: parent.id,
+        const [threadCommentCount, postCommentCount] = await Promise.all([
+          ctx.db.comment.count({
+            where: {
+              thread: {
+                postId: parent.id,
+              },
             },
-          },
-        })
-        const postCommentCount = await ctx.db.postComment.count({
-          where: {
-            postId: parent.id
-          }
-        })
+          }),
+          ctx.db.postComment.count({
+            where: {
+              postId: parent.id
+            }
+          })
+        ])
         return threadCommentCount + postCommentCount
       },
     })

--- a/nexus/post.ts
+++ b/nexus/post.ts
@@ -103,14 +103,20 @@ schema.objectType({
     t.model.images()
     t.model.publishedAt()
     t.int('commentCount', {
-      resolve(parent, _args, ctx, _info) {
-        return ctx.db.comment.count({
+      resolve: async (parent, _args, ctx, _info) => {
+        const threadCommentCount = await ctx.db.comment.count({
           where: {
             thread: {
               postId: parent.id,
             },
           },
         })
+        const postCommentCount = await ctx.db.postComment.count({
+          where: {
+            postId: parent.id
+          }
+        })
+        return threadCommentCount + postCommentCount
       },
     })
   },


### PR DESCRIPTION
## Description

**Issue:** closes #383 

I've been noticing that when you first look at the feed, it appears that a lot of posts don't have comments due to the 0 comment count shown on the PostCard, which gives a perception that a lot of posts don't have engagement.
However, once clicking into a bunch of them, I see there are post-level comments.

Since the main purpose of displaying that comment count on the post card is to indicate the level of post engagement, and we do want people to have a good impression that it is worth it to write posts, I think this might help achieve a more accurate perception.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Update `commentCount` field

## Screenshots

**Left:** Updated count (shows 5), **Right:** Old count (shows 0)

![image](https://user-images.githubusercontent.com/34203886/98898519-ae9f4300-2462-11eb-9298-a917fb2ce41e.png)

**Here you can see that basically all counts are higher with this update including two that were 0 before**

![image](https://user-images.githubusercontent.com/34203886/98898583-cf679880-2462-11eb-86a1-3bfd0b2d8307.png)
