### PR TITLE
Fix 404 on thread click

### DIFF
--- a/components/InlineFeedbackPopover/index.tsx
+++ b/components/InlineFeedbackPopover/index.tsx
@@ -33,7 +33,18 @@ type InlineFeedbackPopoverProps = {
 const VP_PADDING = 20
 
 const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(({ target, children }, ref) => {
-  const popoverRoot = document.getElementById('popover-root') as HTMLElement
+  const [rerenderCount, setRerenderCount] = React.useState<number>(0)
+  const popoverRoot = document.getElementById('popover-root')
+
+  if (!popoverRoot) {
+    // Re-render until we can actually get a popover root to render into. Unclear
+    // what situation would cause popover root to not show up before this but
+    // hey, not a bad check to do.
+    if (rerenderCount < 10) {
+      setTimeout(() => setRerenderCount(i => i+1), 500)
+    }
+    return null
+  }
 
   const ownPosition: CSS.Properties = {}
 


### PR DESCRIPTION
Was never able to repro in local but looking at the stack trace I got the one time I could repro on prod I think this should fix it. The `popover-root` portal container appears to be null in some situations, so we need to handle that case instead of waving away the null case with a type assertion.

## Migrations

No migs