### PR TITLE
Avarar specific sizing

### DIFF
--- a/components/Dashboard/Settings/DetailsForm.tsx
+++ b/components/Dashboard/Settings/DetailsForm.tsx
@@ -47,7 +47,7 @@ const DetailsForm: React.FC<DetailsFormProps> = ({ currentUser }) => {
     if (image) {
       updateUser({
         variables: {
-          profileImage: image.large,
+          profileImage: image.finalUrl,
         },
       })
     }

--- a/components/Dashboard/Settings/DetailsForm.tsx
+++ b/components/Dashboard/Settings/DetailsForm.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from '@/config/i18n'
 import FormError from '@/components/FormError'
 import SettingsForm from '@/components/Dashboard/Settings/SettingsForm'
 import SettingsFieldset from '@/components/Dashboard/Settings/SettingsFieldset'
-import useImageUpload from '@/hooks/useImageUpload'
+import useAvatarImageUpload from '@/hooks/useAvatarImageUpload'
 import Button, { ButtonVariant } from '@/elements/Button'
 import theme from '@/theme'
 import { User as UserType, useUpdateUserMutation } from '@/generated/graphql'
@@ -39,8 +39,8 @@ const DetailsForm: React.FC<DetailsFormProps> = ({ currentUser }) => {
     },
   })
 
-  const [image, uploadingImage, onFileInputChange] = useImageUpload()
-  const profileImage = image?.large || currentUser.profileImage
+  const [image, uploadingImage, onFileInputChange] = useAvatarImageUpload()
+  const profileImage = image?.finalUrl || currentUser.profileImage
 
   const updateUserProfileImage = async (e: HTMLInputEvent): Promise<void> => {
     const image = await onFileInputChange(e)

--- a/components/PostEditor/PostEditor.tsx
+++ b/components/PostEditor/PostEditor.tsx
@@ -9,7 +9,7 @@ import Select from '@/elements/Select'
 import MultiSelect from '@/elements/MultiSelect'
 import { ButtonVariant } from '@/elements/Button'
 import theme from '@/theme'
-import useImageUpload from '@/hooks/useImageUpload'
+import usePostImageUpload from '@/hooks/usePostImageUpload'
 import useAutosavedState from '@/hooks/useAutosavedState'
 import {
   UserWithLanguagesFragmentFragment as UserWithLanguagesType,
@@ -96,8 +96,8 @@ const PostEditor: React.FC<PostEditorProps> = ({
     return { value, displayName }
   })
 
-  const [image, uploadingImage, onFileInputChange, resetImage] = useImageUpload()
-  const postImage = image?.large || initialData.image?.largeSize || DEFAULT_IMAGE_URL
+  const [image, uploadingImage, onFileInputChange, resetImage] = usePostImageUpload()
+  const postImage = image?.finalUrlLarge || initialData.image?.largeSize || DEFAULT_IMAGE_URL
 
   const [selectedTopics, setSelectedTopics] = React.useState<number[]>(initialData.topicIds)
   const formattedTopicOptions = (topics || []).map(({ name, id }) => ({
@@ -132,8 +132,8 @@ const PostEditor: React.FC<PostEditorProps> = ({
     const returnImage = !image
       ? null
       : {
-          largeSize: image.large,
-          smallSize: image.small,
+          largeSize: image.finalUrlLarge,
+          smallSize: image.finalUrlSmall,
           imageRole: ImageRole.Headline,
         }
 

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -175,6 +175,16 @@ export type UserBadge = {
   createdAt: Scalars['DateTime']
 }
 
+export type InitiateAvatarImageUploadResponse = {
+  __typename?: 'InitiateAvatarImageUploadResponse'
+  /** URL for the client to PUT an image to */
+  uploadUrl: Scalars['String']
+  /** polling goes here */
+  checkUrl: Scalars['String']
+  /** final url of the transform */
+  finalUrl: Scalars['String']
+}
+
 export type LanguageRelation = {
   __typename?: 'LanguageRelation'
   id: Scalars['Int']
@@ -325,6 +335,7 @@ export type Mutation = {
   initiatePostImageUpload: InitiatePostImageUploadResponse
   createUser: User
   updateUser: User
+  initiateAvatarImageUpload: InitiateAvatarImageUploadResponse
   updatePassword: User
   loginUser: User
   requestResetPassword: User
@@ -917,6 +928,15 @@ export type FollowingUsersQuery = { __typename?: 'Query' } & {
     { __typename?: 'User' } & Pick<User, 'id'> & {
         following: Array<{ __typename?: 'User' } & Pick<User, 'id'>>
       }
+  >
+}
+
+export type InitiateAvatarImageUploadMutationVariables = Exact<{ [key: string]: never }>
+
+export type InitiateAvatarImageUploadMutation = { __typename?: 'Mutation' } & {
+  initiateAvatarImageUpload: { __typename?: 'InitiateAvatarImageUploadResponse' } & Pick<
+    InitiateAvatarImageUploadResponse,
+    'uploadUrl' | 'checkUrl' | 'finalUrl'
   >
 }
 
@@ -2837,6 +2857,57 @@ export type FollowingUsersLazyQueryHookResult = ReturnType<typeof useFollowingUs
 export type FollowingUsersQueryResult = ApolloReactCommon.QueryResult<
   FollowingUsersQuery,
   FollowingUsersQueryVariables
+>
+export const InitiateAvatarImageUploadDocument = gql`
+  mutation initiateAvatarImageUpload {
+    initiateAvatarImageUpload {
+      uploadUrl
+      checkUrl
+      finalUrl
+    }
+  }
+`
+export type InitiateAvatarImageUploadMutationFn = ApolloReactCommon.MutationFunction<
+  InitiateAvatarImageUploadMutation,
+  InitiateAvatarImageUploadMutationVariables
+>
+
+/**
+ * __useInitiateAvatarImageUploadMutation__
+ *
+ * To run a mutation, you first call `useInitiateAvatarImageUploadMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useInitiateAvatarImageUploadMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [initiateAvatarImageUploadMutation, { data, loading, error }] = useInitiateAvatarImageUploadMutation({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useInitiateAvatarImageUploadMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    InitiateAvatarImageUploadMutation,
+    InitiateAvatarImageUploadMutationVariables
+  >,
+) {
+  return ApolloReactHooks.useMutation<
+    InitiateAvatarImageUploadMutation,
+    InitiateAvatarImageUploadMutationVariables
+  >(InitiateAvatarImageUploadDocument, baseOptions)
+}
+export type InitiateAvatarImageUploadMutationHookResult = ReturnType<
+  typeof useInitiateAvatarImageUploadMutation
+>
+export type InitiateAvatarImageUploadMutationResult = ApolloReactCommon.MutationResult<
+  InitiateAvatarImageUploadMutation
+>
+export type InitiateAvatarImageUploadMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  InitiateAvatarImageUploadMutation,
+  InitiateAvatarImageUploadMutationVariables
 >
 export const LoginUserDocument = gql`
   mutation loginUser($identifier: String!, $password: String!) {

--- a/graphql/user/initiateAvatarImageUpload.graphql
+++ b/graphql/user/initiateAvatarImageUpload.graphql
@@ -1,0 +1,7 @@
+mutation initiateAvatarImageUpload {
+  initiateAvatarImageUpload {
+    uploadUrl
+    checkUrl
+    finalUrl
+  }
+}

--- a/hooks/useAvatarImageUpload.ts
+++ b/hooks/useAvatarImageUpload.ts
@@ -1,0 +1,23 @@
+import useImageUpload from '@/hooks/useImageUpload'
+import {
+  useInitiateAvatarImageUploadMutation,
+  InitiateAvatarImageUploadResponse,
+} from '@/generated/graphql'
+
+const useAvatarImageUpload: UploadHook<InitiateAvatarImageUploadResponse> = () => {
+  const [initiateAvatarImageUpload] = useInitiateAvatarImageUploadMutation()
+
+  const getUploadData = async () =>  {
+    const {
+      data: {
+        initiateAvatarImageUpload: uploadData
+      }
+    } = await initiateAvatarImageUpload()
+
+    return uploadData
+  }
+
+  return useImageUpload(getUploadData)
+}
+
+export default useAvatarImageUpload

--- a/hooks/useAvatarImageUpload.ts
+++ b/hooks/useAvatarImageUpload.ts
@@ -1,4 +1,4 @@
-import useImageUpload from '@/hooks/useImageUpload'
+import useImageUpload, { UploadHook } from '@/hooks/useImageUpload'
 import {
   useInitiateAvatarImageUploadMutation,
   InitiateAvatarImageUploadResponse,
@@ -8,13 +8,9 @@ const useAvatarImageUpload: UploadHook<InitiateAvatarImageUploadResponse> = () =
   const [initiateAvatarImageUpload] = useInitiateAvatarImageUploadMutation()
 
   const getUploadData = async () =>  {
-    const {
-      data: {
-        initiateAvatarImageUpload: uploadData
-      }
-    } = await initiateAvatarImageUpload()
+    const resp = await initiateAvatarImageUpload()
 
-    return uploadData
+    return resp?.data?.initiateAvatarImageUpload
   }
 
   return useImageUpload(getUploadData)

--- a/hooks/useImageUpload.ts
+++ b/hooks/useImageUpload.ts
@@ -9,17 +9,25 @@ interface HTMLInputEvent extends React.FormEvent {
   target: HTMLInputElement & EventTarget
 }
 
-interface UploadHook<T> {
-  (getUploadData: () => Promise<T>): [
-    T | null,
-    boolean,
-    (e: HTMLInputEvent) => Promise<T | null>,
-    () => void,
-  ]
+type UploadHookOutput<T> = [
+  T | null,
+  boolean,
+  (e: HTMLInputEvent) => Promise<T | null>,
+  () => void,
+]
+
+type BaseUploadData = {
+  uploadUrl: string
+  checkUrl: string
 }
 
-const useImageUpload: UploadHook = (getUploadData) => {
-  const [image, setImage] = useState<Image | null>(null)
+export interface UploadHook<T> {
+  (): UploadHookOutput<T>
+}
+
+
+const useImageUpload = <T extends BaseUploadData>(getUploadData: () => Promise<T | undefined>): UploadHookOutput<T> => {
+  const [image, setImage] = useState<T | null>(null)
   const [uploadingImage, setUploadingImage] = useState(false)
   const { t } = useTranslation('common')
 
@@ -33,10 +41,11 @@ const useImageUpload: UploadHook = (getUploadData) => {
       return null
     }
 
-    const uploadData: T  = await getUploadData()
+    const uploadData = await getUploadData()
 
     if (!uploadData) {
       setUploadingImage(false)
+      toast.error(t('imageUploadErrorMessage'))
       return null
     }
 

--- a/hooks/usePostImageUpload.ts
+++ b/hooks/usePostImageUpload.ts
@@ -1,4 +1,4 @@
-import useImageUpload from '@/hooks/useImageUpload'
+import useImageUpload, { UploadHook } from '@/hooks/useImageUpload'
 import {
   useInitiatePostImageUploadMutation,
   InitiatePostImageUploadResponse,
@@ -8,13 +8,9 @@ const usePostImageUpload: UploadHook<InitiatePostImageUploadResponse> = () => {
   const [initiatePostImageUpload] = useInitiatePostImageUploadMutation()
 
   const getUploadData = async () =>  {
-    const {
-      data: {
-        initiatePostImageUpload: uploadData
-      }
-    } = await initiatePostImageUpload()
+    const resp = await initiatePostImageUpload()
 
-    return uploadData
+    return resp?.data?.initiatePostImageUpload
   }
 
   return useImageUpload(getUploadData)

--- a/hooks/usePostImageUpload.ts
+++ b/hooks/usePostImageUpload.ts
@@ -1,0 +1,23 @@
+import useImageUpload from '@/hooks/useImageUpload'
+import {
+  useInitiatePostImageUploadMutation,
+  InitiatePostImageUploadResponse,
+} from '@/generated/graphql'
+
+const usePostImageUpload: UploadHook<InitiatePostImageUploadResponse> = () => {
+  const [initiatePostImageUpload] = useInitiatePostImageUploadMutation()
+
+  const getUploadData = async () =>  {
+    const {
+      data: {
+        initiatePostImageUpload: uploadData
+      }
+    } = await initiatePostImageUpload()
+
+    return uploadData
+  }
+
+  return useImageUpload(getUploadData)
+}
+
+export default usePostImageUpload

--- a/nexus/user.ts
+++ b/nexus/user.ts
@@ -239,7 +239,7 @@ const UserMutations = extendType({
 
     t.field('initiateAvatarImageUpload', {
       type: 'InitiateAvatarImageUploadResponse',
-      resolve: async (_parent, args, ctx: any) => {
+      resolve: async (_parent, _args, ctx) => {
         const transformBucket = process.env.THUMBBUSTER_TRANSFORM_BUCKET
         const cdnDomain = process.env.THUMBBUSTER_CDN_DOMAIN
 

--- a/nexus/utils/index.ts
+++ b/nexus/utils/index.ts
@@ -342,3 +342,4 @@ export const createNotification = (
 
 export * from './email'
 export * from './aws'
+export * from './resolverUtils'

--- a/nexus/utils/resolverUtils.ts
+++ b/nexus/utils/resolverUtils.ts
@@ -1,0 +1,23 @@
+import { v4 as uuidv4 } from 'uuid';
+import { AWS } from './aws'
+
+const s3 = new AWS.S3({ region: 'us-east-2' })
+
+export const generateThumbbusterUrl = async (transform: string) => {
+  const upBucket = process.env.THUMBBUSTER_UPLOAD_BUCKET
+
+  if (!upBucket) {
+    throw new Error('Must specify `THUMBBUSTER_UPLOAD_BUCKET` env var')
+  }
+
+  const uuid = uuidv4()
+  const uploadUrl = await (new Promise<string>((res, rej) => {
+    s3.getSignedUrl(
+      'putObject',
+      { Bucket: upBucket, Key: `${transform}/${uuid}` },
+      (err, url) => err ? rej(err) : res(url)
+    )
+  }))
+
+  return [uuid, uploadUrl]
+}


### PR DESCRIPTION
## Description

Adds support for multiple transform configurations, our second configuration is for avatar images. Previously we were reusing the post image config so we'd get a 1200px by something image which was wayyyy bigger than we'd ever present to the user. Now avatar uploads are 150px square. This should reduce the total network IO required to load the feed and comments, plus save us a little on S3 costs. Main goal here however is a PoC for multiple image transforms which will be necessary for inline images.


## Migrations

No migs

Related thumbbuster PR that needs to be deployed first: https://github.com/Journaly/thumbbuster/pull/1