### PR TITLE
Display number of likes in a user's own comments

### DIFF
--- a/packages/web/components/InlineFeedbackPopover/Comment.tsx
+++ b/packages/web/components/InlineFeedbackPopover/Comment.tsx
@@ -186,14 +186,15 @@ const Comment = ({ comment, canEdit, onUpdateComment, currentUser }: CommentProp
       </div>
       {canEdit && !isEditMode && (
         <div className="edit-thanks-block">
-          {numThanks > 0 && (
-            <div className="thanks-block">
-              <span>
-                <LikeIcon filled={true} />
-              </span>
-              <span className="thanks-count">{numThanks}</span>
-            </div>
-          )}
+          <div className="thanks-block">
+            <span>
+              <LikeIcon 
+                filled={numThanks > 0}
+                title={t('numUsersGaveThanks', {numThanks})}
+              />
+            </span>
+            <span className="thanks-count">{numThanks}</span>
+          </div>
           <div className="edit-block">
             <span
               role="button"

--- a/packages/web/components/InlineFeedbackPopover/Comment.tsx
+++ b/packages/web/components/InlineFeedbackPopover/Comment.tsx
@@ -185,27 +185,37 @@ const Comment = ({ comment, canEdit, onUpdateComment, currentUser }: CommentProp
         </div>
       </div>
       {canEdit && !isEditMode && (
-        <div className="edit-block">
-          <span
-            role="button"
-            className="edit-btn"
-            onClick={() => {
-              setIsEditMode(true)
-              setUpdatingCommentBody(comment.body)
-              setTimeout(() => {
-                const el = editTextarea.current
-                if (el) {
-                  el.focus()
-                  el.setSelectionRange(el.value.length, el.value.length)
-                }
-              }, 0)
-            }}
-          >
-            <EditIcon size={24} />
-          </span>
-          <span role="button" className="delete-btn" onClick={deleteExistingComment}>
-            <DeleteIcon size={24} />
-          </span>
+        <div className="edit-thanks-block">
+          {numThanks > 0 && (
+            <div className="thanks-block">
+              <span>
+                <LikeIcon filled={true} />
+              </span>
+              <span className="thanks-count">{numThanks}</span>
+            </div>
+          )}
+          <div className="edit-block">
+            <span
+              role="button"
+              className="edit-btn"
+              onClick={() => {
+                setIsEditMode(true)
+                setUpdatingCommentBody(comment.body)
+                setTimeout(() => {
+                  const el = editTextarea.current
+                  if (el) {
+                    el.focus()
+                    el.setSelectionRange(el.value.length, el.value.length)
+                  }
+                }, 0)
+              }}
+            >
+              <EditIcon size={24} />
+            </span>
+            <span role="button" className="delete-btn" onClick={deleteExistingComment}>
+              <DeleteIcon size={24} />
+            </span>
+          </div>
         </div>
       )}
       {canEdit && isEditMode && (
@@ -237,7 +247,7 @@ const Comment = ({ comment, canEdit, onUpdateComment, currentUser }: CommentProp
       {!canEdit && currentUser?.id && (
         <div className={classNames('edit-block', { progress: isLoadingCommentThanks })}>
           <span
-            className="like-btn"
+            className="like-btn-clickable"
             onClick={hasThankedComment ? deleteExistingCommentThanks : createNewCommentThanks}
             role="button"
           >
@@ -313,15 +323,27 @@ const Comment = ({ comment, canEdit, onUpdateComment, currentUser }: CommentProp
           word-wrap: break-word;
         }
 
-        .edit-block {
+        .edit-thanks-block {
           display: flex;
+          flex-direction: column;
           margin-left: 10px;
         }
 
-        .edit-block span {
+        .edit-block {
+          display: flex;
+          margin: auto 0 auto 10px;
+        }
+
+        .edit-block span,
+        .thanks-block span {
           margin-right: 5px;
           display: flex;
           align-items: center;
+        }
+
+        .thanks-block {
+          display: flex;
+          margin: 0 0 10px auto;
         }
 
         .edit-btn :global(svg:hover) {
@@ -332,13 +354,13 @@ const Comment = ({ comment, canEdit, onUpdateComment, currentUser }: CommentProp
           cursor: pointer;
           fill: ${theme.colors.red};
         }
-        .like-btn :global(svg:hover) {
+        .like-btn-clickable :global(svg:hover) {
           cursor: pointer;
         }
         .progress {
           cursor: progress;
         }
-        .progress > .like-btn {
+        .progress > .like-btn-clickable {
           pointer-events: none;
         }
 

--- a/packages/web/public/static/locales/en/comment.json
+++ b/packages/web/public/static/locales/en/comment.json
@@ -10,5 +10,6 @@
   "tabOutdatedKey": "Outdated",
   "noOutdatedThreadsMessage": "No outdated threads to see",
   "deleteCommentConfirmModalTitle": "Delete Comment",
-  "deleteCommentConfirmModalBody": "Are you sure you want to delete this comment?"
+  "deleteCommentConfirmModalBody": "Are you sure you want to delete this comment?",
+  "numUsersGaveThanks": "{{numThanks}} users thanked you for this comment."
 }


### PR DESCRIPTION
## Description

**Issue:** #512

I added a non-clickable like icon to the user's own inline comments, if the comment has at least one like.

I thought it looked too busy to put the icon side-by-side with the edit/delete icons, so I placed it above. It was a bit tricky to get the CSS right, and there might be a better way that doesn't result in so many new CSS classes.

Journaly.com profile url (include if you'd like the "code contributor" badge): https://journaly.com/dashboard/profile/8654

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅

### Deployment Checklist

- [ ] 🚨 Publish new j-db-client version and update in both `web` and `j-mail`
- [ ] 🚨 Deploy migs to stage
- [ ] 🚨 Deploy code to stage
- [ ] 🚨 DEPLOY `j-mail` to stage
- [ ] 🚨 Deploy migs to prod
- [ ] 🚨 Deploy code to prod
- [ ] 🚨 DEPLOY `j-mail` TO PROD

## Screenshots

Short comment with likes:
![Screen Shot 2021-07-30 at 9 41 41 PM](https://user-images.githubusercontent.com/351124/127728872-3153d865-a5b8-45b7-a11c-5876cc040679.png)

Long comment with likes:
![Screen Shot 2021-07-30 at 9 41 25 PM](https://user-images.githubusercontent.com/351124/127728873-c7e7f438-b862-4ac5-aae5-7ce599c05509.png)

A comment without any likes appears the same as before:
![Screen Shot 2021-07-30 at 9 41 50 PM](https://user-images.githubusercontent.com/351124/127728871-41eef0cd-b28d-4bff-82ec-e1eae8c96cb9.png)