### PR TITLE
[j-mail] Add prisma as a direct dep and upgrade typescript to 4.x

### DIFF
--- a/packages/j-mail/package-lock.json
+++ b/packages/j-mail/package-lock.json
@@ -56,6 +56,12 @@
         "@prisma/engines-version": "2.21.0-36.e421996c87d5f3c8f7eeadd502d4ad402c89464d"
       }
     },
+    "@prisma/engines": {
+      "version": "2.21.0-36.e421996c87d5f3c8f7eeadd502d4ad402c89464d",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-2.21.0-36.e421996c87d5f3c8f7eeadd502d4ad402c89464d.tgz",
+      "integrity": "sha512-L57tvSoom2GDWDqik4wrAUBvLTAv5MTm2OOzNMBKsv0w5cX7ONoZ8KnGQN+csmdJpQVBs93dIvIBm72OO+l/9Q==",
+      "dev": true
+    },
     "@prisma/engines-version": {
       "version": "2.21.0-36.e421996c87d5f3c8f7eeadd502d4ad402c89464d",
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-2.21.0-36.e421996c87d5f3c8f7eeadd502d4ad402c89464d.tgz",
@@ -1275,6 +1281,15 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
+    "prisma": {
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-2.21.0.tgz",
+      "integrity": "sha512-lmlfcWEyl24AO788DmZOerFl8npH0xW2aY1BmXLeTgHvovvk3/AJIYZNfaDEx9wuvjNLhZTExICMDAtJIFi3kQ==",
+      "dev": true,
+      "requires": {
+        "@prisma/engines": "2.21.0-36.e421996c87d5f3c8f7eeadd502d4ad402c89464d"
+      }
+    },
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
@@ -1749,9 +1764,9 @@
       }
     },
     "typescript": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
       "dev": true
     },
     "union-value": {

--- a/packages/j-mail/package.json
+++ b/packages/j-mail/package.json
@@ -4,8 +4,8 @@
   "description": "An email notification queueing service.",
   "main": "index.js",
   "scripts": {
-    "deploy:stage": "sls deploy --stage stage",
-    "deploy:prod": "sls deploy --stage prod",
+    "deploy:stage": "npm run prisma:generate && sls deploy --stage stage",
+    "deploy:prod": "npm run prisma:generate && sls deploy --stage prod",
     "scenarios": "ts-node email-scenarios/index.ts",
     "type-check": "tsc",
     "prisma:generate": "npm explore '@journaly/j-db-client' -- npm run prisma:generate"
@@ -27,9 +27,10 @@
     "@types/aws-lambda": "^8.10.70",
     "@types/node": "^14.14.20",
     "@types/pug": "^2.0.4",
+    "prisma": "^2.21.0",
     "serverless-plugin-typescript": "^1.1.9",
     "ts-node": "^9.1.1",
-    "typescript": "3.8.3"
+    "typescript": "4.2.4"
   },
   "dependencies": {
     "@journaly/j-db-client": "^11.0.0",


### PR DESCRIPTION
Upgrade typescript for j-mail and ensure prisma:generate runs before a deploy.