### PR TITLE
Preserve User's Search Filters With Cookies

### DIFF
--- a/packages/web/components/Dashboard/MyFeed/MyFeed.tsx
+++ b/packages/web/components/Dashboard/MyFeed/MyFeed.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useState, useEffect } from 'react'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
 
@@ -25,11 +25,17 @@ import FeedHeader from './FeedHeader'
 
 const NUM_POSTS_PER_PAGE = 9
 
-type Props = {
-  currentUser: UserType
+export type InitialSearchFilters = {
+  languages: number[],
+  topics: number[],
 }
 
-const MyFeed: React.FC<Props> = ({ currentUser }) => {
+type Props = {
+  currentUser: UserType
+  initialSearchFilters: InitialSearchFilters | null
+}
+
+const MyFeed: React.FC<Props> = ({ currentUser, initialSearchFilters }) => {
   const { t } = useTranslation('my-feed')
 
   const [search, setSearchState] = useState('')
@@ -51,7 +57,7 @@ const MyFeed: React.FC<Props> = ({ currentUser }) => {
   )
 
   const [selectedLanguageFilters, setSelectedLanguageFilters] = useState<number[]>([
-    ...userLanguages.values(),
+    ...initialSearchFilters ? initialSearchFilters.languages : userLanguages.values(),
   ])
 
   const isUserLanguagesFilterActive = _.isEqual(
@@ -130,6 +136,14 @@ const MyFeed: React.FC<Props> = ({ currentUser }) => {
     },
     [selectedLanguageFilters],
   )
+
+  useEffect(() => {
+    const searchFilters = {
+      languages: selectedLanguageFilters,
+      topics: selectedTopicsFilters,
+    }
+    document.cookie = `default_search_filters=${JSON.stringify({searchFilters})};`
+  }, [selectedLanguageFilters, selectedTopicsFilters])
 
   return (
     <div className="my-feed-wrapper">

--- a/packages/web/components/Dashboard/MyFeed/MyFeed.tsx
+++ b/packages/web/components/Dashboard/MyFeed/MyFeed.tsx
@@ -40,7 +40,7 @@ const MyFeed: React.FC<Props> = ({ currentUser, initialSearchFilters }) => {
 
   const [search, setSearchState] = useState('')
   const [selectedTopicsFilters, setSelectedTopicsFilters] = useState<number[]>(
-    initialSearchFilters?.topics.length > 0 ? initialSearchFilters.topics : []
+    initialSearchFilters?.topics || []
   )
 
   // Fetch languages that have at least 1 post
@@ -59,7 +59,7 @@ const MyFeed: React.FC<Props> = ({ currentUser, initialSearchFilters }) => {
   )
 
   const [selectedLanguageFilters, setSelectedLanguageFilters] = useState<number[]>(
-    initialSearchFilters?.languages?.length > 0 ? initialSearchFilters.languages : [],
+    initialSearchFilters?.languages || [],
   )
 
   const isUserLanguagesFilterActive = _.isEqual(

--- a/packages/web/components/Dashboard/MyFeed/MyFeed.tsx
+++ b/packages/web/components/Dashboard/MyFeed/MyFeed.tsx
@@ -39,7 +39,9 @@ const MyFeed: React.FC<Props> = ({ currentUser, initialSearchFilters }) => {
   const { t } = useTranslation('my-feed')
 
   const [search, setSearchState] = useState('')
-  const [selectedTopicsFilters, setSelectedTopicsFilters] = useState<number[]>([])
+  const [selectedTopicsFilters, setSelectedTopicsFilters] = useState<number[]>(
+    initialSearchFilters?.topics.length > 0 ? initialSearchFilters.topics : []
+  )
 
   // Fetch languages that have at least 1 post
   const { data: languagesData } = useLanguagesQuery({
@@ -56,9 +58,9 @@ const MyFeed: React.FC<Props> = ({ currentUser, initialSearchFilters }) => {
       .map((lr) => lr.language.id) || [],
   )
 
-  const [selectedLanguageFilters, setSelectedLanguageFilters] = useState<number[]>([
-    ...initialSearchFilters ? initialSearchFilters.languages : userLanguages.values(),
-  ])
+  const [selectedLanguageFilters, setSelectedLanguageFilters] = useState<number[]>(
+    initialSearchFilters?.languages?.length > 0 ? initialSearchFilters.languages : [],
+  )
 
   const isUserLanguagesFilterActive = _.isEqual(
     Array.from(userLanguages.values()),
@@ -142,7 +144,7 @@ const MyFeed: React.FC<Props> = ({ currentUser, initialSearchFilters }) => {
       languages: selectedLanguageFilters,
       topics: selectedTopicsFilters,
     }
-    document.cookie = `default_search_filters=${JSON.stringify({searchFilters})};`
+    document.cookie = `default_search_filters=${JSON.stringify(searchFilters)};`
   }, [selectedLanguageFilters, selectedTopicsFilters])
 
   return (

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -3054,14 +3054,6 @@
       "integrity": "sha512-y7mImlc/rNkvCRmg8gC3/lj87S7pTUIJ6QGjwHR9WQJcFs+ZMTOaoPrkdFA/YdbuqVEmEbb5RdhVxMkAcgOnpg==",
       "dev": true
     },
-    "@types/cookie-parser": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.2.tgz",
-      "integrity": "sha512-uwcY8m6SDQqciHsqcKDGbo10GdasYsPCYkH3hVegj9qAah6pX5HivOnOuI3WYmyQMnOATV39zv/Ybs0bC/6iVg==",
-      "requires": {
-        "@types/express": "*"
-      }
-    },
     "@types/cookies": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.6.tgz",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -43,7 +43,6 @@
     "@stripe/react-stripe-js": "^1.2.2",
     "@stripe/stripe-js": "^1.12.1",
     "@types/bcryptjs": "^2.4.2",
-    "@types/cookie-parser": "^1.4.2",
     "@types/cors": "^2.8.6",
     "@types/diff": "^4.0.2",
     "@types/escape-html": "^1.0.0",

--- a/packages/web/pages/dashboard/my-feed.tsx
+++ b/packages/web/pages/dashboard/my-feed.tsx
@@ -28,15 +28,22 @@ const MyFeedPage: NextPage<InitialProps> = ({ initialSearchFilters }) => {
 }
 
 MyFeedPage.getInitialProps = async (ctx) => {
-  let initialSearchFilters
+  let initialSearchFilters = null
   if (typeof window !== 'undefined') {
-    const defaultSearchFilters = JSON.parse(cookie.parse(document.cookie).default_search_filters)
-    initialSearchFilters = defaultSearchFilters ? defaultSearchFilters as InitialSearchFilters : null
+    try {
+      const defaultSearchFilters = cookie.parse(document.cookie).default_search_filters
+      initialSearchFilters = defaultSearchFilters ? JSON.parse(defaultSearchFilters) as InitialSearchFilters : null
+    } catch (e) {
+      console.log('Error parsing default_search_filters cookie', e)
+    }
   } else {
-    // TODO: double check this choice
-    const request = ctx.req as Request
-    const defaultSearchFilters = JSON.parse(request.cookies.default_search_filters)
-    initialSearchFilters = defaultSearchFilters ? defaultSearchFilters as InitialSearchFilters : null
+    try {
+      const request = ctx.req as Request
+      const defaultSearchFilters = request.cookies.default_search_filters
+      initialSearchFilters = defaultSearchFilters ? JSON.parse(defaultSearchFilters) as InitialSearchFilters : null
+    } catch (e) {
+      console.log('Error parsing default_search_filters cookie', e)
+    }
   }
   return {
     namespacesRequired: ['common', 'settings', 'my-feed'],

--- a/packages/web/pages/dashboard/my-feed.tsx
+++ b/packages/web/pages/dashboard/my-feed.tsx
@@ -30,13 +30,13 @@ const MyFeedPage: NextPage<InitialProps> = ({ initialSearchFilters }) => {
 MyFeedPage.getInitialProps = async (ctx) => {
   let initialSearchFilters
   if (typeof window !== 'undefined') {
-    initialSearchFilters = JSON.parse(cookie.parse(document.cookie).default_search_fitlers) as InitialSearchFilters
+    const defaultSearchFilters = JSON.parse(cookie.parse(document.cookie).default_search_filters)
+    initialSearchFilters = defaultSearchFilters ? defaultSearchFilters as InitialSearchFilters : null
   } else {
     // TODO: double check this choice
     const request = ctx.req as Request
-    const defaultSearchFilters = request.cookies.default_search_fitlers
-    console.log(defaultSearchFilters)
-    initialSearchFilters = defaultSearchFilters ? JSON.parse(defaultSearchFilters) as InitialSearchFilters : null
+    const defaultSearchFilters = JSON.parse(request.cookies.default_search_filters)
+    initialSearchFilters = defaultSearchFilters ? defaultSearchFilters as InitialSearchFilters : null
   }
   return {
     namespacesRequired: ['common', 'settings', 'my-feed'],


### PR DESCRIPTION
## Description

**Issue:** closes #490 

Builds a mechanism using cookies so that a user's search filters persist throughout and across sessions.
Cookies were used due to SSR.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Figure out technical design
- [x] Implement it
- [x] Test test test

## Migrations

No migs

## Screenshots

Nada