### PR TITLE
Restrict access to email field

### DIFF
--- a/nexus/user.ts
+++ b/nexus/user.ts
@@ -15,7 +15,18 @@ schema.objectType({
   definition(t) {
     t.model.id()
     t.model.name()
-    t.model.email()
+    t.string('email', {
+      nullable: true,
+      resolve(parent, _args, ctx, _info) {
+        const { userId } = ctx.request
+
+        if (userId && userId === parent.id) {
+          return parent.email
+        }
+
+        return null
+      },
+    })
     t.model.handle()
     t.model.bio()
     t.model.userRole()


### PR DESCRIPTION
## Description

**Issue:**

Let's restrict access to someone's email
You can get users emails by querying e.g. `users`, `userById`, and other graphQL queries

## Subtasks

- [ ] I have added this PR to the Journaly Kanban project ✅