### PR TITLE
Set max vert size on inline images

### DIFF
--- a/packages/web/components/PostBodyStyles/PostBodyStyles.tsx
+++ b/packages/web/components/PostBodyStyles/PostBodyStyles.tsx
@@ -42,6 +42,7 @@ const PostBodyStyles: React.FC<Props> = ({ parentClassName }: Props) => {
 
       .${parentClassName} img {
         max-width: 100%;
+        max-height: 75vh;
         margin: 0 auto;
         display: block;
       }

--- a/packages/web/pages/post/[id]/index.tsx
+++ b/packages/web/pages/post/[id]/index.tsx
@@ -24,7 +24,7 @@ const PostPage: NextPage = () => {
   const outdatedThreads = post ? post.threads.filter((post) => post.archived) : []
 
   return (
-    <DashboardLayout>
+    <DashboardLayout pad="aboveMobile">
       <LoadingWrapper loading={loading} error={error}>
         <div className="post-page-wrapper">
           {post && post.postComments && (


### PR DESCRIPTION
## Description

On laptop resolutions (wide, limited vertical resolution) images could end up occupying more the the full view port, this PR limits the vertical size of an image to 75% of the VP height. 

@robin-macpherson you mentioned that you thought it was going to be more complicated than this, but just a simple limit on vertical size seems to work. Some screenshots below. Let me know if any of these seem off.

Also removes layout padding on posts which I think gives post bodies some needed additional real estate

## Screenshots

Posts with layout padding (existing):

<img width="521" alt="Screen Shot 2021-06-02 at 1 46 33 PM" src="https://user-images.githubusercontent.com/2343714/120537068-76cdfd80-c3aa-11eb-9487-79cc56e0a72f.png">

Without layout padding (proposed):

<img width="476" alt="Screen Shot 2021-06-02 at 1 46 05 PM" src="https://user-images.githubusercontent.com/2343714/120537132-8cdbbe00-c3aa-11eb-81e9-d6bfa4dabe37.png">

Vertical size limiting:

<img width="1410" alt="Screen Shot 2021-06-02 at 1 59 00 PM" src="https://user-images.githubusercontent.com/2343714/120537355-d1675980-c3aa-11eb-8ce5-29b12558593a.png">
<img width="1410" alt="Screen Shot 2021-06-02 at 1 59 03 PM" src="https://user-images.githubusercontent.com/2343714/120537363-d3311d00-c3aa-11eb-83d2-56b3b7da3262.png">
<img width="418" alt="Screen Shot 2021-06-02 at 1 59 09 PM" src="https://user-images.githubusercontent.com/2343714/120537367-d4624a00-c3aa-11eb-8017-36c10fbe6c83.png">
<img width="462" alt="Screen Shot 2021-06-02 at 1 59 14 PM" src="https://user-images.githubusercontent.com/2343714/120537370-d4624a00-c3aa-11eb-8107-bcdd4bc44877.png">
