### PR TITLE
Ensure no extra fields show up when saving a post with an existing image

### DIFF
--- a/packages/j-mail/src/emails/updateEmail.ts
+++ b/packages/j-mail/src/emails/updateEmail.ts
@@ -18,7 +18,7 @@ const formatNotificationBlock = (note: ValidatedNotification): string => {
     case ('POST_COMMENT'): {
       return `
         <div>
-          <img src="${note.image}" style="
+          <img src="${note.headlineImage}" style="
             display: block;
             width: 100%;
             height: 150px;
@@ -50,7 +50,7 @@ const formatNotificationBlock = (note: ValidatedNotification): string => {
     case ('THREAD_COMMENT'): {
       return `
         <div>
-          <img src="${note.image}" style="
+          <img src="${note.headlineImage}" style="
             display: block;
             width: 100%;
             height: 150px;

--- a/packages/j-mail/src/handler.ts
+++ b/packages/j-mail/src/handler.ts
@@ -79,7 +79,7 @@ const getDataForUpdateEmail = async (
           notificationDate: note.createdAt,
           postComment: note.postComment,
           post: note.postComment.post,
-          headlineImage: note.postComment.post.headlineImage,
+          headlineImage: note.postComment.post.headlineImage.smallSize,
           commentAuthor: note.postComment.author.handle,
         })
       }
@@ -91,7 +91,7 @@ const getDataForUpdateEmail = async (
           comment: note.comment,
           thread: note.comment.thread,
           post: note.comment.thread.post,
-          headlineImage: note.comment.thread.post.headlineImage,
+          headlineImage: note.comment.thread.post.headlineImage.smallSize,
           commentAuthor: note.comment.author.handle,
         })
       }

--- a/packages/j-mail/src/utils.ts
+++ b/packages/j-mail/src/utils.ts
@@ -23,8 +23,8 @@ export type EmailParams = {
 }
 
 export type ValidatedNotification = 
-  | { type: 'POST_COMMENT', notificationDate: Date, postComment: PostComment, post: Post, image: string, commentAuthor: string, }
-  | { type: 'THREAD_COMMENT', notificationDate: Date, comment: Comment, thread: Thread, post: Post, image: string, commentAuthor: string, }
+  | { type: 'POST_COMMENT', notificationDate: Date, postComment: PostComment, post: Post, headlineImage: string, commentAuthor: string, }
+  | { type: 'THREAD_COMMENT', notificationDate: Date, comment: Comment, thread: Thread, post: Post, headlineImage: string, commentAuthor: string, }
 
 export type DataForUpdateEmail = {
   user: User,

--- a/packages/web/components/Dashboard/Post/Post.tsx
+++ b/packages/web/components/Dashboard/Post/Post.tsx
@@ -464,6 +464,11 @@ const Post = ({ post, currentUser, refetch }: IPostProps) => {
       variables: {
         postId: post.id,
         status,
+        // headlineImage is required now but the resolver will see it hasn't changed and do nothing
+        headlineImage: {
+          smallSize: post.headlineImage.smallSize,
+          largeSize: post.headlineImage.largeSize,
+        },
       },
     })
   }

--- a/packages/web/components/PostEditor/PostEditor.tsx
+++ b/packages/web/components/PostEditor/PostEditor.tsx
@@ -132,12 +132,13 @@ const PostEditor: React.FC<PostEditorProps> = ({
       resetLangId()
     }
 
-    const returnImage = !image
-      ? initialData.headlineImage
-      : {
-          largeSize: image.finalUrlLarge,
-          smallSize: image.finalUrlSmall,
-        }
+    const returnImage = !image ? {
+        largeSize: initialData.headlineImage.largeSize,
+        smallSize: initialData.headlineImage.smallSize,
+      } : {
+        largeSize: image.finalUrlLarge,
+        smallSize: image.finalUrlSmall,
+      }
 
     dataRef.current = {
       title,

--- a/packages/web/generated/graphql.tsx
+++ b/packages/web/generated/graphql.tsx
@@ -446,7 +446,7 @@ export type MutationUpdatePostArgs = {
   topicIds?: Maybe<Array<Scalars['Int']>>
   body?: Maybe<Array<EditorNode>>
   status?: Maybe<PostStatus>
-  headlineImage?: Maybe<HeadlineImageInput>
+  headlineImage: HeadlineImageInput
 }
 
 export type MutationDeletePostArgs = {
@@ -730,7 +730,7 @@ export type PostCardFragmentFragment = { __typename?: 'Post' } & Pick<
   | 'commentCount'
   | 'status'
 > & {
-    headlineImage: { __typename?: 'HeadlineImage' } & Pick<HeadlineImage, 'smallSize'>
+    headlineImage: { __typename?: 'HeadlineImage' } & Pick<HeadlineImage, 'id' | 'smallSize'>
     likes: Array<{ __typename?: 'PostLike' } & Pick<PostLike, 'id'>>
     author: { __typename?: 'User' } & AuthorFragmentFragment
     language: { __typename?: 'Language' } & LanguageFragmentFragment
@@ -1004,7 +1004,7 @@ export type UpdatePostMutationVariables = Exact<{
   topicIds?: Maybe<Array<Scalars['Int']> | Scalars['Int']>
   body?: Maybe<Array<EditorNode> | EditorNode>
   status?: Maybe<PostStatus>
-  headlineImage?: Maybe<HeadlineImageInput>
+  headlineImage: HeadlineImageInput
 }>
 
 export type UpdatePostMutation = { __typename?: 'Mutation' } & {
@@ -1418,6 +1418,7 @@ export const PostCardFragmentFragmentDoc = gql`
     commentCount
     status
     headlineImage {
+      id
       smallSize
     }
     likes {
@@ -2939,7 +2940,7 @@ export const UpdatePostDocument = gql`
     $topicIds: [Int!]
     $body: [EditorNode!]
     $status: PostStatus
-    $headlineImage: HeadlineImageInput
+    $headlineImage: HeadlineImageInput!
   ) {
     updatePost(
       postId: $postId

--- a/packages/web/graphql/post/updatePost.graphql
+++ b/packages/web/graphql/post/updatePost.graphql
@@ -5,7 +5,7 @@ mutation updatePost(
   $topicIds: [Int!]
   $body: [EditorNode!]
   $status: PostStatus
-  $headlineImage: HeadlineImageInput
+  $headlineImage: HeadlineImageInput!
 ) {
   updatePost(
     postId: $postId

--- a/packages/web/pages/post/[id]/edit.tsx
+++ b/packages/web/pages/post/[id]/edit.tsx
@@ -36,8 +36,6 @@ const EditPostPage: NextPage = () => {
   const [updatePost] = useUpdatePostMutation()
   const uploadInlineImages = useUploadInlineImages()
 
-  const initialHeadlineImage = initialData?.headlineImage
-
   useAuthCheck(() => {
     return currentUser!.id === postById!.author.id
   }, !!(currentUser && postById))
@@ -83,7 +81,6 @@ const EditPostPage: NextPage = () => {
     let postId: number
     try {
       const modifiedBody = await uploadInlineImages(body)
-      const modifiedHeadlineImage = headlineImage.smallSize === initialHeadlineImage?.smallSize
 
       const { data } = await updatePost({
         variables: {
@@ -92,7 +89,7 @@ const EditPostPage: NextPage = () => {
           title,
           languageId,
           topicIds,
-          headlineImage: modifiedHeadlineImage ? headlineImage : null,
+          headlineImage,
         },
       })
 

--- a/packages/web/resolvers/post.ts
+++ b/packages/web/resolvers/post.ts
@@ -25,8 +25,6 @@ import {
   LanguageRelation,
 } from '@journaly/j-db-client'
 import { EditorNode, HeadlineImageInput } from './inputTypes'
-import headlineImage from './headlineImage'
-
 
 const assignPostCountBadges = async (
   db: PrismaClient,
@@ -448,7 +446,7 @@ const PostMutations = extendType({
         topicIds: intArg({ list: true, required: false }),
         body: EditorNode.asArg({ list: true, required: false }),
         status: arg({ type: 'PostStatus', required: false }),
-        headlineImage: HeadlineImageInput.asArg({ required: false }),
+        headlineImage: HeadlineImageInput.asArg({ required: true }),
       },
       resolve: async (_parent, args, ctx) => {
         // Check user can actually do this
@@ -533,18 +531,15 @@ const PostMutations = extendType({
           data.publishedAt = new Date().toISOString()
         }
 
-        if (args.headlineImage) {
-          if (args.headlineImage.smallSize !== originalPost.headlineImage.smallSize) {
-            await ctx.db.headlineImage.create({
-              data: {
-                ...headlineImage,
-                post: {
-                  connect: {
-                    id: args.postId,
-                  },
-                },
-              },
-            })
+        if (args.headlineImage.smallSize !== originalPost.headlineImage.smallSize) {
+          const headlineImage = await ctx.db.headlineImage.create({
+            data: {
+              smallSize: args.headlineImage.smallSize,
+              largeSize: args.headlineImage.largeSize,
+            }
+          })
+          data.headlineImage = {
+            connect: { id: headlineImage.id }
           }
         }
 
@@ -564,7 +559,6 @@ const PostMutations = extendType({
 
           await Promise.all(insertPromises)
         }
-
 
         const post = await ctx.db.post.update({
           where: { id: args.postId },


### PR DESCRIPTION
Presence of `id` and `__typename` were throwing gql for a loop when saving a post without changing the headline image.