### PR TITLE
Move #popover-root to _document.tsx

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -29,7 +29,6 @@ class JournalyApp extends App {
         </Head>
         <Component {...pageProps} />
         <ToastContainer />
-        <div id="popover-root" />
       </>
     )
   }

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -46,6 +46,7 @@ class MyDocument extends Document<DocumentProps & { children?: ReactNode } & Cus
         <body className="block-transitions-on-page-load">
           <Main />
           <div id="modal-root" />
+          <div id="popover-root" />
           <NextScript />
         </body>
       </Html>


### PR DESCRIPTION
Relates to #407 , core issue is `#popover-root` is not present when a thread is opened and it needs to be. It's unclear to me why that element doesn't get rendered sometimes, but it seems to also affect `<ToastContainer>` (also in `_app.tsx`) but not `#modal-root` (in `_document.tsx`) so let's just try moving lifting it up out of `_app.tsx` and see what happens