### PR TITLE
Payments: Update Payment Method Improvement

### DIFF
--- a/packages/web/resolvers/subscription.ts
+++ b/packages/web/resolvers/subscription.ts
@@ -336,6 +336,9 @@ const MembershipSubscriptionMutations = extendType({
         if (!user?.membershipSubscription?.stripeSubscriptionId) {
           throw new Error("User has no subscription to update")
         }
+        if (!user?.stripeCustomerId) {
+          throw new Error('User has no stripeCustomerId')
+        }
 
         await setPaymentMethod(
           userId,

--- a/packages/web/resolvers/subscription.ts
+++ b/packages/web/resolvers/subscription.ts
@@ -340,7 +340,7 @@ const MembershipSubscriptionMutations = extendType({
         await setPaymentMethod(
           userId,
           ctx.db,
-          user.membershipSubscription.stripeSubscriptionId,
+          user.stripeCustomerId,
           args.paymentMethodId,
         )
         return user.membershipSubscription


### PR DESCRIPTION
## Description

**Issue:**
- fixes #694 

Fixes the call site of `setPaymentMethod` within the `updateSubscriptionPaymentMethod` resolver where we were passing through a subscription ID instead of a customer ID.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Make the fix
- [x] Test on stage
- [ ] Verify in prod after deployment

### Deployment Checklist

- [x] 🚨 Publish new j-db-client version and update in both `web` and `j-mail`
- [x] 🚨 Deploy migs to stage
- [x] 🚨 Deploy code to stage
- [x] 🚨 DEPLOY `j-mail` to stage
- [ ] 🚨 Deploy migs to prod
- [ ] 🚨 Deploy code to prod
- [ ] 🚨 DEPLOY `j-mail` TO PROD

## Migrations

No migs.

## Screenshots

