### PR TITLE
Add Markdown Support For Comments - Take 2

### DIFF
--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -386,7 +386,8 @@
     "@babel/helper-plugin-utils": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
-      "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
+      "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
+      "dev": true
     },
     "@babel/helper-replace-supers": {
       "version": "7.15.0",
@@ -578,6 +579,7 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.14.5.tgz",
       "integrity": "sha512-ohuFIsOMXJnbOMRfX7/w7LocdR6R7whhuRD4ax8IipLcLPlZGJKkBxgHp++U4N/vKyU16/YDQr2f5seajD3jIw==",
+      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
       }
@@ -866,6 +868,7 @@
       "version": "7.15.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
       "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.14.9",
         "to-fast-properties": "^2.0.0"
@@ -2325,11 +2328,6 @@
         }
       }
     },
-    "@napi-rs/triples": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@napi-rs/triples/-/triples-1.0.3.tgz",
-      "integrity": "sha512-jDJTpta+P4p1NZTFVLHJ/TLFVYVcOqv6l8xwOeBKNPMgY/zDYH/YH7SJbvrr/h1RcS9GzbPcLKGzpuK9cV56UA=="
-    },
     "@next/bundle-analyzer": {
       "version": "10.2.3",
       "resolved": "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-10.2.3.tgz",
@@ -2340,9 +2338,9 @@
       }
     },
     "@next/env": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-11.1.0.tgz",
-      "integrity": "sha512-zPJkMFRenSf7BLlVee8987G0qQXAhxy7k+Lb/5hLAGkPVHAHm+oFFeL+2ipbI2KTEFlazdmGY0M+AlLQn7pWaw=="
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-11.0.1.tgz",
+      "integrity": "sha512-yZfKh2U6R9tEYyNUrs2V3SBvCMufkJ07xMH5uWy8wqcl5gAXoEw6A/1LDqwX3j7pUutF9d1ZxpdGDA3Uag+aQQ=="
     },
     "@next/eslint-plugin-next": {
       "version": "11.1.0",
@@ -2354,14 +2352,14 @@
       }
     },
     "@next/polyfill-module": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@next/polyfill-module/-/polyfill-module-11.1.0.tgz",
-      "integrity": "sha512-64EgW8SzJRQls2yJ5DkuljRxgE24o2kYtX/ghTkPUJYsfidHMWzQGwg26IgRbb/uHqTd1G0W5UkKag+Nt8TWaQ=="
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@next/polyfill-module/-/polyfill-module-11.0.1.tgz",
+      "integrity": "sha512-Cjs7rrKCg4CF4Jhri8PCKlBXhszTfOQNl9AjzdNy4K5jXFyxyoSzuX2rK4IuoyE+yGp5A3XJCBEmOQ4xbUp9Mg=="
     },
     "@next/react-dev-overlay": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@next/react-dev-overlay/-/react-dev-overlay-11.1.0.tgz",
-      "integrity": "sha512-h+ry0sTk1W3mJw+TwEf91aqLbBJ5oqAsxfx+QryqEItNtfW6zLSSjxkyTYTqX8DkgSssQQutQfATkzBVgOR+qQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@next/react-dev-overlay/-/react-dev-overlay-11.0.1.tgz",
+      "integrity": "sha512-lvUjMVpLsgzADs9Q8wtC5LNqvfdN+M0BDMSrqr04EDWAyyX0vURHC9hkvLbyEYWyh+WW32pwjKBXdkMnJhoqMg==",
       "requires": {
         "@babel/code-frame": "7.12.11",
         "anser": "1.4.9",
@@ -2435,17 +2433,9 @@
       }
     },
     "@next/react-refresh-utils": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-11.1.0.tgz",
-      "integrity": "sha512-g5DtFTpLTGa36iy9DuZawtJeitI11gysFGKPQQqy+mNbSFazguArcJ10gAYFlbqpIi4boUamWNI5mAoSPx3kog=="
-    },
-    "@node-rs/helper": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@node-rs/helper/-/helper-1.2.1.tgz",
-      "integrity": "sha512-R5wEmm8nbuQU0YGGmYVjEc0OHtYsuXdpRG+Ut/3wZ9XAvQWyThN08bTh2cBJgoZxHQUPtvRfeQuxcAgLuiBISg==",
-      "requires": {
-        "@napi-rs/triples": "^1.0.3"
-      }
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-11.0.1.tgz",
+      "integrity": "sha512-K347DM6Z7gBSE+TfUaTTceWvbj0B6iNAsFZXbFZOlfg3uyz2sbKpzPYYFocCc27yjLaS8OfR8DEdS2mZXi8Saw=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -3106,8 +3096,7 @@
     "@types/node": {
       "version": "14.17.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.9.tgz",
-      "integrity": "sha512-CMjgRNsks27IDwI785YMY0KLt3co/c0cQ5foxHYv/shC2w8oOnVwz5Ubq1QG5KzrcW+AXk6gzdnxIkDnTvzu3g==",
-      "dev": true
+      "integrity": "sha512-CMjgRNsks27IDwI785YMY0KLt3co/c0cQ5foxHYv/shC2w8oOnVwz5Ubq1QG5KzrcW+AXk6gzdnxIkDnTvzu3g=="
     },
     "@types/node-fetch": {
       "version": "2.5.12",
@@ -4170,6 +4159,11 @@
       "requires": {
         "object.assign": "^4.1.0"
       }
+    },
+    "babel-plugin-syntax-jsx": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-plugin-syntax-trailing-function-commas": {
       "version": "7.0.0-beta.0",
@@ -5409,19 +5403,19 @@
       "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4="
     },
     "cssnano-preset-simple": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-simple/-/cssnano-preset-simple-3.0.0.tgz",
-      "integrity": "sha512-vxQPeoMRqUT3c/9f0vWeVa2nKQIHFpogtoBvFdW4GQ3IvEJ6uauCP6p3Y5zQDLFcI7/+40FTgX12o7XUL0Ko+w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-simple/-/cssnano-preset-simple-2.0.0.tgz",
+      "integrity": "sha512-HkufSLkaBJbKBFx/7aj5HmCK9Ni/JedRQm0mT2qBzMG/dEuJOLnMt2lK6K1rwOOyV4j9aSY+knbW9WoS7BYpzg==",
       "requires": {
         "caniuse-lite": "^1.0.30001202"
       }
     },
     "cssnano-simple": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssnano-simple/-/cssnano-simple-3.0.0.tgz",
-      "integrity": "sha512-oU3ueli5Dtwgh0DyeohcIEE00QVfbPR3HzyXdAl89SfnQG3y0/qcpfLVW+jPIh3/rgMZGwuW96rejZGaYE9eUg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cssnano-simple/-/cssnano-simple-2.0.0.tgz",
+      "integrity": "sha512-0G3TXaFxlh/szPEG/o3VcmCwl0N3E60XNb9YZZijew5eIs6fLjJuOPxQd9yEBaX2p/YfJtt49i4vYi38iH6/6w==",
       "requires": {
-        "cssnano-preset-simple": "^3.0.0"
+        "cssnano-preset-simple": "^2.0.0"
       }
     },
     "csso": {
@@ -6623,8 +6617,7 @@
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "etag": {
       "version": "1.8.1",
@@ -8668,11 +8661,6 @@
         "supports-color": "^8.0.0"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "16.6.1",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.6.1.tgz",
-          "integrity": "sha512-Sr7BhXEAer9xyGuCN3Ek9eg9xPviCF2gfu9kTfuU2HkTVAMYSDeX40fvpmo72n5nansg3nsBjuQBrsS28r+NUw=="
-        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -9819,17 +9807,16 @@
       "dev": true
     },
     "next": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/next/-/next-11.1.0.tgz",
-      "integrity": "sha512-GHBk/c7Wyr6YbFRFZF37I0X7HKzkHHI8pur/loyXo5AIE8wdkbGPGO0ds3vNAO6f8AxZAKGCRYtAzoGlVLoifA==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/next/-/next-11.0.1.tgz",
+      "integrity": "sha512-yR7be7asNbvpVNpi6xxEg28wZ7Gqmj1nOt0sABH9qORmF3+pms2KZ7Cng33oK5nqPIzEEFJD0pp2PCe3/ueMIg==",
       "requires": {
         "@babel/runtime": "7.12.5",
         "@hapi/accept": "5.0.2",
-        "@next/env": "11.1.0",
-        "@next/polyfill-module": "11.1.0",
-        "@next/react-dev-overlay": "11.1.0",
-        "@next/react-refresh-utils": "11.1.0",
-        "@node-rs/helper": "1.2.1",
+        "@next/env": "11.0.1",
+        "@next/polyfill-module": "11.0.1",
+        "@next/react-dev-overlay": "11.0.1",
+        "@next/react-refresh-utils": "11.0.1",
         "assert": "2.0.0",
         "ast-types": "0.13.2",
         "browserify-zlib": "0.2.0",
@@ -9840,7 +9827,7 @@
         "chokidar": "3.5.1",
         "constants-browserify": "1.0.0",
         "crypto-browserify": "3.12.0",
-        "cssnano-simple": "3.0.0",
+        "cssnano-simple": "2.0.0",
         "domain-browser": "4.19.0",
         "encoding": "0.1.13",
         "etag": "1.8.1",
@@ -9857,8 +9844,9 @@
         "p-limit": "3.1.0",
         "path-browserify": "1.0.1",
         "pnp-webpack-plugin": "1.6.4",
-        "postcss": "8.2.15",
+        "postcss": "8.2.13",
         "process": "0.11.10",
+        "prop-types": "15.7.2",
         "querystring-es3": "0.2.1",
         "raw-body": "2.4.1",
         "react-is": "17.0.2",
@@ -9866,7 +9854,7 @@
         "stream-browserify": "3.0.0",
         "stream-http": "3.1.1",
         "string_decoder": "1.3.0",
-        "styled-jsx": "4.0.0",
+        "styled-jsx": "3.3.2",
         "timers-browserify": "2.0.12",
         "tty-browserify": "0.0.1",
         "use-subscription": "1.5.1",
@@ -11222,12 +11210,12 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.2.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.15.tgz",
-      "integrity": "sha512-2zO3b26eJD/8rb106Qu2o7Qgg52ND5HPjcyQiK2B98O388h43A448LCslC0dI2P97wCAQRJsFvwTRcXxTKds+Q==",
+      "version": "8.2.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.13.tgz",
+      "integrity": "sha512-FCE5xLH+hjbzRdpbRb1IMCvPv9yZx2QnDarBEYSN0N0HYk+TcXsEhwdFcFb+SRWOKzKGErhIEbBK2ogyLdTtfQ==",
       "requires": {
         "colorette": "^1.2.2",
-        "nanoid": "^3.1.23",
+        "nanoid": "^3.1.22",
         "source-map": "^0.6.1"
       }
     },
@@ -13039,12 +13027,12 @@
       }
     },
     "styled-jsx": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-4.0.0.tgz",
-      "integrity": "sha512-2USeoWMoJ/Lx5s2y1PxuvLy/cz2Yrr8cTySV3ILHU1Vmaw1bnV7suKdblLPjnyhMD+qzN7B1SWyh4UZTARn/WA==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-3.3.2.tgz",
+      "integrity": "sha512-daAkGd5mqhbBhLd6jYAjYBa9LpxYCzsgo/f6qzPdFxVB8yoGbhxvzQgkC0pfmCVvW3JuAEBn0UzFLBfkHVZG1g==",
       "requires": {
-        "@babel/plugin-syntax-jsx": "7.14.5",
-        "@babel/types": "7.15.0",
+        "@babel/types": "7.8.3",
+        "babel-plugin-syntax-jsx": "6.18.0",
         "convert-source-map": "1.7.0",
         "loader-utils": "1.2.3",
         "source-map": "0.7.3",
@@ -13053,6 +13041,16 @@
         "stylis-rule-sheet": "0.0.10"
       },
       "dependencies": {
+        "@babel/types": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
         "source-map": {
           "version": "0.7.3",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -69,7 +69,7 @@
     "isomorphic-unfetch": "^3.0.0",
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.20",
-    "next": "^11.0.1",
+    "next": "11.0.1",
     "next-i18next": "^6.0.2",
     "nexus": "^1.0.0",
     "nexus-plugin-prisma": "^0.34.0",


### PR DESCRIPTION
## Description

**Issue:** closes #425 

Yesterday we merged in #635 but found a pretty disruptive bug in production where `getInitialProps` was exhibiting some strange behaviour (seeming to only return partial results for our translation JSON files) resulting in the Dashboard mainly just showing the i18n keys/labels and not the translation strings. This appeared to be due to some version bumps we got down the dependency tree in the `package-lock.json` file related to Next.js. I find that quite concerning and would like to investigate more, but for now found that simply pinning `Next` in our `package.json` did the trick so that we can at least release the feature.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Try pinning Next in `package.json` & test on `stage`

### Deployment Checklist

- [ ] 🚨 Publish new j-db-client version and update in both `web` and `j-mail`
- [ ] 🚨 Deploy migs to stage
- [ ] 🚨 Deploy code to stage
- [ ] 🚨 DEPLOY `j-mail` to stage
- [ ] 🚨 Deploy migs to prod
- [ ] 🚨 Deploy code to prod
- [ ] 🚨 DEPLOY `j-mail` TO PROD

## Migrations

No migs