### PR TITLE
Improve Stripe Weebhook Handler with new events for subscription cancellations

### DIFF
--- a/packages/web/pages/api/stripe/webhook.ts
+++ b/packages/web/pages/api/stripe/webhook.ts
@@ -27,7 +27,7 @@ const updateStripeSubscription = async (subscriptionId: string, db: PrismaClient
   // If this has been set, subscription has expired
   // Covers both customer.subscription.updated & customer.subscription.deleted
   if (stripeSubscription.ended_at) {
-    expiresAt = stripeSubscription.ended_at
+    expiresAt = stripeSubscription.ended_at * 1000
   } else if (stripeSubscription.status === 'active') {
     // Apply a grace period of 2 days to 'active' subscriptions
     expiresAt += 24 * 60 * 60 * 1000 * 2


### PR DESCRIPTION
## Description

**Issue:**
- closes #672 

We discovered a couple of new events that we should be listening for in order to correctly handle a few scenarios where subscriptions have ended, primarily due to failed payments. Previously, we were giving significantly more time before actually cancelling on our side in these cases.

**New events covered:**
- `customer.subscription.updated` with `ended_at` field
- `customer.subscription.deleted`

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Handle `customer.subscription.updated`
- [x] Handle `customer.subscription.deleted`

### Deployment Checklist

- [ ] 🚨 Publish new j-db-client version and update in both `web` and `j-mail`
- [ ] 🚨 Deploy migs to stage
- [ ] 🚨 Deploy code to stage
- [ ] 🚨 DEPLOY `j-mail` to stage
- [ ] 🚨 Deploy migs to prod
- [ ] 🚨 Deploy code to prod
- [ ] 🚨 DEPLOY `j-mail` TO PROD

## Migrations

No hay.

## Screenshots
N/A