### PR TITLE
Fix Next.js Meta Tag Warning

### DIFF
--- a/packages/web/pages/_app.tsx
+++ b/packages/web/pages/_app.tsx
@@ -26,6 +26,7 @@ class JournalyApp extends App {
       <>
         <Head>
           <title>Journaly</title>
+          <meta name="viewport" content="width=device-width, initial-scale=1" />
           <link rel="stylesheet" type="text/css" href="/nprogress.css" />
         </Head>
         <Component {...pageProps} />

--- a/packages/web/pages/_document.tsx
+++ b/packages/web/pages/_document.tsx
@@ -31,7 +31,6 @@ class MyDocument extends Document<DocumentProps & { children?: ReactNode } & Cus
     return (
       <Html lang={language}>
         <Head>
-          <meta name="viewport" content="width=device-width, initial-scale=1" />
           <meta charSet="utf-8" />
           <link
             href="https://fonts.googleapis.com/css?family=Playfair+Display&display=swap"


### PR DESCRIPTION
## Description

**Issue:** fixes #470 

Follows the advice in https://err.sh/next.js/no-document-viewport-meta that viewport meta tag should be in the `<Head>` component in `_app.js` and not `_document.js`.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Make the fix

## Migrations

No hay.

## Screenshots

No hay.
