### PR TITLE
Fix database seed command

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,13 @@ More detailed documentation can be found within each directory (WIP).
 1. Update your `.env` file with your new postgres username & password.
 1. Set the env var `DATABASE_URL` to be the value in your `.env` file (the server will consult the `.env` file but for standalone scripts, you must set the environment variable). This looks like: `export DATABASE_URL='postgresql://<user>:<password>@localhost:5432/<db_name>'`
 
-1. Seed the database with `npm run db:seed`
+1. Seed the database with:
+
+   ```
+   $ npm run db:seed
+   ```
+
+   BOOM! You now have some users, along with a wee selection of posts :)
 
 1. Finally apply database migrations to your new database instance:
 
@@ -117,10 +123,7 @@ The seed script contains a handful of test users and posts to cut down on data c
 
 ### Running Journaly
 
-1. To run the entire app in local development mode, simply run `npm run dev` from the root of the project!
-1. Let's seed that baby DB! From the root of the repo, run `npm run reseed-db`
-
-BOOM! You now have some users, along with a wee selection of posts :)
+To run the entire app in local development mode, simply run `npm run dev` from the root of the project!
 
 **NOTE: the playground is currently not working, we are working on fixing this. This doesn't impact your ability to work on the project**
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Some major reasons for this are:
 - Writing is relatively _effortful_ and practicing it consistently requires building a habit around it.
 - It is hard to find people to give you feedback.
 - Even once finding someone, figuring out how best to give someone feedback isn't obvious and takes a lot of effort.
-- Once you get feedback from soneone, it isn't easy to actually apply, store, organize, and keep track of it over time.
+- Once you get feedback from someone, it isn't easy to actually apply, store, organize, and keep track of it over time.
 
 **Journaly is about striving to build excellent software with beautiful, simple, and intuitive User Interface & User Experience Design that solves each of the above problems for our users:**
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The seed script contains a handful of test users and posts to cut down on data c
 
 ### Running Journaly
 
-To run the entire app in local development mode, simply run `npm run dev` from the root of the project!
+To run the entire app in local development mode, simply run `npm run dev` from the `packages/web` directory!
 
 **NOTE: the playground is currently not working, we are working on fixing this. This doesn't impact your ability to work on the project**
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -26,7 +26,7 @@
     "type-check": "tsc",
     "db:snapshot": "SNAPSHOT_FILE=$(pwd)/snapshot.sql npm explore '@journaly/j-db-client' -- npm run db:snapshot",
     "db:restore": "SNAPSHOT_FILE=$(pwd)/snapshot.sql npm explore '@journaly/j-db-client' -- npm run db:restore",
-    "db:seed": "SNAPSHOT_FILE=$(pwd)/seed.sql npm run db:restore",
+    "db:seed": "SNAPSHOT_FILE=$(pwd)/seed.sql npm explore '@journaly/j-db-client' -- npm run db:restore",
     "prisma:generate": "npm explore '@journaly/j-db-client' -- npm run prisma:generate",
     "migrate:apply": "npm explore '@journaly/j-db-client' -- npm run migrate:apply",
     "migrate:create": "npm explore '@journaly/j-db-client' -- npm run migrate:create",


### PR DESCRIPTION
## Description

**Issue:** None

Update the `db:seed` command to set the `SNAPSHOT_FILE` variable to `seed.sql` and not `snapshot.sql`. Update the README for clarity & accuracy.

Journaly.com profile url (include if you'd like the "code contributor" badge):

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [ ] ...

### Deployment Checklist

- [ ] 🚨 Publish new j-db-client version and update in both `web` and `j-mail`
- [ ] 🚨 Deploy migs to stage
- [ ] 🚨 Deploy code to stage
- [ ] 🚨 DEPLOY `j-mail` to stage
- [ ] 🚨 Deploy migs to prod
- [ ] 🚨 Deploy code to prod
- [ ] 🚨 DEPLOY `j-mail` TO PROD

## Screenshots
