### PR TITLE
fix(496): add created post on cache

### DIFF
--- a/packages/web/generated/graphql.tsx
+++ b/packages/web/generated/graphql.tsx
@@ -663,6 +663,7 @@ export type PostCardFragmentFragment = { __typename?: 'Post' } & Pick<
   | 'publishedAt'
   | 'publishedLanguageLevel'
   | 'commentCount'
+  | 'status'
 > & {
     images: Array<{ __typename?: 'Image' } & Pick<Image, 'smallSize'>>
     likes: Array<{ __typename?: 'PostLike' } & Pick<PostLike, 'id'>>
@@ -776,7 +777,7 @@ export type CreatePostMutationVariables = Exact<{
 }>
 
 export type CreatePostMutation = { __typename?: 'Mutation' } & {
-  createPost: { __typename?: 'Post' } & Pick<Post, 'id'>
+  createPost: { __typename?: 'Post' } & PostCardFragmentFragment
 }
 
 export type DeletePostMutationVariables = Exact<{
@@ -1228,6 +1229,7 @@ export const PostCardFragmentFragmentDoc = gql`
     publishedAt
     publishedLanguageLevel
     commentCount
+    status
     images {
       smallSize
     }
@@ -1396,9 +1398,7 @@ export function useCreatePostCommentMutation(
   >(CreatePostCommentDocument, baseOptions)
 }
 export type CreatePostCommentMutationHookResult = ReturnType<typeof useCreatePostCommentMutation>
-export type CreatePostCommentMutationResult = ApolloReactCommon.MutationResult<
-  CreatePostCommentMutation
->
+export type CreatePostCommentMutationResult = ApolloReactCommon.MutationResult<CreatePostCommentMutation>
 export type CreatePostCommentMutationOptions = ApolloReactCommon.BaseMutationOptions<
   CreatePostCommentMutation,
   CreatePostCommentMutationVariables
@@ -1550,9 +1550,7 @@ export function useDeletePostCommentMutation(
   >(DeletePostCommentDocument, baseOptions)
 }
 export type DeletePostCommentMutationHookResult = ReturnType<typeof useDeletePostCommentMutation>
-export type DeletePostCommentMutationResult = ApolloReactCommon.MutationResult<
-  DeletePostCommentMutation
->
+export type DeletePostCommentMutationResult = ApolloReactCommon.MutationResult<DeletePostCommentMutation>
 export type DeletePostCommentMutationOptions = ApolloReactCommon.BaseMutationOptions<
   DeletePostCommentMutation,
   DeletePostCommentMutationVariables
@@ -1694,9 +1692,7 @@ export function useUpdatePostCommentMutation(
   >(UpdatePostCommentDocument, baseOptions)
 }
 export type UpdatePostCommentMutationHookResult = ReturnType<typeof useUpdatePostCommentMutation>
-export type UpdatePostCommentMutationResult = ApolloReactCommon.MutationResult<
-  UpdatePostCommentMutation
->
+export type UpdatePostCommentMutationResult = ApolloReactCommon.MutationResult<UpdatePostCommentMutation>
 export type UpdatePostCommentMutationOptions = ApolloReactCommon.BaseMutationOptions<
   UpdatePostCommentMutation,
   UpdatePostCommentMutationVariables
@@ -1747,9 +1743,7 @@ export function useAddLanguageRelationMutation(
 export type AddLanguageRelationMutationHookResult = ReturnType<
   typeof useAddLanguageRelationMutation
 >
-export type AddLanguageRelationMutationResult = ApolloReactCommon.MutationResult<
-  AddLanguageRelationMutation
->
+export type AddLanguageRelationMutationResult = ApolloReactCommon.MutationResult<AddLanguageRelationMutation>
 export type AddLanguageRelationMutationOptions = ApolloReactCommon.BaseMutationOptions<
   AddLanguageRelationMutation,
   AddLanguageRelationMutationVariables
@@ -1906,9 +1900,7 @@ export function useRemoveLanguageRelationMutation(
 export type RemoveLanguageRelationMutationHookResult = ReturnType<
   typeof useRemoveLanguageRelationMutation
 >
-export type RemoveLanguageRelationMutationResult = ApolloReactCommon.MutationResult<
-  RemoveLanguageRelationMutation
->
+export type RemoveLanguageRelationMutationResult = ApolloReactCommon.MutationResult<RemoveLanguageRelationMutation>
 export type RemoveLanguageRelationMutationOptions = ApolloReactCommon.BaseMutationOptions<
   RemoveLanguageRelationMutation,
   RemoveLanguageRelationMutationVariables
@@ -2037,9 +2029,10 @@ export const CreatePostDocument = gql`
       status: $status
       images: $images
     ) {
-      id
+      ...PostCardFragment
     }
   }
+  ${PostCardFragmentFragmentDoc}
 `
 export type CreatePostMutationFn = ApolloReactCommon.MutationFunction<
   CreatePostMutation,
@@ -2307,9 +2300,7 @@ export function useInitiatePostImageUploadMutation(
 export type InitiatePostImageUploadMutationHookResult = ReturnType<
   typeof useInitiatePostImageUploadMutation
 >
-export type InitiatePostImageUploadMutationResult = ApolloReactCommon.MutationResult<
-  InitiatePostImageUploadMutation
->
+export type InitiatePostImageUploadMutationResult = ApolloReactCommon.MutationResult<InitiatePostImageUploadMutation>
 export type InitiatePostImageUploadMutationOptions = ApolloReactCommon.BaseMutationOptions<
   InitiatePostImageUploadMutation,
   InitiatePostImageUploadMutationVariables
@@ -2562,9 +2553,7 @@ export function useCreateCommentThanksMutation(
 export type CreateCommentThanksMutationHookResult = ReturnType<
   typeof useCreateCommentThanksMutation
 >
-export type CreateCommentThanksMutationResult = ApolloReactCommon.MutationResult<
-  CreateCommentThanksMutation
->
+export type CreateCommentThanksMutationResult = ApolloReactCommon.MutationResult<CreateCommentThanksMutation>
 export type CreateCommentThanksMutationOptions = ApolloReactCommon.BaseMutationOptions<
   CreateCommentThanksMutation,
   CreateCommentThanksMutationVariables
@@ -2612,9 +2601,7 @@ export function useDeleteCommentThanksMutation(
 export type DeleteCommentThanksMutationHookResult = ReturnType<
   typeof useDeleteCommentThanksMutation
 >
-export type DeleteCommentThanksMutationResult = ApolloReactCommon.MutationResult<
-  DeleteCommentThanksMutation
->
+export type DeleteCommentThanksMutationResult = ApolloReactCommon.MutationResult<DeleteCommentThanksMutation>
 export type DeleteCommentThanksMutationOptions = ApolloReactCommon.BaseMutationOptions<
   DeleteCommentThanksMutation,
   DeleteCommentThanksMutationVariables
@@ -2902,9 +2889,7 @@ export function useInitiateAvatarImageUploadMutation(
 export type InitiateAvatarImageUploadMutationHookResult = ReturnType<
   typeof useInitiateAvatarImageUploadMutation
 >
-export type InitiateAvatarImageUploadMutationResult = ApolloReactCommon.MutationResult<
-  InitiateAvatarImageUploadMutation
->
+export type InitiateAvatarImageUploadMutationResult = ApolloReactCommon.MutationResult<InitiateAvatarImageUploadMutation>
 export type InitiateAvatarImageUploadMutationOptions = ApolloReactCommon.BaseMutationOptions<
   InitiateAvatarImageUploadMutation,
   InitiateAvatarImageUploadMutationVariables
@@ -3039,9 +3024,7 @@ export function useRequestResetPasswordMutation(
 export type RequestResetPasswordMutationHookResult = ReturnType<
   typeof useRequestResetPasswordMutation
 >
-export type RequestResetPasswordMutationResult = ApolloReactCommon.MutationResult<
-  RequestResetPasswordMutation
->
+export type RequestResetPasswordMutationResult = ApolloReactCommon.MutationResult<RequestResetPasswordMutation>
 export type RequestResetPasswordMutationOptions = ApolloReactCommon.BaseMutationOptions<
   RequestResetPasswordMutation,
   RequestResetPasswordMutationVariables
@@ -3305,9 +3288,7 @@ export function useUpdateSocialMediaMutation(
   >(UpdateSocialMediaDocument, baseOptions)
 }
 export type UpdateSocialMediaMutationHookResult = ReturnType<typeof useUpdateSocialMediaMutation>
-export type UpdateSocialMediaMutationResult = ApolloReactCommon.MutationResult<
-  UpdateSocialMediaMutation
->
+export type UpdateSocialMediaMutationResult = ApolloReactCommon.MutationResult<UpdateSocialMediaMutation>
 export type UpdateSocialMediaMutationOptions = ApolloReactCommon.BaseMutationOptions<
   UpdateSocialMediaMutation,
   UpdateSocialMediaMutationVariables

--- a/packages/web/graphql/fragments.graphql
+++ b/packages/web/graphql/fragments.graphql
@@ -153,6 +153,7 @@ fragment PostCardFragment on Post {
   publishedAt
   publishedLanguageLevel
   commentCount
+  status
   images {
     smallSize
   }

--- a/packages/web/graphql/post/createPost.graphql
+++ b/packages/web/graphql/post/createPost.graphql
@@ -14,6 +14,6 @@ mutation createPost(
     status: $status
     images: $images
   ) {
-    id
+    ...PostCardFragment
   }
 }

--- a/packages/web/pages/dashboard/new-post.tsx
+++ b/packages/web/pages/dashboard/new-post.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef, useState } from 'react'
 import { NextPage } from 'next'
 import { useRouter } from 'next/router'
 import { withApollo } from '@/lib/apollo'
@@ -15,10 +15,14 @@ import {
   useNewPostQuery,
   useCreatePostMutation,
   PostStatus as PostStatusType,
+  PostsQuery,
+  PostsQueryVariables,
+  PostsDocument,
 } from '@/generated/graphql'
 import AuthGate from '@/components/AuthGate'
 import { useTranslation } from '@/config/i18n'
 import useUILanguage from '@/hooks/useUILanguage'
+import { toast } from 'react-toastify'
 
 const initialData: InputPostData = {
   title: '',
@@ -39,11 +43,35 @@ const NewPostPage: NextPage = () => {
   const { data: { currentUser, topics } = {} } = useNewPostQuery({
     variables: { uiLanguage },
   })
-  const dataRef = React.useRef<OutputPostData>()
+  const dataRef = useRef<OutputPostData>()
   const router = useRouter()
   const { t } = useTranslation('post')
-  const [createPost] = useCreatePostMutation()
-  const [errorMessage, setErrorMessage] = React.useState<string | null>(null)
+  const [createPost, createPostOptions] = useCreatePostMutation({
+    onCompleted: (mutationResult) => {
+      dataRef.current?.clear()
+      router.push({ pathname: `/post/${mutationResult.createPost.id}` })
+    },
+    onError: (error) => {
+      toast.error(error.message)
+    },
+    update: (cache, mutationResult) => {
+      if (currentUser?.id && mutationResult.data?.createPost) {
+        const data = cache.readQuery<PostsQuery, PostsQueryVariables>({
+          query: PostsDocument,
+          variables: {
+            status: mutationResult.data.createPost.status,
+            authorId: currentUser.id,
+          },
+        })
+
+        if (data?.posts) {
+          data.posts.push(mutationResult.data.createPost)
+          cache.writeQuery({ query: PostsDocument, data: data.posts })
+        }
+      }
+    },
+  })
+  const [errorMessage, setErrorMessage] = useState('')
 
   const createNewPost = async (status: PostStatusType) => {
     if (!(createPost && dataRef.current)) {
@@ -56,20 +84,10 @@ const NewPostPage: NextPage = () => {
       return
     }
 
-    const { title, languageId, topicIds, image, body, clear } = dataRef.current
+    const { title, languageId, topicIds, image, body } = dataRef.current
     const images = image ? [image] : []
 
-    const createPostResponse = await createPost({
-      variables: { title, body, status, languageId, topicIds, images },
-    })
-
-    if (!createPostResponse?.data?.createPost) {
-      console.error('Got empty response when attempting to create post.')
-      return
-    }
-
-    clear()
-    router.push({ pathname: `/post/${createPostResponse.data.createPost.id}` })
+    createPost({ variables: { title, body, status, languageId, topicIds, images } })
   }
 
   return (
@@ -93,18 +111,21 @@ const NewPostPage: NextPage = () => {
               type="submit"
               variant={ButtonVariant.Primary}
               data-test="post-submit"
-              onClick={(e: React.MouseEvent) => {
+              loading={createPostOptions.loading}
+              onClick={(e) => {
                 e.preventDefault()
                 createNewPost(PostStatusType.Published)
               }}
             >
               {t('publishCTA')}
             </Button>
+
             <Button
               type="submit"
               variant={ButtonVariant.Secondary}
               data-test="post-draft"
-              onClick={(e: React.MouseEvent) => {
+              disabled={createPostOptions.loading}
+              onClick={(e) => {
                 e.preventDefault()
                 createNewPost(PostStatusType.Draft)
               }}
@@ -112,7 +133,9 @@ const NewPostPage: NextPage = () => {
               {t('saveDraftCTA')}
             </Button>
           </div>
+
           {errorMessage && <span className="error-message">{errorMessage}</span>}
+
           <style jsx>{`
             display: flex;
             flex-direction: column;

--- a/packages/web/pages/dashboard/new-post.tsx
+++ b/packages/web/pages/dashboard/new-post.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState } from 'react'
 import { NextPage } from 'next'
 import { useRouter } from 'next/router'
+import { toast } from 'react-toastify'
 import { withApollo } from '@/lib/apollo'
 
 import DashboardLayout from '@/components/Layouts/DashboardLayout'
@@ -22,7 +23,6 @@ import {
 import AuthGate from '@/components/AuthGate'
 import { useTranslation } from '@/config/i18n'
 import useUILanguage from '@/hooks/useUILanguage'
-import { toast } from 'react-toastify'
 
 const initialData: InputPostData = {
   title: '',


### PR DESCRIPTION
## Description

**Issue:** #496 

After creating a post as a draft or publishing it, the user will be able to see this one on the list of `My posts`

FYI: Instead of invalidating the query, I'm following the previous implementation of update the cache after receive a request success callback. With this approach, we can avoid an extra request.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅

component `packages/web/pages/dashboard/new-post.tsx` refactors:
- [x] use `toast` in case of error;
- [x] remove sending generic types on `useState`, once the initial value can be an empty string;
- [x] use `useCreatePostMutation` callbacks;
