### PR TITLE
Fix issue where emails would always be sent to author of a post comment when a new one is made

### DIFF
--- a/nexus/comment.ts
+++ b/nexus/comment.ts
@@ -366,7 +366,7 @@ const PostMutations = extendType({
 
           const promise = sendPostCommentNotification({
             post,
-            user: postComment.author,
+            user: user,
             postComment,
             postCommentAuthor: postComment.author,
           })

--- a/nexus/utils/email.ts
+++ b/nexus/utils/email.ts
@@ -144,7 +144,7 @@ export const sendPostCommentNotification = ({
     to: user.email,
     subject: `New activity on post: ${post.title}`,
     html: makeEmail(`
-      <p>Great news! <strong>@${postCommentAuthor.handle}</strong> left a comment on your post!</p>
+      <p>Great news! <strong>@${postCommentAuthor.handle}</strong> left a comment on a post you're subscribed to!</p>
       <p><strong>Journal entry:</strong> ${post.title}</p>
       <p><strong>Comment:</strong> "${postComment.body}"</p>
       <p>Click <a href="https://${process.env.SITE_DOMAIN}/post/${post.id}">here</a> to go to your journal entry!</p>


### PR DESCRIPTION
## Description

See title, we were just passing the wrong user into "sendPostCommentNotification", seemingly a holdover from the previous "only notify the post author" implementation. Also slight copy change to that email to make it correct for non-post-authors

## Migrations

No migs.

