### PR TITLE
Fix profile page bug fetching currentUser's posts

### DIFF
--- a/packages/web/generated/graphql.tsx
+++ b/packages/web/generated/graphql.tsx
@@ -1044,6 +1044,7 @@ export type PostsQueryVariables = Exact<{
   hasInteracted?: Maybe<Scalars['Boolean']>
   authoredOnly: Scalars['Boolean']
   status: PostStatus
+  authorId?: Maybe<Scalars['Int']>
 }>
 
 export type PostsQuery = { __typename?: 'Query' } & {
@@ -2525,7 +2526,7 @@ export const ProfilePageDocument = gql`
     userById(id: $userId) {
       ...ProfileUserFragment
     }
-    posts(first: 20, skip: 0, status: PUBLISHED, authoredOnly: true) {
+    posts(first: 20, skip: 0, status: PUBLISHED, authoredOnly: true, authorId: $userId) {
       posts {
         ...PostCardFragment
       }
@@ -3071,6 +3072,7 @@ export const PostsDocument = gql`
     $hasInteracted: Boolean
     $authoredOnly: Boolean!
     $status: PostStatus!
+    $authorId: Int
   ) {
     posts(
       first: $first
@@ -3083,6 +3085,7 @@ export const PostsDocument = gql`
       hasInteracted: $hasInteracted
       authoredOnly: $authoredOnly
       status: $status
+      authorId: $authorId
     ) {
       posts {
         ...PostCardFragment
@@ -3115,6 +3118,7 @@ export const PostsDocument = gql`
  *      hasInteracted: // value for 'hasInteracted'
  *      authoredOnly: // value for 'authoredOnly'
  *      status: // value for 'status'
+ *      authorId: // value for 'authorId'
  *   },
  * });
  */

--- a/packages/web/graphql/language/languages.graphql
+++ b/packages/web/graphql/language/languages.graphql
@@ -1,4 +1,4 @@
-query languages($hasPosts: Boolean, $authoredOnly: Boolean) {
+query languages($hasPosts: Boolean, $authoredOnly: Boolean, $topics: [Int!]) {
   languages(hasPosts: $hasPosts, authoredOnly: $authoredOnly) {
     ...LanguageWithPostCountFragment
   }

--- a/packages/web/graphql/pages/profilePage.graphql
+++ b/packages/web/graphql/pages/profilePage.graphql
@@ -2,7 +2,7 @@ query profilePage($userId: Int!) {
   userById(id: $userId) {
     ...ProfileUserFragment
   }
-  posts(first: 20, skip: 0, status: PUBLISHED, authoredOnly: true) {
+  posts(first: 20, skip: 0, status: PUBLISHED, authoredOnly: true, authorId: $userId) {
     posts {
       ...PostCardFragment
     }

--- a/packages/web/graphql/post/posts.graphql
+++ b/packages/web/graphql/post/posts.graphql
@@ -9,6 +9,7 @@ query posts(
   $hasInteracted: Boolean
   $authoredOnly: Boolean!
   $status: PostStatus!
+  $authorId: Int
 ) {
   posts(
     first: $first
@@ -21,6 +22,7 @@ query posts(
     hasInteracted: $hasInteracted
     authoredOnly: $authoredOnly
     status: $status
+    authorId: $authorId
   ) {
     posts {
       ...PostCardFragment


### PR DESCRIPTION
## Description

A bug was introduced with #639 where a user is seeing their own posts on another user's profile. This PR fixes that.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Fix bug and test locally
- [ ] Test on stage

### Deployment Checklist

- [ ] 🚨 Publish new j-db-client version and update in both `web` and `j-mail`
- [ ] 🚨 Deploy migs to stage
- [ ] 🚨 Deploy code to stage
- [ ] 🚨 DEPLOY `j-mail` to stage
- [ ] 🚨 Deploy migs to prod
- [ ] 🚨 Deploy code to prod
- [ ] 🚨 DEPLOY `j-mail` TO PROD

## Migrations

No migs
