### PR TITLE
🔧  Fix In-App Notifications Bug: Deleting A Comment With A Thanks

### DIFF
--- a/packages/web/components/NotificationFeed/Notifications.tsx
+++ b/packages/web/components/NotificationFeed/Notifications.tsx
@@ -238,7 +238,8 @@ export const ThreadCommentThanksNotificationLevelOne: React.FC<LevelOneNotificat
   onMarkRead,
 }) => {
   const { t } = useTranslation('common')
-  const thanksAuthor = notification.threadCommentThanksNotifications[0].thanks.author
+  const thanksAuthor = notification.triggeringUser
+  if (!thanksAuthor) return null
   const count = notification.threadCommentThanksNotifications.length
 
   return (

--- a/packages/web/components/NotificationFeed/Notifications.tsx
+++ b/packages/web/components/NotificationFeed/Notifications.tsx
@@ -360,7 +360,8 @@ export const ThreadCommentThanksNotificationLevelTwo: React.FC<LevelTwoNotificat
   closeNotificationFeed,
 }) => {
   const { t } = useTranslation('common')
-  const thanksAuthor = notification.threadCommentThanksNotifications[0].thanks.author
+  const thanksAuthor = notification.triggeringUser
+  if (!thanksAuthor) return null
   const count = notification.threadCommentThanksNotifications.length
   // Separate the different threads
   const threadGroupedThanks: ThreadGroupedThanksType = {}


### PR DESCRIPTION
## Description

**Issue:**
- Fixes #736 

Fixes an issue where a user deletes a comment that has a thanks attached to it. Solution is to use the top-level `triggeringUser` field instead for `thanksAuthor` and then null check.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Repro
- [x] Make fix
- [x] Test

### Deployment Checklist

- [ ] 🚨 Deploy code to stage
- [ ] 🚨 Deploy code to prod

## Migrations

No migs

## Screenshots

N/A