### PR TITLE
Comments in activity graph

### DIFF
--- a/packages/web/components/Dashboard/Profile/ProfileStats.tsx
+++ b/packages/web/components/Dashboard/Profile/ProfileStats.tsx
@@ -202,6 +202,32 @@ const ProfileStats = ({ userId }: ProfileStatsProps) => {
       </div>
 
       <h2>{t('stats.activity.title')}</h2>
+      <div className="activity-type-toggles">
+        <label>
+          <input
+            type="checkbox"
+            checked={includePosts}
+            onChange={(e) => setIncludePosts(!includePosts)}
+          />
+          <span>{t('stats.activity.types.posts')}</span>
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            checked={includePostComments}
+            onChange={(e) => setIncludePostComments(!includePostComments)}
+          />
+          <span>{t('stats.activity.types.postComments')}</span>
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            checked={includeThreadComments}
+            onChange={(e) => setIncludeThreadComments(!includeThreadComments)}
+          />
+          <span>{t('stats.activity.types.threadComments')}</span>
+        </label>
+      </div>
       <svg
         className="activityChart"
         viewBox={`0 0 ${(NUM_WEEKS + 1) * (CELL_WIDTH + CELL_PADDING) + 20} 100`}
@@ -247,32 +273,6 @@ const ProfileStats = ({ userId }: ProfileStatsProps) => {
           ))}
         </g>
       </svg>
-      <div>
-        <label>
-          <input
-            type="checkbox"
-            checked={includePosts}
-            onChange={(e) => setIncludePosts(!includePosts)}
-          />
-          <span>{t('stats.activity.types.posts')}</span>
-        </label>
-        <label>
-          <input
-            type="checkbox"
-            checked={includePostComments}
-            onChange={(e) => setIncludePostComments(!includePostComments)}
-          />
-          <span>{t('stats.activity.types.postComments')}</span>
-        </label>
-        <label>
-          <input
-            type="checkbox"
-            checked={includeThreadComments}
-            onChange={(e) => setIncludeThreadComments(!includeThreadComments)}
-          />
-          <span>{t('stats.activity.types.threadComments')}</span>
-        </label>
-      </div>
       <style jsx>{`
         h2 {
           text-align: center;
@@ -289,6 +289,18 @@ const ProfileStats = ({ userId }: ProfileStatsProps) => {
           max-width: 600px;
           align-self: center;
           margin-bottom: 20px;
+        }
+
+        .activity-type-toggles {
+          display: flex;
+          flex-direction: row;
+          flex-wrap: wrap;
+          justify-content: space-around;
+          padding-bottom: 10px;
+        }
+
+        .activity-type-toggles > label > input {
+          margin-right: 5px;
         }
       `}</style>
     </>

--- a/packages/web/components/Dashboard/Profile/ProfileStats.tsx
+++ b/packages/web/components/Dashboard/Profile/ProfileStats.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useState, useMemo, useCallback } from 'react'
 import { useTranslation } from '@/config/i18n'
 import chroma from 'chroma-js'
 
@@ -20,6 +20,12 @@ import { useUserStatsQuery } from '@/generated/graphql'
 
 type ProfileStatsProps = {
   userId: number
+}
+
+type ActivityCounts = {
+  postCount: number
+  postCommentCount: number
+  threadCommentCount: number
 }
 
 const CELL_WIDTH = 8
@@ -49,6 +55,17 @@ const ProfileStats = ({ userId }: ProfileStatsProps) => {
     }
   })
 
+  const [includePosts, setIncludePosts] = useState(true)
+  const [includePostComments, setIncludePostComments] = useState(true)
+  const [includeThreadComments, setIncludeThreadComments] = useState(true)
+
+  const getCount = useCallback((d: ActivityCounts) => {
+    return (0
+      + (includePosts ? d.postCount : 0)
+      + (includePostComments ? d.postCommentCount : 0)
+      + (includeThreadComments ? d.threadCommentCount : 0))
+  }, [includePosts, includePostComments, includeThreadComments])
+
   const [start, end] = useMemo(() => {
     const end = addDays(new Date(), 1)
     const start = addWeeks(end, -NUM_WEEKS)
@@ -56,15 +73,24 @@ const ProfileStats = ({ userId }: ProfileStatsProps) => {
   }, [data])
 
   const denseData = useMemo(() => {
-    const indexable: { [key: string]: number } = {}
-    if (data?.userById?.postActivity) {
-      const { postActivity } = data.userById
-      for (var i=0; i < postActivity.length; i++) {
-        indexable[postActivity[i].date] = postActivity[i].count
+    const indexable: { [key: string]: ActivityCounts } = {}
+    if (data?.userById?.activityGraphData) {
+      const { activityGraphData } = data.userById
+      for (var i=0; i < activityGraphData.length; i++) {
+        const {
+          date,
+          postCount,
+          postCommentCount,
+          threadCommentCount
+        } = activityGraphData[i]
+        indexable[date] = {
+          postCount,
+          postCommentCount,
+          threadCommentCount
+        }
       }
     }
 
-    let max = 0
     const rightEdge = NUM_WEEKS * (CELL_WIDTH + CELL_PADDING)
     const days = eachDayOfInterval({ start, end }).map(date => {
       const x = (
@@ -72,11 +98,20 @@ const ProfileStats = ({ userId }: ProfileStatsProps) => {
         - (CELL_WIDTH + CELL_PADDING)
         * differenceInCalendarWeeks(end, date))
       const y = (CELL_WIDTH + CELL_PADDING) * getDay(date)
-      const count = indexable[formatISO(date, { representation: 'date' })] || 0
+      const {
+        postCount,
+        postCommentCount,
+        threadCommentCount
+      } = indexable[formatISO(date, { representation: 'date' })] || {}
 
-      max = Math.max(max, count)
-
-      return { x, y, count, date }
+      return {
+        x,
+        y,
+        date,
+        postCount: postCount || 0,
+        postCommentCount: postCommentCount || 0,
+        threadCommentCount: threadCommentCount || 0,
+      }
     })
 
     const months = eachMonthOfInterval({ start, end }).map(date => {
@@ -94,16 +129,27 @@ const ProfileStats = ({ userId }: ProfileStatsProps) => {
     months.shift()
 
     return {
-      max: Math.max(max, 1),
       months,
       days,
     }
   }, [data, start, end])
 
+  const { maxValue, days } = useMemo(() => {
+    let max =  0
+    const days = denseData.days.map((d) => {
+      const count = getCount(d)
+      max = Math.max(max, count)
+
+      return { ...d, count }
+    })
+
+    return { days, maxValue: Math.max(max, 1) }
+  }, [denseData, getCount])
+
   const colorScale = chroma
     .scale([theme.colors.white, theme.colors.blueLight])
     .mode('lab')
-    .domain([0, denseData.max])
+    .domain([0, maxValue])
 
   if (loading || !data) {
     return <span>Loading...</span>
@@ -161,7 +207,7 @@ const ProfileStats = ({ userId }: ProfileStatsProps) => {
         viewBox={`0 0 ${(NUM_WEEKS + 1) * (CELL_WIDTH + CELL_PADDING) + 20} 100`}
       >
         <g transform="translate(20, 10)">
-          {denseData.days.map(d => (
+          {days.map(d => (
             <rect
               key={formatISO(d.date)}
               fill={colorScale(d.count).hex()}
@@ -201,6 +247,32 @@ const ProfileStats = ({ userId }: ProfileStatsProps) => {
           ))}
         </g>
       </svg>
+      <div>
+        <label>
+          <input
+            type="checkbox"
+            checked={includePosts}
+            onChange={(e) => setIncludePosts(!includePosts)}
+          />
+          <span>{t('stats.activity.types.posts')}</span>
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            checked={includePostComments}
+            onChange={(e) => setIncludePostComments(!includePostComments)}
+          />
+          <span>{t('stats.activity.types.postComments')}</span>
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            checked={includeThreadComments}
+            onChange={(e) => setIncludeThreadComments(!includeThreadComments)}
+          />
+          <span>{t('stats.activity.types.threadComments')}</span>
+        </label>
+      </div>
       <style jsx>{`
         h2 {
           text-align: center;

--- a/packages/web/components/Dashboard/Profile/ProfileStats.tsx
+++ b/packages/web/components/Dashboard/Profile/ProfileStats.tsx
@@ -207,7 +207,7 @@ const ProfileStats = ({ userId }: ProfileStatsProps) => {
           <input
             type="checkbox"
             checked={includePosts}
-            onChange={(e) => setIncludePosts(!includePosts)}
+            onChange={() => setIncludePosts(!includePosts)}
           />
           <span>{t('stats.activity.types.posts')}</span>
         </label>
@@ -215,7 +215,7 @@ const ProfileStats = ({ userId }: ProfileStatsProps) => {
           <input
             type="checkbox"
             checked={includePostComments}
-            onChange={(e) => setIncludePostComments(!includePostComments)}
+            onChange={() => setIncludePostComments(!includePostComments)}
           />
           <span>{t('stats.activity.types.postComments')}</span>
         </label>
@@ -223,7 +223,7 @@ const ProfileStats = ({ userId }: ProfileStatsProps) => {
           <input
             type="checkbox"
             checked={includeThreadComments}
-            onChange={(e) => setIncludeThreadComments(!includeThreadComments)}
+            onChange={() => setIncludeThreadComments(!includeThreadComments)}
           />
           <span>{t('stats.activity.types.threadComments')}</span>
         </label>

--- a/packages/web/generated/graphql.tsx
+++ b/packages/web/generated/graphql.tsx
@@ -181,7 +181,7 @@ export type User = {
   thanksReceivedCount: Scalars['Int']
   threadCommentsCount: Scalars['Int']
   postCommentsCount: Scalars['Int']
-  postActivity: Array<DatedActivityCount>
+  activityGraphData: Array<DatedActivityCount>
 }
 
 export type UserBadge = {
@@ -203,8 +203,10 @@ export type InitiateAvatarImageUploadResponse = {
 
 export type DatedActivityCount = {
   __typename?: 'DatedActivityCount'
-  count: Scalars['Int']
   date: Scalars['String']
+  postCount: Scalars['Int']
+  threadCommentCount: Scalars['Int']
+  postCommentCount: Scalars['Int']
 }
 
 export type LanguageRelation = {
@@ -301,8 +303,8 @@ export enum UserRole {
 export enum BadgeType {
   AlphaUser = 'ALPHA_USER',
   BetaUser = 'BETA_USER',
-  TenPosts = 'TEN_POSTS',
   OnehundredPosts = 'ONEHUNDRED_POSTS',
+  TenPosts = 'TEN_POSTS',
   CodeContributor = 'CODE_CONTRIBUTOR',
 }
 
@@ -1200,8 +1202,11 @@ export type UserStatsQuery = { __typename?: 'Query' } & {
     | 'thanksReceivedCount'
     | 'createdAt'
   > & {
-      postActivity: Array<
-        { __typename?: 'DatedActivityCount' } & Pick<DatedActivityCount, 'count' | 'date'>
+      activityGraphData: Array<
+        { __typename?: 'DatedActivityCount' } & Pick<
+          DatedActivityCount,
+          'date' | 'postCount' | 'threadCommentCount' | 'postCommentCount'
+        >
       >
     }
 }
@@ -3916,9 +3921,11 @@ export const UserStatsDocument = gql`
       postCommentsCount
       thanksReceivedCount
       createdAt
-      postActivity {
-        count
+      activityGraphData {
         date
+        postCount
+        threadCommentCount
+        postCommentCount
       }
     }
   }

--- a/packages/web/graphql/user/userStats.graphql
+++ b/packages/web/graphql/user/userStats.graphql
@@ -9,9 +9,11 @@ query userStats($id: Int!) {
     postCommentsCount
     thanksReceivedCount
     createdAt
-    postActivity {
-      count
+    activityGraphData {
       date
+      postCount
+      threadCommentCount
+      postCommentCount
     }
   }
 }

--- a/packages/web/public/static/locales/en/profile.json
+++ b/packages/web/public/static/locales/en/profile.json
@@ -15,7 +15,12 @@
       "thanksCount": "For their hard work helping others, they've been thanked {{thanksCount}} times."
     },
     "activity": {
-      "title": "Posting History"
+      "title": "Activity History",
+      "types": {
+        "posts": "Posts",
+        "postComments": "Post Comments",
+        "threadComments": "Inline Comments"
+      }
     }
   },
   "statsTitle": "Stats",

--- a/packages/web/resolvers/user.ts
+++ b/packages/web/resolvers/user.ts
@@ -23,8 +23,10 @@ import { validateUpdateUserMutationData } from './utils/userValidation'
 const DatedActivityCount = objectType({
   name: 'DatedActivityCount',
   definition(t) {
-    t.int('count')
     t.string('date')
+    t.int('postCount')
+    t.int('threadCommentCount')
+    t.int('postCommentCount')
   }
 })
 
@@ -117,7 +119,7 @@ const User = objectType({
         })
       },
     })
-    t.list.field('postActivity', {
+    t.list.field('activityGraphData', {
       type: 'DatedActivityCount',
       resolve(parent, _args, ctx, _info) {
         const stats = ctx.db.$queryRaw`
@@ -128,7 +130,7 @@ const User = objectType({
                 COUNT(*) as count
               FROM "Post"
               WHERE
-                "authorId" = 1
+                "authorId" = ${parent.id}
                 AND "status" = 'PUBLISHED'
               GROUP BY date
               ORDER BY date DESC
@@ -139,7 +141,7 @@ const User = objectType({
                 COUNT(*) as count
               FROM "Comment"
               WHERE
-                "authorId" = 1
+                "authorId" = ${parent.id}
               GROUP BY date
               ORDER BY date DESC
             ),
@@ -149,7 +151,7 @@ const User = objectType({
                 COUNT(*) as count
               FROM "PostComment"
               WHERE
-                "authorId" = 1
+                "authorId" = ${parent.id}
               GROUP BY date
               ORDER BY date DESC
             )


### PR DESCRIPTION
## Description

**Issue:** #567

Includes post comments and thread comments in activity graph on profile/stats page, with toggles to select which sorts of activities are included in the graph

## Migrations

No DB changes, as before the stats query is ad-hoc

## Screenshots

<img width="1402" alt="Screen Shot 2021-05-21 at 12 39 20 PM" src="https://user-images.githubusercontent.com/2343714/119177179-93287c80-ba31-11eb-9101-9e7f09d8a5b4.png">

