### PR TITLE
Old post feedback badge

### DIFF
--- a/packages/j-db-client/package.json
+++ b/packages/j-db-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@journaly/j-db-client",
-  "version": "13.3.0",
+  "version": "13.4.0",
   "description": "Journaly's internal database client.",
   "main": "dist/index",
   "scripts": {

--- a/packages/j-db-client/prisma/migrations/20210612192514_add_odradek_and_necromancer_badges/migration.sql
+++ b/packages/j-db-client/prisma/migrations/20210612192514_add_odradek_and_necromancer_badges/migration.sql
@@ -1,0 +1,10 @@
+-- AlterEnum
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+
+
+ALTER TYPE "BadgeType" ADD VALUE 'ODRADEK';
+ALTER TYPE "BadgeType" ADD VALUE 'NECROMANCER';

--- a/packages/j-db-client/prisma/schema.prisma
+++ b/packages/j-db-client/prisma/schema.prisma
@@ -394,6 +394,8 @@ enum BadgeType {
   ONEHUNDRED_POSTS
   TEN_POSTS
   CODE_CONTRIBUTOR
+  ODRADEK
+  NECROMANCER
 }
 
 enum NotificationType {

--- a/packages/j-mail/package-lock.json
+++ b/packages/j-mail/package-lock.json
@@ -25,9 +25,9 @@
       }
     },
     "@journaly/j-db-client": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/@journaly/j-db-client/-/j-db-client-13.3.0.tgz",
-      "integrity": "sha512-/bOQnuOJvZrR63RWIS29Sw1I8KA7xim5kSS2Jg1B+im9fvoQMJroP6gHCxmuomwhA6hD5wgo8UOPJI2jdoTD+g==",
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@journaly/j-db-client/-/j-db-client-13.4.0.tgz",
+      "integrity": "sha512-vlQBM9iDvTQOwh5w0I/KN2OoeMya/sJZjGYbsIreTFIFpNBkPpuJCaESBTaFHwOqyEfWg1OHDWhIjOHWROZLEw==",
       "requires": {
         "@prisma/client": "2.21.0"
       }

--- a/packages/j-mail/package.json
+++ b/packages/j-mail/package.json
@@ -33,7 +33,7 @@
     "typescript": "4.2.4"
   },
   "dependencies": {
-    "@journaly/j-db-client": "^13.3.0",
+    "@journaly/j-db-client": "^13.4.0",
     "aws-sdk": "^2.737.0",
     "date-fns": "^2.16.1",
     "nodemailer": "^6.4.11",

--- a/packages/web/components/Badge/Badge.tsx
+++ b/packages/web/components/Badge/Badge.tsx
@@ -24,6 +24,10 @@ const getBadgeCopySubpath = (badgeType: BadgeType): string => {
       return 'badge.ONEHUNDRED_POSTS'
     case BadgeType.CodeContributor:
       return 'badge.CODE_CONTRIBUTOR'
+    case BadgeType.Necromancer:
+      return 'badge.NECROMANCER'
+    case BadgeType.Odradek:
+      return 'badge.ODRADEK'
   }
 
   return assertUnreachable(badgeType)

--- a/packages/web/generated/graphql.tsx
+++ b/packages/web/generated/graphql.tsx
@@ -304,6 +304,8 @@ export enum BadgeType {
   OnehundredPosts = 'ONEHUNDRED_POSTS',
   TenPosts = 'TEN_POSTS',
   CodeContributor = 'CODE_CONTRIBUTOR',
+  Odradek = 'ODRADEK',
+  Necromancer = 'NECROMANCER',
 }
 
 export enum MembershipSubscriptionPeriod {

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -2540,9 +2540,9 @@
       "dev": true
     },
     "@journaly/j-db-client": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/@journaly/j-db-client/-/j-db-client-13.3.0.tgz",
-      "integrity": "sha512-/bOQnuOJvZrR63RWIS29Sw1I8KA7xim5kSS2Jg1B+im9fvoQMJroP6gHCxmuomwhA6hD5wgo8UOPJI2jdoTD+g==",
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@journaly/j-db-client/-/j-db-client-13.4.0.tgz",
+      "integrity": "sha512-vlQBM9iDvTQOwh5w0I/KN2OoeMya/sJZjGYbsIreTFIFpNBkPpuJCaESBTaFHwOqyEfWg1OHDWhIjOHWROZLEw==",
       "requires": {
         "@prisma/client": "2.21.0"
       }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@apollo/client": "^3.3.12",
     "@apollo/react-ssr": "^4.0.0",
-    "@journaly/j-db-client": "^13.3.0",
+    "@journaly/j-db-client": "^13.4.0",
     "@stripe/react-stripe-js": "^1.2.2",
     "@stripe/stripe-js": "^1.12.1",
     "@types/bcryptjs": "^2.4.2",

--- a/packages/web/public/static/locales/en/common.json
+++ b/packages/web/public/static/locales/en/common.json
@@ -53,6 +53,14 @@
     "ONEHUNDRED_POSTS": {
       "title": "100 Posts",
       "description": "Published 100 posts. Talk about sticking with it!"
+    },
+    "NECROMANCER": {
+      "title": "Necromancer",
+      "description": "Gave new feedback on a post that's over a week old."
+    },
+    "ODRADEK": {
+      "title": "Odradek",
+      "description": "Did something that has no apparent function."
     }
   },
   "emptyMessage": "Empty...",

--- a/packages/web/resolvers/comment.ts
+++ b/packages/web/resolvers/comment.ts
@@ -15,6 +15,7 @@ import {
 import {
   hasAuthorPermissions,
   createNotification,
+  assignBadge,
 } from './utils'
 import { NotFoundError } from './errors'
 
@@ -229,15 +230,11 @@ const CommentMutations = extendType({
           thread.post.author.id !== userId &&
           isPast(add(thread.post.createdAt, { weeks: 1 }))
         ) {
-          await ctx.db.userBadge.createMany({
-            data: [
-              {
-                type: BadgeType.NECROMANCER, 
-                userId,
-              }
-            ],
-            skipDuplicates: true
-          })
+          await assignBadge(
+            ctx.db,
+            userId,
+            BadgeType.NECROMANCER
+          )
         }
 
         return comment

--- a/packages/web/resolvers/comment.ts
+++ b/packages/web/resolvers/comment.ts
@@ -51,7 +51,7 @@ const PostComment = objectType({
   },
 })
 
-const PostMutations = extendType({
+const CommentMutations = extendType({
   type: 'Mutation',
   definition(t) {
     t.field('createThread', {
@@ -468,5 +468,5 @@ export default [
   Thread,
   Comment,
   PostComment,
-  PostMutations,
+  CommentMutations,
 ]

--- a/packages/web/resolvers/post.ts
+++ b/packages/web/resolvers/post.ts
@@ -9,6 +9,7 @@ import {
 
 import {
   processEditorDocument,
+  assignBadge,
   updatedThreadPositions,
   hasAuthorPermissions,
   NodeType,
@@ -527,6 +528,14 @@ const PostMutations = extendType({
               })
             }
           }))
+
+          if (data.body === originalPost.body) {
+            await assignBadge(
+              ctx.db,
+              userId,
+              BadgeType.ODRADEK
+            )
+          }
         }
 
         const languageId = args.languageId  || originalPost.languageId

--- a/packages/web/resolvers/utils/email.ts
+++ b/packages/web/resolvers/utils/email.ts
@@ -108,6 +108,10 @@ const getBadgeName = (badgeType: BadgeType): string => {
       return '100 Posts'
     case BadgeType.CODE_CONTRIBUTOR:
       return 'Code Contributor'
+    case BadgeType.NECROMANCER:
+      return 'Necromancer'
+    case BadgeType.ODRADEK:
+      return 'Odradek'
   }
 
   return assertUnreachable(badgeType)

--- a/packages/web/resolvers/utils/index.ts
+++ b/packages/web/resolvers/utils/index.ts
@@ -353,17 +353,19 @@ export const createNotification = (
   return db.pendingNotification.create({ data })
 }
 
-export const assignBadge = (
+export const assignBadge = async (
   db: PrismaClient,
   userId: number,
   badge: BadgeType,
 ): Promise<void> => {
-  return db.userBadge.createMany({
+  await db.userBadge.createMany({
     data: [
       { type: badge, userId, }
     ],
     skipDuplicates: true
   })
+
+  return
 }
 
 export * from './email'

--- a/packages/web/resolvers/utils/index.ts
+++ b/packages/web/resolvers/utils/index.ts
@@ -10,6 +10,7 @@ import {
   PostComment,
   CommentThanks,
   PostClap,
+  BadgeType,
 } from '@journaly/j-db-client'
 
 
@@ -350,6 +351,19 @@ export const createNotification = (
   }
 
   return db.pendingNotification.create({ data })
+}
+
+export const assignBadge = (
+  db: PrismaClient,
+  userId: number,
+  badge: BadgeType,
+): Promise<void> => {
+  return db.userBadge.createMany({
+    data: [
+      { type: badge, userId, }
+    ],
+    skipDuplicates: true
+  })
 }
 
 export * from './email'


### PR DESCRIPTION
## Description

Closes #433

Adds a badge ("Necromancer", which is terminology borrowed from SO. I couldn't think some something concise and better) that is assigned when leaving feedback on a post authored by someone else that's over a week old.

Also adds an easter egg badge that's assigned for saving a post without any edits.

### Deployment Checklist

- [ ] 🚨 Publish new j-db-client version and update in both `web` and `j-mail`
- [ ] 🚨 Deploy migs to stage
- [ ] 🚨 Deploy code to stage
- [ ] 🚨 DEPLOY `j-mail` to stage
- [ ] 🚨 Deploy migs to prod
- [ ] 🚨 Deploy code to prod
- [ ] 🚨 DEPLOY `j-mail` TO PROD

## Migrations

One mig, low risk as all it does is expand an enum