### PR TITLE
Increase Comment Markdown Support & Add Missing Styles

### DIFF
--- a/packages/web/components/Dashboard/Post/PostComment.tsx
+++ b/packages/web/components/Dashboard/Post/PostComment.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import Link from 'next/link'
 import Markdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
 
 import {
   useUpdatePostCommentMutation,
@@ -104,7 +105,11 @@ const PostComment: React.FC<PostCommentProps> = ({
               onChange={(e) => setUpdatingCommentBody(e.target.value)}
             />
           ) : (
-            <Markdown className="comment-body" disallowedElements={['img']}>
+            <Markdown
+              className="comment-body"
+              disallowedElements={['img']}
+              remarkPlugins={[remarkGfm]}
+            >
               {comment.body}
             </Markdown>
           )}
@@ -224,6 +229,7 @@ const PostComment: React.FC<PostCommentProps> = ({
           word-wrap: break-word;
         }
 
+        // MarkDown Styles
         :global(.comment-body h1),
         :global(.comment-body h2),
         :global(.comment-body h3),
@@ -233,7 +239,12 @@ const PostComment: React.FC<PostCommentProps> = ({
           font-weight: 600;
           margin: 0.5em 0 0.5em 0;
         }
-        :global(.comment-body li) {
+        :global(.comment-body ol > li) {
+          list-style: inside;
+          list-style-type: decimal;
+          margin-left: 20px;
+        }
+        :global(.comment-body ul > li) {
           list-style: inside;
           list-style-type: disc;
           margin-left: 20px;
@@ -248,6 +259,14 @@ const PostComment: React.FC<PostCommentProps> = ({
           padding-left: 5px;
           background-color: ${theme.colors.gray100};
           font-style: italic;
+          margin: 5px 0;
+        }
+        :global(.comment-body a) {
+          color: ${theme.colors.blueLight};
+        }
+        :global(.comment-body a:hover) {
+          cursor: pointer;
+          text-decoration: underline;
         }
 
         .body-block :global(p) {

--- a/packages/web/components/InlineFeedbackPopover/Comment.tsx
+++ b/packages/web/components/InlineFeedbackPopover/Comment.tsx
@@ -3,6 +3,9 @@ import Link from 'next/link'
 import { toast } from 'react-toastify'
 import classNames from 'classnames'
 import Markdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+
+// TODO: Update `react-markdown` and `remark-gfm` once Next.js versioning issues are resolved
 
 import {
   useUpdateCommentMutation,
@@ -180,7 +183,11 @@ const Comment = ({ comment, canEdit, onUpdateComment, currentUser }: CommentProp
               onChange={(e) => setUpdatingCommentBody(e.target.value)}
             />
           ) : (
-            <Markdown className="comment-body" disallowedElements={['img']}>
+            <Markdown
+              className="comment-body"
+              disallowedElements={['img']}
+              remarkPlugins={[remarkGfm]}
+            >
               {comment.body}
             </Markdown>
           )}
@@ -323,6 +330,7 @@ const Comment = ({ comment, canEdit, onUpdateComment, currentUser }: CommentProp
           word-wrap: break-word;
         }
 
+        // MarkDown Styles
         :global(.comment-body h1),
         :global(.comment-body h2),
         :global(.comment-body h3),
@@ -332,7 +340,12 @@ const Comment = ({ comment, canEdit, onUpdateComment, currentUser }: CommentProp
           font-weight: 600;
           margin: 0.5em 0 0.5em 0;
         }
-        :global(.comment-body li) {
+        :global(.comment-body ol > li) {
+          list-style: inside;
+          list-style-type: decimal;
+          margin-left: 20px;
+        }
+        :global(.comment-body ul > li) {
           list-style: inside;
           list-style-type: disc;
           margin-left: 20px;
@@ -345,8 +358,16 @@ const Comment = ({ comment, canEdit, onUpdateComment, currentUser }: CommentProp
         :global(.comment-body blockquote) {
           border-left: 4px solid ${theme.colors.blueLight};
           padding-left: 5px;
+          margin: 5px 0;
           background-color: ${theme.colors.gray100};
           font-style: italic;
+        }
+        :global(.comment-body a) {
+          color: ${theme.colors.blueLight};
+        }
+        :global(.comment-body a:hover) {
+          cursor: pointer;
+          text-decoration: underline;
         }
 
         .edit-thanks-block {

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -4991,6 +4991,11 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
+    "ccount": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.1.0.tgz",
+      "integrity": "sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg=="
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -9587,6 +9592,11 @@
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
+    "longest-streak": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
+      "integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg=="
+    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -9662,6 +9672,14 @@
         "object-visit": "^1.0.0"
       }
     },
+    "markdown-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
+      "integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
+      "requires": {
+        "repeat-string": "^1.0.0"
+      }
+    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -9680,6 +9698,23 @@
         "unist-util-visit": "^2.0.0"
       }
     },
+    "mdast-util-find-and-replace": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-1.1.1.tgz",
+      "integrity": "sha512-9cKl33Y21lyckGzpSmEQnIDjEfeeWelN5s1kUW1LwdB0Fkuq2u+4GdqcGEygYxJE8GVqCl0741bYXHgamfWAZA==",
+      "requires": {
+        "escape-string-regexp": "^4.0.0",
+        "unist-util-is": "^4.0.0",
+        "unist-util-visit-parents": "^3.0.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        }
+      }
+    },
     "mdast-util-from-markdown": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz",
@@ -9690,6 +9725,53 @@
         "micromark": "~2.11.0",
         "parse-entities": "^2.0.0",
         "unist-util-stringify-position": "^2.0.0"
+      }
+    },
+    "mdast-util-gfm": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-0.1.2.tgz",
+      "integrity": "sha512-NNkhDx/qYcuOWB7xHUGWZYVXvjPFFd6afg6/e2g+SV4r9q5XUcCbV4Wfa3DLYIiD+xAEZc6K4MGaE/m0KDcPwQ==",
+      "requires": {
+        "mdast-util-gfm-autolink-literal": "^0.1.0",
+        "mdast-util-gfm-strikethrough": "^0.2.0",
+        "mdast-util-gfm-table": "^0.1.0",
+        "mdast-util-gfm-task-list-item": "^0.1.0",
+        "mdast-util-to-markdown": "^0.6.1"
+      }
+    },
+    "mdast-util-gfm-autolink-literal": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-0.1.3.tgz",
+      "integrity": "sha512-GjmLjWrXg1wqMIO9+ZsRik/s7PLwTaeCHVB7vRxUwLntZc8mzmTsLVr6HW1yLokcnhfURsn5zmSVdi3/xWWu1A==",
+      "requires": {
+        "ccount": "^1.0.0",
+        "mdast-util-find-and-replace": "^1.1.0",
+        "micromark": "^2.11.3"
+      }
+    },
+    "mdast-util-gfm-strikethrough": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-0.2.3.tgz",
+      "integrity": "sha512-5OQLXpt6qdbttcDG/UxYY7Yjj3e8P7X16LzvpX8pIQPYJ/C2Z1qFGMmcw+1PZMUM3Z8wt8NRfYTvCni93mgsgA==",
+      "requires": {
+        "mdast-util-to-markdown": "^0.6.0"
+      }
+    },
+    "mdast-util-gfm-table": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-0.1.6.tgz",
+      "integrity": "sha512-j4yDxQ66AJSBwGkbpFEp9uG/LS1tZV3P33fN1gkyRB2LoRL+RR3f76m0HPHaby6F4Z5xr9Fv1URmATlRRUIpRQ==",
+      "requires": {
+        "markdown-table": "^2.0.0",
+        "mdast-util-to-markdown": "~0.6.0"
+      }
+    },
+    "mdast-util-gfm-task-list-item": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-0.1.6.tgz",
+      "integrity": "sha512-/d51FFIfPsSmCIRNp7E6pozM9z1GYPIkSy1urQ8s/o4TC22BZ7DqfHFWiqBD23bc7J3vV1Fc9O4QIHBlfuit8A==",
+      "requires": {
+        "mdast-util-to-markdown": "~0.6.0"
       }
     },
     "mdast-util-to-hast": {
@@ -9705,6 +9787,19 @@
         "unist-util-generated": "^1.0.0",
         "unist-util-position": "^3.0.0",
         "unist-util-visit": "^2.0.0"
+      }
+    },
+    "mdast-util-to-markdown": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz",
+      "integrity": "sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==",
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "longest-streak": "^2.0.0",
+        "mdast-util-to-string": "^2.0.0",
+        "parse-entities": "^2.0.0",
+        "repeat-string": "^1.0.0",
+        "zwitch": "^1.0.0"
       }
     },
     "mdast-util-to-string": {
@@ -9775,6 +9870,56 @@
       "requires": {
         "debug": "^4.0.0",
         "parse-entities": "^2.0.0"
+      }
+    },
+    "micromark-extension-gfm": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-0.3.3.tgz",
+      "integrity": "sha512-oVN4zv5/tAIA+l3GbMi7lWeYpJ14oQyJ3uEim20ktYFAcfX1x3LNlFGGlmrZHt7u9YlKExmyJdDGaTt6cMSR/A==",
+      "requires": {
+        "micromark": "~2.11.0",
+        "micromark-extension-gfm-autolink-literal": "~0.5.0",
+        "micromark-extension-gfm-strikethrough": "~0.6.5",
+        "micromark-extension-gfm-table": "~0.4.0",
+        "micromark-extension-gfm-tagfilter": "~0.3.0",
+        "micromark-extension-gfm-task-list-item": "~0.3.0"
+      }
+    },
+    "micromark-extension-gfm-autolink-literal": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-0.5.7.tgz",
+      "integrity": "sha512-ePiDGH0/lhcngCe8FtH4ARFoxKTUelMp4L7Gg2pujYD5CSMb9PbblnyL+AAMud/SNMyusbS2XDSiPIRcQoNFAw==",
+      "requires": {
+        "micromark": "~2.11.3"
+      }
+    },
+    "micromark-extension-gfm-strikethrough": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-0.6.5.tgz",
+      "integrity": "sha512-PpOKlgokpQRwUesRwWEp+fHjGGkZEejj83k9gU5iXCbDG+XBA92BqnRKYJdfqfkrRcZRgGuPuXb7DaK/DmxOhw==",
+      "requires": {
+        "micromark": "~2.11.0"
+      }
+    },
+    "micromark-extension-gfm-table": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-0.4.3.tgz",
+      "integrity": "sha512-hVGvESPq0fk6ALWtomcwmgLvH8ZSVpcPjzi0AjPclB9FsVRgMtGZkUcpE0zgjOCFAznKepF4z3hX8z6e3HODdA==",
+      "requires": {
+        "micromark": "~2.11.0"
+      }
+    },
+    "micromark-extension-gfm-tagfilter": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-0.3.0.tgz",
+      "integrity": "sha512-9GU0xBatryXifL//FJH+tAZ6i240xQuFrSL7mYi8f4oZSbc+NvXjkrHemeYP0+L4ZUT+Ptz3b95zhUZnMtoi/Q=="
+    },
+    "micromark-extension-gfm-task-list-item": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-0.3.3.tgz",
+      "integrity": "sha512-0zvM5iSLKrc/NQl84pZSjGo66aTGd57C1idmlWmE87lkMcXrTxg1uXa/nXomxJytoje9trP0NDLvw4bZ/Z/XCQ==",
+      "requires": {
+        "micromark": "~2.11.0"
       }
     },
     "micromatch": {
@@ -12194,6 +12339,15 @@
         "invariant": "^2.2.4"
       }
     },
+    "remark-gfm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-1.0.0.tgz",
+      "integrity": "sha512-KfexHJCiqvrdBZVbQ6RopMZGwaXz6wFJEfByIuEwGf0arvITHjiKKZ1dpXujjH9KZdm1//XJQwgfnJ3lmXaDPA==",
+      "requires": {
+        "mdast-util-gfm": "^0.1.0",
+        "micromark-extension-gfm": "^0.3.0"
+      }
+    },
     "remark-parse": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
@@ -12246,8 +12400,7 @@
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "replaceall": {
       "version": "0.1.6",
@@ -14683,6 +14836,11 @@
         "@types/zen-observable": "0.8.3",
         "zen-observable": "0.8.15"
       }
+    },
+    "zwitch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
+      "integrity": "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw=="
     }
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -81,6 +81,7 @@
     "react-markdown": "^6.0.3",
     "react-toastify": "^6.0.8",
     "reactjs-popup": "^2.0.4",
+    "remark-gfm": "^1.0.0",
     "slate": "https://journaly-hosted-packages.s3.us-east-2.amazonaws.com/slate-v0.62.0.tgz",
     "slate-history": "https://journaly-hosted-packages.s3.us-east-2.amazonaws.com/slate-history-v0.62.0.tgz",
     "slate-hyperscript": "https://journaly-hosted-packages.s3.us-east-2.amazonaws.com/slate-hyperscript-v0.62.0.tgz",


### PR DESCRIPTION
## Description

Users seem to be loving the new Markdown support which is **great!**
- This PR adds the `remark-gfm` package which can be used as a plugin with `react-markdown` and adds support for strikethroughs, which I think are **super** helpful on Journaly for indicating deletions, and also seems to handle *some* new line scenarios better (after a block quote, the new line no longer gets eaten).
- Also adds some missing styles so that links are now properly visible, numbered lists are numbered, and improves a bit of spacing on block quotes

### NOTE

- Due to version issues we're experiencing with Next.js, I've had to use an older but still recent version of `react-markdown` and also an older version of `remark-gfm`. I've included a TODO to update these as soon as we figure out our Next versioning issues which is high priority 🚨 in my opinion.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Add missing styles
- [x] Add strikethrough support
- [x] Get build passing re: versioning issues

### Deployment Checklist

- [ ] 🚨 Publish new j-db-client version and update in both `web` and `j-mail`
- [ ] 🚨 Deploy migs to stage
- [ ] 🚨 Deploy code to stage
- [ ] 🚨 DEPLOY `j-mail` to stage
- [ ] 🚨 Deploy migs to prod
- [ ] 🚨 Deploy code to prod
- [ ] 🚨 DEPLOY `j-mail` TO PROD

## Migrations

No migs

## Screenshots
