### PR TITLE
Fix "Publish Draft" Bug

### DIFF
--- a/components/Dashboard/Post/Post.tsx
+++ b/components/Dashboard/Post/Post.tsx
@@ -442,7 +442,6 @@ const Post: React.FC<IPostProps> = ({ post, currentUser, refetch }: IPostProps) 
     updatePost({
       variables: {
         postId: post.id,
-        languageId: post.language.id,
         status,
       }
     })

--- a/components/Dashboard/Post/Post.tsx
+++ b/components/Dashboard/Post/Post.tsx
@@ -439,7 +439,13 @@ const Post: React.FC<IPostProps> = ({ post, currentUser, refetch }: IPostProps) 
   }
 
   const setPostStatus = (status: PostStatus) => () => {
-    updatePost({ variables: { postId: post.id, status } })
+    updatePost({
+      variables: {
+        postId: post.id,
+        languageId: post.language.id,
+        status,
+      }
+    })
   }
 
   const activeThread = post.threads.find((thread: ThreadType) => thread.id === activeThreadId)

--- a/nexus/post.ts
+++ b/nexus/post.ts
@@ -518,7 +518,8 @@ const PostMutations = extendType({
           }))
         }
 
-        const userLanguageLevel = currentUser.languages.filter((language: LanguageRelation) => language.languageId === originalPost.languageId)[0].level
+        const languageId = args.languageId  || originalPost.languageId
+        const userLanguageLevel = currentUser.languages.filter((language: LanguageRelation) => language.languageId === languageId)[0].level
         data.publishedLanguageLevel = userLanguageLevel
         
         if (args.status === 'PUBLISHED' && !originalPost.publishedAt) {

--- a/nexus/post.ts
+++ b/nexus/post.ts
@@ -518,7 +518,7 @@ const PostMutations = extendType({
           }))
         }
 
-        const userLanguageLevel = currentUser.languages.filter((language: LanguageRelation) => language.languageId === args.languageId)[0].level
+        const userLanguageLevel = currentUser.languages.filter((language: LanguageRelation) => language.languageId === originalPost.languageId)[0].level
         data.publishedLanguageLevel = userLanguageLevel
         
         if (args.status === 'PUBLISHED' && !originalPost.publishedAt) {


### PR DESCRIPTION
## Description

**Issue:** closes #411 

User's aren't unable to publish their drafts.
This was due to looking for `args.languageId` instead of `originalPost.languageId` since languageId is not required in the `updatePost` mutation.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Find the issue
- [x] Make the fix

## Migrations

No migs.
