### PR TITLE
Implement Optimistic UI / Directly Updating My Feed Cache on publishing a post

### DIFF
--- a/packages/web/components/Dashboard/Post/Post.tsx
+++ b/packages/web/components/Dashboard/Post/Post.tsx
@@ -558,8 +558,9 @@ const Post = ({ post, currentUser, refetch }: IPostProps) => {
           cache.modify({
             id: cache.identify(makeReference('ROOT_QUERY')),
             fields: {
-              posts: (existingPosts) => {
-                return [data.updatePost, ...existingPosts.posts]
+              posts: () => {
+                // This simply invalidates the cache for the `posts` query
+                return undefined
               },
             },
           })

--- a/packages/web/pages/dashboard/new-post.tsx
+++ b/packages/web/pages/dashboard/new-post.tsx
@@ -143,8 +143,9 @@ const NewPostPage: NextPage<NewPostPageProps> = ({ defaultImage }) => {
               cache.modify({
                 id: cache.identify(makeReference('ROOT_QUERY')),
                 fields: {
-                  posts: (existingPosts) => {
-                    return [data.createPost, ...existingPosts.posts]
+                  posts: () => {
+                    // This simply invalidates the cache for the `posts` query
+                    return undefined
                   },
                 },
               })


### PR DESCRIPTION
## Description

**Issue:** closes #655 

Fixes the issue where user's had to refresh the page in order to see their new post in My Feed by directly updating the cache rather than simply refetching the entire feed.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Figure out correctly updating the cache
- [x] Protect drafts
- [x] Implement for publishing drafts
- [ ] Test edge cases and potential drawbacks

### Deployment Checklist

- [ ] 🚨 Publish new j-db-client version and update in both `web` and `j-mail`
- [ ] 🚨 Deploy migs to stage
- [ ] 🚨 Deploy code to stage
- [ ] 🚨 DEPLOY `j-mail` to stage
- [ ] 🚨 Deploy migs to prod
- [ ] 🚨 Deploy code to prod
- [ ] 🚨 DEPLOY `j-mail` TO PROD

## Migrations

No migs

## Screenshots

N/A