### PR TITLE
Add New Default Post Image

### DIFF
--- a/packages/web/pages/dashboard/new-post.tsx
+++ b/packages/web/pages/dashboard/new-post.tsx
@@ -64,6 +64,12 @@ const defaultImages = [
     largeSize:
       'https://d2ieewwzq5w1x7.cloudfront.net/post-image/77cc91d6-7b9c-4c02-9233-1bea2dc1f674-large',
   },
+  {
+    smallSize:
+      'https://d2ieewwzq5w1x7.cloudfront.net/post-image/ee047239-f255-49cf-beb2-d73aa4cfdcb3-small',
+    largeSize:
+      'https://d2ieewwzq5w1x7.cloudfront.net/post-image/ee047239-f255-49cf-beb2-d73aa4cfdcb3-large',
+  },
 ]
 
 const selectDefaultImage = () => {


### PR DESCRIPTION
## Description

Having 5 default post images definitely helped a TON with keeping the feed nice and fresh, but we do still often end up with a couple of posts back-to-back having the same image, sometimes multiple times on one page of the feed.

This PR adds one more default post image, just to give us that tiny bit extra diversity on the feed and also to keep things fresh for users who have gotten used to the other five 😊

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Add new image

### Deployment Checklist

- [x] 🚨 Deploy code to stage
- [x] 🚨 Deploy code to prod


## Screenshots

<img src="https://user-images.githubusercontent.com/34203886/145687117-e874a596-6713-4dae-b9a3-add5275b4a54.png" width="500">
