### PR TITLE
Fix J-Editor Toolbar Transparency Bug

### DIFF
--- a/packages/web/components/JournalyEditor/Toolbar/Toolbar.tsx
+++ b/packages/web/components/JournalyEditor/Toolbar/Toolbar.tsx
@@ -161,6 +161,7 @@ const Toolbar = ({ allowInlineImages }: ToolbarProps) => {
           justify-content: center;
           padding: 15px 0;
           border-bottom: 2px solid #eee;
+          z-index: 1;
         }
 
         .is-fixed .editor-toolbar {


### PR DESCRIPTION
## Description

**Issue:** fixes #586 

The toolbar ended up with appearing as transparent when floating above elements and was actually behind them making it also unclickable.

This PR simply sets the z-index to `1` which appears to be sufficient.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Make the fix

## Migrations

No migs

## Screenshots

(See issue for original problem)
![image](https://user-images.githubusercontent.com/34203886/120100113-df14a900-c136-11eb-8df5-9ca69d40d486.png)

