### PR TITLE
Show a tooltip with the specific users who clapped for a post

### DIFF
--- a/packages/web/components/Dashboard/Post/Post.tsx
+++ b/packages/web/components/Dashboard/Post/Post.tsx
@@ -32,7 +32,7 @@ import { Router, useTranslation } from '@/config/i18n'
 import PostHeader from '@/components/PostHeader'
 import ConfirmationModal from '@/components/Modals/ConfirmationModal'
 
-import {getCoords} from './helpers'
+import { getCoords, getUsersClappedText } from './helpers'
 import ClapIcon from '@/components/Icons/ClapIcon'
 import { generateNegativeRandomNumber } from '@/utils/number'
 import { POST_BUMP_LIMIT } from '../../../constants'
@@ -612,7 +612,11 @@ const Post = ({ post, currentUser, refetch }: IPostProps) => {
                 loading={isLoadingPostClap}
                 disabled={currentUser?.id === post.author.id || !currentUser}
               >
-                <ClapIcon width={24} clapped={hasClappedPost} />
+                <ClapIcon 
+                  width={24} 
+                  clapped={hasClappedPost} 
+                  title={getUsersClappedText(post.claps, currentUser?.id)}
+                />
               </Button>
               <span>{post.claps.length}</span>
             </div>

--- a/packages/web/components/Dashboard/Post/helpers.ts
+++ b/packages/web/components/Dashboard/Post/helpers.ts
@@ -1,3 +1,6 @@
+import { PostClap, User } from '@/generated/graphql'
+import { useTranslation } from '@/config/i18n'
+
 /**
  * Get an element’s position relative to the document
  * @see https://stackoverflow.com/a/26230989/3610495
@@ -18,4 +21,48 @@ export const getCoords = (htmlElement: HTMLElement) => {
   const left = box.left + scrollLeft - clientLeft
 
   return { y: Math.round(top), x: Math.round(left) }
+}
+
+export const getUsersClappedText = (claps: Array<
+  { __typename?: 'PostClap' } & Pick<PostClap, 'id'> & {
+    author: { __typename?: 'User' } & Pick<User, 'id' | 'name' | 'handle'>
+  }
+>, currentUserId: number | undefined) => {
+  // JonSnow clapped for this post.
+  // JonSnow and Arya Stark clapped for this post.
+  // JonSnow, Arya Stark, and 1 others clapped for this post.
+  // current user -> You && move to front
+  const { t } = useTranslation('post')
+
+  const containsCurrentUser = claps.some((clap) => {
+    return clap.author.id === currentUserId
+  })
+
+  console.log(claps)
+
+  let usersClapped = claps
+    .filter((clap) => clap.author.id !== currentUserId)
+    .map((clap) => {
+      return clap.author.name ? clap.author.name : clap.author.handle
+    })
+
+  console.log(usersClapped)
+
+  if (containsCurrentUser) {
+    usersClapped = [t('You'), ...usersClapped]
+  }
+
+  if (usersClapped.length == 0) {
+    return t('0 users clapped for this post.')
+  }
+  else if (usersClapped.length == 1) {
+    return t(`${usersClapped[0]} clapped for this post.`)
+  }
+  else if (usersClapped.length == 2) {
+    return t(`${usersClapped[0]} and ${usersClapped[1]} clapped for this post.`)
+  }
+  else /* usersClapped.length > 2 */ {
+    const numOthersClapped = usersClapped.length - 2
+    return t(`${usersClapped[0]}, ${usersClapped[1]}, and ${numOthersClapped} others clapped for this post.`)
+  }
 }

--- a/packages/web/components/Dashboard/Post/helpers.ts
+++ b/packages/web/components/Dashboard/Post/helpers.ts
@@ -23,6 +23,13 @@ export const getCoords = (htmlElement: HTMLElement) => {
   return { y: Math.round(top), x: Math.round(left) }
 }
 
+/**
+ * Generate the text to show for claps on a specific post.
+ * 
+ * @param claps The array of PostClap objects containing their author
+ * @param currentUserId The id of the current user
+ * @returns string The text to show
+ */
 export const getUsersClappedText = (claps: Array<
   { __typename?: 'PostClap' } & Pick<PostClap, 'id'> & {
     author: { __typename?: 'User' } & Pick<User, 'id' | 'name' | 'handle'>

--- a/packages/web/components/Dashboard/Post/helpers.ts
+++ b/packages/web/components/Dashboard/Post/helpers.ts
@@ -1,4 +1,4 @@
-import { PostClap, User } from '@/generated/graphql'
+import { PostClapFragmentFragment as PostClapType } from '@/generated/graphql'
 import { useTranslation } from '@/config/i18n'
 
 /**
@@ -30,11 +30,10 @@ export const getCoords = (htmlElement: HTMLElement) => {
  * @param currentUserId The id of the current user
  * @returns string The text to show
  */
-export const getUsersClappedText = (claps: Array<
-  { __typename?: 'PostClap' } & Pick<PostClap, 'id'> & {
-    author: { __typename?: 'User' } & Pick<User, 'id' | 'name' | 'handle'>
-  }
->, currentUserId: number | undefined) => {
+export const getUsersClappedText = (
+  claps: Array<PostClapType>,
+  currentUserId: number | undefined) => {
+
   const { t } = useTranslation('post')
 
   const containsCurrentUser = claps.some(

--- a/packages/web/components/Dashboard/Post/helpers.ts
+++ b/packages/web/components/Dashboard/Post/helpers.ts
@@ -28,41 +28,37 @@ export const getUsersClappedText = (claps: Array<
     author: { __typename?: 'User' } & Pick<User, 'id' | 'name' | 'handle'>
   }
 >, currentUserId: number | undefined) => {
-  // JonSnow clapped for this post.
-  // JonSnow and Arya Stark clapped for this post.
-  // JonSnow, Arya Stark, and 1 others clapped for this post.
-  // current user -> You && move to front
   const { t } = useTranslation('post')
 
-  const containsCurrentUser = claps.some((clap) => {
-    return clap.author.id === currentUserId
-  })
-
-  console.log(claps)
+  const containsCurrentUser = claps.some(
+    (clap) => clap.author.id === currentUserId)
 
   let usersClapped = claps
     .filter((clap) => clap.author.id !== currentUserId)
-    .map((clap) => {
-      return clap.author.name ? clap.author.name : clap.author.handle
-    })
-
-  console.log(usersClapped)
+    .map((clap) => clap.author.name ? clap.author.name : clap.author.handle)
 
   if (containsCurrentUser) {
-    usersClapped = [t('You'), ...usersClapped]
+    usersClapped = [t('claps.currentUserPronoun'), ...usersClapped]
   }
 
   if (usersClapped.length == 0) {
-    return t('0 users clapped for this post.')
+    return t('claps.noUsersClapped')
   }
   else if (usersClapped.length == 1) {
-    return t(`${usersClapped[0]} clapped for this post.`)
+    return t('claps.oneUserClapped', { name1: usersClapped[0] })
   }
   else if (usersClapped.length == 2) {
-    return t(`${usersClapped[0]} and ${usersClapped[1]} clapped for this post.`)
+    return t('claps.twoUsersClapped', {
+      name1: usersClapped[0],
+      name2: usersClapped[1]
+    })
   }
   else /* usersClapped.length > 2 */ {
     const numOthersClapped = usersClapped.length - 2
-    return t(`${usersClapped[0]}, ${usersClapped[1]}, and ${numOthersClapped} others clapped for this post.`)
+    return t('claps.manyUsersClapped', {
+      name1: usersClapped[0],
+      name2: usersClapped[1],
+      numOthers: numOthersClapped
+    })
   }
 }

--- a/packages/web/public/static/locales/en/post.json
+++ b/packages/web/public/static/locales/en/post.json
@@ -42,7 +42,7 @@
   "websitePatternError": "Invalid website url. e.g. domain.com or sub.domain.com",
   "claps": {
     "currentUserPronoun": "You",
-    "noUsersClapped": "0 users clapped for this post.",
+    "noUsersClapped": "No users clapped for this post... yet!",
     "oneUserClapped": "{{name1}} clapped for this post.",
     "twoUsersClapped": "{{name1}} and {{name2}} clapped for this post.",
     "manyUsersClapped": "{{name1}}, {{name2}}, and {{numOthers}} others clapped for this post."

--- a/packages/web/public/static/locales/en/post.json
+++ b/packages/web/public/static/locales/en/post.json
@@ -39,5 +39,12 @@
     "body": "Are you sure you want to cancel editing this post? Unsaved progress will be lost."
   },
   "enterUrlPrompt": "Enter the URL of the link:",
-  "websitePatternError": "Invalid website url. e.g. domain.com or sub.domain.com"
+  "websitePatternError": "Invalid website url. e.g. domain.com or sub.domain.com",
+  "claps": {
+    "currentUserPronoun": "You",
+    "noUsersClapped": "0 users clapped for this post.",
+    "oneUserClapped": "{{name1}} clapped for this post.",
+    "twoUsersClapped": "{{name1}} and {{name2}} clapped for this post.",
+    "manyUsersClapped": "{{name1}}, {{name2}}, and {{numOthers}} others clapped for this post."
+  }
 }


### PR DESCRIPTION
## Description

**Issue:** closes #631 

One potential issue with my code is that it was quite messy to put the type of the `claps` array in `helpers.ts`. I couldn't figure out a better way (the type checker didn't like the `PostClap` type), but if there is one, please let me know!

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅

### Deployment Checklist

- [ ] 🚨 Publish new j-db-client version and update in both `web` and `j-mail`
- [ ] 🚨 Deploy migs to stage
- [ ] 🚨 Deploy code to stage
- [ ] 🚨 DEPLOY `j-mail` to stage
- [ ] 🚨 Deploy migs to prod
- [ ] 🚨 Deploy code to prod
- [ ] 🚨 DEPLOY `j-mail` TO PROD

## Screenshots

![Screen Shot 2021-08-01 at 6 26 04 PM](https://user-images.githubusercontent.com/351124/127792681-904b274b-7ac5-47ee-9b7a-db46bc11e2b5.png)