### PR TITLE
Bump post minor followups

### DIFF
--- a/packages/web/components/Dashboard/Post/Post.tsx
+++ b/packages/web/components/Dashboard/Post/Post.tsx
@@ -578,9 +578,9 @@ const Post = ({ post, currentUser, refetch }: IPostProps) => {
   })
 
   const canAttemptBump = (
-      currentUser.membershipSubscription?.isActive
-      || currentUser.userRole === UserRole.Admin
-      || currentUser.userRole === UserRole.Moderator
+      currentUser?.membershipSubscription?.isActive
+      || currentUser?.userRole === UserRole.Admin
+      || currentUser?.userRole === UserRole.Moderator
     ) && post.status === 'PUBLISHED'
 
   return (

--- a/packages/web/components/Dashboard/Post/Post.tsx
+++ b/packages/web/components/Dashboard/Post/Post.tsx
@@ -577,6 +577,12 @@ const Post = ({ post, currentUser, refetch }: IPostProps) => {
     },
   })
 
+  const canAttemptBump = (
+      currentUser.membershipSubscription?.isActive
+      || currentUser.userRole === UserRole.Admin
+      || currentUser.userRole === UserRole.Moderator
+    ) && post.status === 'PUBLISHED'
+
   return (
     <div className="post-container">
       <Head>
@@ -613,7 +619,7 @@ const Post = ({ post, currentUser, refetch }: IPostProps) => {
             <div className="post-action-container">
             {currentUser && post.author.id === currentUser.id && (
               <>
-                {currentUser.membershipSubscription?.isActive || currentUser.userRole === (UserRole.Admin || UserRole.Moderator) && (
+                {canAttemptBump && (
                   <Button
                     type="button"
                     variant={ButtonVariant.Secondary}
@@ -718,7 +724,7 @@ const Post = ({ post, currentUser, refetch }: IPostProps) => {
           display: grid;
           grid-column-gap: 10px;
           grid-template-columns: 10px 1fr 10px;
-          grid-auto-rows: max-content 1fr 40px;
+          grid-auto-rows: max-content 1fr auto;
           background-color: ${theme.colors.white};
         }
 
@@ -775,6 +781,22 @@ const Post = ({ post, currentUser, refetch }: IPostProps) => {
         .post-action-container {
           display: flex;
           gap: 10px;
+        }
+
+        @media (max-width: ${theme.breakpoints.SM}) {
+          .post-controls {
+            flex-direction: column;
+          }
+
+          .post-action-container {
+            padding-top: 10px;
+            flex-direction: column;
+            gap: 5px;
+          }
+
+          .post-action-container > :global(button) {
+            align-self: stretch;
+          }
         }
 
         .clap-container {


### PR DESCRIPTION
## Description

Visual fix for 3 post controls on mobile and change to not render bump CTA on unpublished posts.

## Migrations

No migs, UI only

## Screenshots
<img width="436" alt="Screen Shot 2021-06-10 at 5 12 49 PM" src="https://user-images.githubusercontent.com/2343714/121603985-5a1b7080-ca0f-11eb-8ba0-7700784aa74b.png">