### PR TITLE
Inline image misc fixes

### DIFF
--- a/packages/web/components/JournalyEditor/JournalyEditor.tsx
+++ b/packages/web/components/JournalyEditor/JournalyEditor.tsx
@@ -102,9 +102,12 @@ const JournalyEditor = ({
           padding: 0 25px 10px;
           border: 1px solid ${theme.colors.black};
           border-radius: 5px;
-          min-height: 200px;
           background-color: ${theme.colors.white};
           opacity: ${disabled ? 0.6 : 'auto'};
+        }
+
+        .editor-container > :global([contenteditable="true"]) {
+          min-height: 200px;
         }
       `}</style>
     </div>

--- a/packages/web/components/JournalyEditor/RenderElement.tsx
+++ b/packages/web/components/JournalyEditor/RenderElement.tsx
@@ -1,10 +1,30 @@
 import React from 'react'
 import { renderElementTable } from '@udecode/slate-plugins'
-import { RenderElementProps } from 'slate-react'
+import { useSelected, RenderElementProps } from 'slate-react'
 
 import { isImageNode, isLinkNode, isTableFamilyNode } from '@/utils/slate'
 
-const RenderElement = ({ attributes, children, element }: RenderElementProps) => {
+const ImageElement = ({ attributes, element, children }: RenderElementProps) => {
+  const selected = useSelected()
+
+  return isImageNode(element) ? (
+    <div {...attributes} className="embedded-image">
+      <div contentEditable={false}>
+        <img src={element.url} />
+      </div>
+      {children}
+      <style jsx>{`
+        .embedded-image img {
+          box-shadow: ${selected ? '0 0 0 3px #B4D5FF' : 'none'};
+        }
+      `}</style>
+    </div>
+  ) : null
+}
+
+const RenderElement = (props: RenderElementProps) => {
+  const { attributes, children, element } = props
+
   if (isTableFamilyNode(element)) {
     const tableElement = renderElementTable()({ attributes, children, element })
     if (tableElement) {
@@ -30,14 +50,7 @@ const RenderElement = ({ attributes, children, element }: RenderElementProps) =>
     case 'numbered-list':
       return <ol {...attributes}>{children}</ol>
     case 'image':
-      return isImageNode(element) ? (
-        <div {...attributes}>
-          <div contentEditable={false}>
-            <img src={element.url} />
-          </div>
-          {children}
-        </div>
-      ) : null
+      return <ImageElement {...props} />
     default:
       return <p {...attributes}>{children}</p>
   }

--- a/packages/web/components/JournalyEditor/helpers.ts
+++ b/packages/web/components/JournalyEditor/helpers.ts
@@ -225,7 +225,6 @@ const dataUrlizeFile = (file: File): Promise<string> => {
 export const insertImage = async (editor: ReactEditor, file: File) => {
   const url = await dataUrlizeFile(file)
 
-  console.log(editor)
   const nodes = [
     {
       type: 'image',

--- a/packages/web/components/JournalyEditor/helpers.ts
+++ b/packages/web/components/JournalyEditor/helpers.ts
@@ -225,13 +225,22 @@ const dataUrlizeFile = (file: File): Promise<string> => {
 export const insertImage = async (editor: ReactEditor, file: File) => {
   const url = await dataUrlizeFile(file)
 
-  const image = {
-    type: 'image',
-    url,
-    uploaded: false,
-    children: [{ text: '' }]
-  }
-  Transforms.insertNodes(editor, image)
+  console.log(editor)
+  const nodes = [
+    {
+      type: 'image',
+      url,
+      uploaded: false,
+      children: [{ text: '' }]
+    },
+    // Insert an empty paragraph after the image so typing can continue.
+    {
+      type: 'paragraph',
+      children: [{text: ''}]
+    },
+  ]
+
+  Transforms.insertNodes(editor, nodes)
 }
 
 export const withImages = (editor: ReactEditor) => {


### PR DESCRIPTION
## Description

Mainly fixes issues with inline images, namely the inability to move the cursor past an inline image when it's at the end of the document, and adds some visibility into when the image is "selected" (meaning the cursor is on it). But also: Fixes #547 while we're here.

## Migrations

No migs