### PR TITLE
bugfix(505): feedback thread position when opened in tables

### DIFF
--- a/packages/web/components/Dashboard/Post/Post.tsx
+++ b/packages/web/components/Dashboard/Post/Post.tsx
@@ -24,6 +24,8 @@ import { Router, useTranslation } from '@/config/i18n'
 import PostHeader from '@/components/PostHeader'
 import ConfirmationModal from '@/components/Modals/ConfirmationModal'
 
+import {getCoords} from './helpers'
+
 interface IPostProps {
   post: PostType
   currentUser: UserType | null | undefined
@@ -427,8 +429,7 @@ const Post = ({ post, currentUser, refetch }: IPostProps) => {
 
     setActiveThreadId(parseInt(target.dataset.tid, 10))
     setPopoverPosition({
-      x: target.offsetLeft,
-      y: target.offsetTop,
+      ...getCoords(target),
       w: target.offsetWidth,
       h: target.offsetHeight,
     })

--- a/packages/web/components/Dashboard/Post/helpers.ts
+++ b/packages/web/components/Dashboard/Post/helpers.ts
@@ -1,0 +1,21 @@
+/**
+ * Get an element’s position relative to the document
+ * @see https://stackoverflow.com/a/26230989/3610495
+ */
+export const getCoords = (htmlElement: HTMLElement) => {
+  const box = htmlElement.getBoundingClientRect()
+
+  const body = document.body
+  const docEl = document.documentElement
+
+  const scrollTop = window.pageYOffset || docEl.scrollTop || body.scrollTop
+  const scrollLeft = window.pageXOffset || docEl.scrollLeft || body.scrollLeft
+
+  const clientTop = docEl.clientTop || body.clientTop || 0
+  const clientLeft = docEl.clientLeft || body.clientLeft || 0
+
+  const top = box.top + scrollTop - clientTop
+  const left = box.left + scrollLeft - clientLeft
+
+  return { y: Math.round(top), x: Math.round(left) }
+}


### PR DESCRIPTION
## Description

**Issue:** fixes #505 

Investigating it, saw that the feedback popover was being shown in the wrong position.
https://www.loom.com/share/78298707a4024d43872625575761fbfe

To fix it decided to get the element's coordinates related to the document.
FYI: current version gets the parent position

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Create a function that gets element's coordinates based on the document

## Screenshots
https://www.loom.com/share/d89ed30c28274abcb5691e1c209d683f