### PR TITLE
feat(434): use optimistic thanks on comments

### DIFF
--- a/packages/web/components/InlineFeedbackPopover/Thread.tsx
+++ b/packages/web/components/InlineFeedbackPopover/Thread.tsx
@@ -81,7 +81,7 @@ const Thread: React.FC<ThreadProps> = ({
                 canEdit={canEdit}
                 key={idx}
                 onUpdateComment={onUpdateComment}
-                currentUserId={currentUser?.id}
+                currentUser={currentUser}
               />
             )
           })}


### PR DESCRIPTION
## Description

**Issue:** #434 

It will add an optimistic UI experience to the thanks on comments.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] refactor types
- [x] memorize the value of the variable `hasThankedComment`
- [x] apply progress cursor when the `thanks` action is loading

> FYI: Just made a re-research about the approach to update the cache data on the latest apollo client, was very unhappy with the last approach I used before using `cache. readQuery` and `cache. writeQuery` (used to use it in my previous experience with apollo-client ). Anyways, found this function `cache.modify` that definitely is very easy to implement and remove all that complexity adopted before.
> - https://www.apollographql.com/blog/first-impressions-with-apollo-client-3-2ae2a069ab2f/
> - https://www.apollographql.com/docs/react/caching/cache-interaction/#cachemodify

## Screenshots
https://www.loom.com/share/2a4478d009304e5496193d7f3e77a45e