### PR TITLE
Don't set a value when clearing autosave state.

### DIFF
--- a/hooks/useAutosavedState.ts
+++ b/hooks/useAutosavedState.ts
@@ -44,7 +44,6 @@ export default function useAutosavedState<T>(
 
   const reset = () => {
     delete storage[storageKey]
-    setValue(initialValue)
   }
 
   return [value, setValue, reset]


### PR DESCRIPTION
## Description

Possibly addresses #416, it looks like when we save a post we "reset" the autosaved values, meaning clear the storage and restore the value to the initial value. The problem with this is the "restore the value to the initial value" step causes a state change and makes us write the reset value back to the local storage, and depending on how much clock drift there is between the server and client it might or might not be considered the more "recent" save. At least that's the theory.

@rickyweb if you have the time it would be awesome if you could try to repro #416 on the preview env.