### PR TITLE
Dependabot Fixes - DECEMBER 2021

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -135,9 +135,9 @@
       }
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
     "ansi-styles": {
@@ -1809,12 +1809,6 @@
         "strip-ansi": "^6.0.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
-        },
         "strip-ansi": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",

--- a/packages/j-mail/package-lock.json
+++ b/packages/j-mail/package-lock.json
@@ -1162,9 +1162,9 @@
       }
     },
     "nodemailer": {
-      "version": "6.4.17",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.4.17.tgz",
-      "integrity": "sha512-89ps+SBGpo0D4Bi5ZrxcrCiRFaMmkCt+gItMXQGzEtZVR3uAD3QAQIDoxTWnx3ky0Dwwy/dhFrQ+6NNGXpw/qQ=="
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.6.1.tgz",
+      "integrity": "sha512-1xzFN3gqv+/qJ6YRyxBxfTYstLNt0FCtZaFRvf4Sg9wxNGWbwFmGXVpfSi6ThGK6aRxAo+KjHtYSW8NvCsNSAg=="
     },
     "object-assign": {
       "version": "4.1.1",

--- a/packages/j-mail/package.json
+++ b/packages/j-mail/package.json
@@ -36,7 +36,7 @@
     "@journaly/j-db-client": "13.16.1",
     "aws-sdk": "^2.737.0",
     "date-fns": "^2.16.1",
-    "nodemailer": "^6.4.11",
+    "nodemailer": "^6.6.1",
     "pug": "^3.0.1"
   }
 }


### PR DESCRIPTION
## Description

A collection of dependabot fixes brought in so they can be smoke tested together.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Bring in all updates
- [ ] Smoke test thoroughly on Stage

### Deployment Checklist

- [ ] 🚨 Publish new j-db-client version and update in both `web` and `j-mail`
- [ ] 🚨 Deploy migs to stage
- [ ] 🚨 Deploy code to stage
- [ ] 🚨 DEPLOY `j-mail` to stage
- [ ] 🚨 Deploy migs to prod
- [ ] 🚨 Deploy code to prod
- [ ] 🚨 DEPLOY `j-mail` TO PROD

## Migrations

N/A

## Screenshots

N/A