### PR TITLE
Fix subscription reactivation

### DIFF
--- a/packages/web/resolvers/subscription.ts
+++ b/packages/web/resolvers/subscription.ts
@@ -192,7 +192,7 @@ const MembershipSubscriptionMutations = extendType({
             customer: customerId,
             trial_end: trialEnd
           })
-  
+
           const membershipSubscriptionData = {
             period: args.period,
             // Give 2 days grace period
@@ -202,19 +202,22 @@ const MembershipSubscriptionMutations = extendType({
             stripeSubscription: stripeSubscription as unknown as Prisma.InputJsonValue,
             stripeSubscriptionId: stripeSubscription.id,
           }
+  
+          let membershipSubscription
 
-          const membershipSubscription = await ctx.db.membershipSubscription.upsert({
-            where: { userId },
-            update: membershipSubscriptionData,
-            create: {
-              ...membershipSubscriptionData,
-              user: {
-                connect: {
-                  id: userId,
-                }, 
-              }
-            }
-          })
+          if (user.membershipSubscription) {
+            membershipSubscription = await ctx.db.membershipSubscription.update({
+              where: { userId },
+              data: membershipSubscriptionData
+            })
+          } else {
+            membershipSubscription = await ctx.db.membershipSubscription.create({
+              data: {
+                ...membershipSubscriptionData,
+                user: { connect: { id: userId, }, }
+              },
+            })
+          }
 
           await sendPremiumWelcomeEmail({ user })
 


### PR DESCRIPTION
## Description

If a user has a subscription which fully expires (e.g. it gets an `ended_at` value), then stripe calls to update that subscription to be active again will fail. In such cases, a new stripe subscription needs to be created for the user (although we'll just overwrite the subscription record in our DB).

### Deployment Checklist

- [N/A] 🚨 Publish new j-db-client version and update in both `web` and `j-mail`
- [N/A] 🚨 Deploy migs to stage
- [X] 🚨 Deploy code to stage
- [N/A] 🚨 DEPLOY `j-mail` to stage
- [N/A] 🚨 Deploy migs to prod
- [ ] 🚨 Deploy code to prod
- [N/A] 🚨 DEPLOY `j-mail` TO PROD

## Migrations

No migs required