### PR TITLE
Make Sign Up Errors More User Friendly

### DIFF
--- a/nexus/user.ts
+++ b/nexus/user.ts
@@ -148,10 +148,24 @@ const UserMutations = extendType({
         email: stringArg({ required: true }),
         password: stringArg({ required: true }),
       },
-      resolve: async (_parent, args, ctx: any) => {
+      resolve: async (_parent, args, ctx) => {
         if (!args.handle.match(/^[a-zA-Z0-9_-]+$/)) {
           throw new Error('Invalid handle')
         }
+
+        let existingUser = await ctx.db.user.findUnique({
+          where: {
+            handle: args.handle,
+          },
+        })
+        if (existingUser) throw new Error("Handle is already in use")
+
+        existingUser = await ctx.db.user.findUnique({
+          where: {
+            email: args.email,
+          },
+        })
+        if (existingUser) throw new Error("Email address is already in use. Please try logging in")
 
         const password = await bcrypt.hash(args.password, 10)
         const user = await ctx.db.user.create({

--- a/nexus/user.ts
+++ b/nexus/user.ts
@@ -10,7 +10,7 @@ import { serialize } from 'cookie'
 import { randomBytes } from 'crypto'
 import { promisify } from 'util'
 
-import { NotAuthorizedError } from './errors'
+import { NotAuthorizedError, UserInputError } from './errors'
 import { sendPasswordResetTokenEmail } from './utils'
 import { validateUpdateUserMutationData } from './utils/userValidation'
 
@@ -153,30 +153,32 @@ const UserMutations = extendType({
           throw new Error('Invalid handle')
         }
 
-        let existingUser = await ctx.db.user.findUnique({
-          where: {
-            handle: args.handle,
-          },
-        })
-        if (existingUser) throw new Error("Handle is already in use")
-
-        existingUser = await ctx.db.user.findUnique({
-          where: {
-            email: args.email,
-          },
-        })
-        if (existingUser) throw new Error("Email address is already in use. Please try logging in")
-
         const password = await bcrypt.hash(args.password, 10)
-        const user = await ctx.db.user.create({
-          data: {
-            handle: args.handle,
-            email: args.email.toLowerCase(),
-            auth: {
-              create: { password },
+        let user
+        try {
+          user = await ctx.db.user.create({
+            data: {
+              handle: args.handle,
+              email: args.email.toLowerCase(),
+              auth: {
+                create: { password },
+              },
             },
-          },
-        })
+          })
+        } catch (ex) {
+          // Prisma's error code for unique constraint violation
+          if (ex.code === 'P2002') {
+            if (ex.meta.target.find((x: string) => x === 'email')) {
+              throw new UserInputError("Email address is already in use. Please try logging in")
+            } else if (ex.meta.target.find((x: string) => x === 'handle')) {
+              throw new UserInputError("Handle is already in use")
+            } else {
+              throw ex
+            }
+          } else {
+            throw ex
+          }
+        }
 
         const token = jwt.sign({ userId: user.id }, process.env.APP_SECRET!)
         ctx.response.setHeader(


### PR DESCRIPTION
## Description

**Issue:** closes #421 

A surprising number of users have been confused into thinking there was a major bug with our app because they were either accidentally clicking sign up twice or using a handle that was unavailable, because we were showing them the unique constraint DB error.

This PR adds a couple of checks to handle those errors better.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Handle `createUser` mutation

