### PR TITLE
Set up GraphCDN

### DIFF
--- a/packages/web/lib/apollo.tsx
+++ b/packages/web/lib/apollo.tsx
@@ -146,20 +146,13 @@ function initApolloClient(initialState?: ApolloClientCache, headers = {}) {
 function createApolloClient(initialState: ApolloClientCache = {}, headers = {}) {
   let graphqlUri = '/api/graphql'
 
-  if (typeof window === 'undefined') {
+  // In production use GraphCDN, which is running at api.journaly.com
+  if (process.env.NODE_ENV === 'production') {
+    graphqlUri = `https://api.journaly.com`
+  } else if (typeof window === 'undefined') {
     // If doing SSR, we have to absolutize this URL. On client domain can be
     // inferred from document location.
-    const deploymentHost = process.env.DEPLOYMENT_URL || process.env.VERCEL_URL
-
-    if (process.env.NODE_ENV === 'production') {
-      if (!deploymentHost) {
-        throw new Error('In production, one of `DEPLOYMENT_URL` or `VERCEL_URL` must be set.')
-      }
-
-      graphqlUri = `https://${deploymentHost}/api/graphql`
-    } else {
-      graphqlUri = `http://${deploymentHost || 'localhost:3000'}/api/graphql`
-    }
+    graphqlUri = `http://localhost:3000/api/graphql`
   } else {
     graphqlUri = `${document.location.origin}/api/graphql`
   }

--- a/packages/web/nexus/user.ts
+++ b/packages/web/nexus/user.ts
@@ -199,6 +199,7 @@ const UserMutations = extendType({
           'Set-Cookie',
           serialize('token', token, {
             httpOnly: true,
+            domain: process.env.NODE_ENV === 'production' ? 'journaly.com' : undefined,
             maxAge: 60 * 60 * 24 * 365,
             path: '/',
           }),


### PR DESCRIPTION
This sets up GraphCDN in production!

Note that I had to explicitly set the domain on the session cookie, refer to that commit for more background on that. Other than that I just changed the URL Apollo Client is fetching from in production to the GraphCDN one!

**DO NOT MERGE THIS UNTIL YOU HAVE api.journaly.com SET UP!** Here's the two CNAME's you have to set to enable it:

```
FROM: _acme-challenge.api.journaly.com 
TO: nbklcf9uy4urmfcm9h.fastly-validations.com

FROM: api.journaly.com
TO: ecp.map.fastly.net
```

**Issue:** N/A

Journaly.com profile url (include if you'd like the "code contributor" badge): https://journaly.com/dashboard/profile/5638
