### PR TITLE
Revert "Set up GraphCDN"

### DIFF
--- a/packages/web/lib/apollo.tsx
+++ b/packages/web/lib/apollo.tsx
@@ -172,13 +172,20 @@ function initApolloClient(initialState?: ApolloClientCache, headers = {}) {
 function createApolloClient(initialState: ApolloClientCache = {}, headers = {}) {
   let graphqlUri = '/api/graphql'
 
-  // In production use GraphCDN, which is running at api.journaly.com
-  if (process.env.NODE_ENV === 'production') {
-    graphqlUri = `https://api.journaly.com`
-  } else if (typeof window === 'undefined') {
+  if (typeof window === 'undefined') {
     // If doing SSR, we have to absolutize this URL. On client domain can be
     // inferred from document location.
-    graphqlUri = `http://localhost:3000/api/graphql`
+    const deploymentHost = process.env.DEPLOYMENT_URL || process.env.VERCEL_URL
+
+    if (process.env.NODE_ENV === 'production') {
+      if (!deploymentHost) {
+        throw new Error('In production, one of `DEPLOYMENT_URL` or `VERCEL_URL` must be set.')
+      }
+
+      graphqlUri = `https://${deploymentHost}/api/graphql`
+    } else {
+      graphqlUri = `http://${deploymentHost || 'localhost:3000'}/api/graphql`
+    }
   } else {
     graphqlUri = `${document.location.origin}/api/graphql`
   }

--- a/packages/web/nexus/user.ts
+++ b/packages/web/nexus/user.ts
@@ -256,7 +256,6 @@ const UserMutations = extendType({
           'Set-Cookie',
           serialize('token', token, {
             httpOnly: true,
-            domain: process.env.NODE_ENV === 'production' ? 'journaly.com' : undefined,
             maxAge: 60 * 60 * 24 * 365,
             path: '/',
           }),


### PR DESCRIPTION
Reverts Journaly/journaly#510

`GET https://www.googletagmanager.com/gtag/js?id=UA-162783279-1 net::ERR_BLOCKED_BY_CLIENT`
`Access to fetch at 'https://api.journaly.com/' from origin 'https://journaly.com' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.`
`POST https://api.journaly.com/ net::ERR_FAILED`