### PR TITLE
Add dialect to filter dropdown

### DIFF
--- a/components/Dashboard/MyFeed/MyFeed.tsx
+++ b/components/Dashboard/MyFeed/MyFeed.tsx
@@ -47,11 +47,14 @@ const MyFeed: React.FC<Props> = ({ currentUser }) => {
       hasPosts: true,
     },
   })
-  const languageOptions = (languagesData?.languages || []).map(({ id, name, postCount }) => ({
-    value: id,
-    displayName: `${name} (${postCount} post${(postCount || 0) === 1 ? '' : 's'})`,
-    selectedDisplayName: `${name}`,
-  }))
+  const languageOptions = (languagesData?.languages || []).map(({ dialect, id, name, postCount }) => {
+    const languageName = typeof dialect === 'string' && dialect.length > 0 ? `${name} - ${dialect}` : `${name}`
+    return {
+      value: id,
+      displayName: `${languageName} (${postCount} post${(postCount || 0) === 1 ? '' : 's'})`,
+      selectedDisplayName: languageName,
+    };
+  })
   const languageOptionIds = new Set((languagesData?.languages || []).map(({ id }) => id))
 
   let userLanguages: Set<number> = new Set([])


### PR DESCRIPTION
## Description

**Issue:** closes #372 

I added the dialect to the language dropdown for the feed as well in the "selected Languages" from the dropdown. It occurs to me that the postCard may need the dialect labeled as well. I wanted to check in about that before pushing that up (@robin-macpherson @Lanny).

I have not yet done any build (per the issues with nexus and windows), and if there are any problems with the circleci build, I will try and fix that with additional commits.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅ (already in the project)