### PR TITLE
chore(446): disable typescript-eslint/explicit-function-return-type

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,7 @@ module.exports = {
     },
   },
   rules: {
-    // e.g. "@typescript-eslint/explicit-function-return-type": "off",
+    "@typescript-eslint/explicit-function-return-type": "off",
   },
   settings: {
     react: {


### PR DESCRIPTION
## Description

**Issue:** #446 

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] remove `eslint` rule comment

## Screenshots
before
![Screen Shot 2021-01-13 at 16 29 09](https://user-images.githubusercontent.com/9276511/104499967-919b0380-55bc-11eb-86a5-5f612bffcab2.png)

after
![Screen Shot 2021-01-13 at 16 30 23](https://user-images.githubusercontent.com/9276511/104500093-b68f7680-55bc-11eb-9378-aa4b61a052e0.png)

