### PR TITLE
Better paragraph formatting for comments

### DIFF
--- a/packages/web/components/Dashboard/Post/PostComment.tsx
+++ b/packages/web/components/Dashboard/Post/PostComment.tsx
@@ -1,7 +1,5 @@
 import React, { useState } from 'react'
 import Link from 'next/link'
-import Markdown from 'react-markdown'
-import remarkGfm from 'remark-gfm'
 
 import {
   useUpdatePostCommentMutation,
@@ -10,6 +8,7 @@ import {
 } from '@/generated/graphql'
 import { useTranslation } from '@/config/i18n'
 
+import EditableMarkdown from '@/components/EditableMarkdown'
 import Button, { ButtonSize, ButtonVariant } from '@/components/Button'
 import { useConfirmationModal } from '@/components/Modals/ConfirmationModal'
 import theme from '@/theme'
@@ -96,22 +95,13 @@ const PostComment: React.FC<PostCommentProps> = ({
             </span>
           </div>
         </div>
-        <div className="body-block">
-          {isEditMode ? (
-            <textarea
-              value={updatingCommentBody}
-              onChange={(e) => setUpdatingCommentBody(e.target.value)}
-            />
-          ) : (
-            <Markdown
-              className="comment-body"
-              disallowedElements={['img']}
-              remarkPlugins={[remarkGfm]}
-            >
-              {comment.body}
-            </Markdown>
-          )}
-        </div>
+
+        <EditableMarkdown
+          body={comment.body}
+          updatingCommentBody={updatingCommentBody}
+          setUpdatingCommentBody={setUpdatingCommentBody}
+          editing={isEditMode}
+        />
       </div>
       {canEdit && !isEditMode && (
         <div className="edit-block">
@@ -219,51 +209,6 @@ const PostComment: React.FC<PostCommentProps> = ({
           white-space: pre-line;
           word-wrap: break-word;
         }
-
-        // MarkDown Styles -->
-        :global(.comment-body h1),
-        :global(.comment-body h2),
-        :global(.comment-body h3),
-        :global(.comment-body h4) {
-          font-family: inherit;
-          font-size: 1.2em;
-          font-weight: 600;
-          margin: 0.5em 0 0.5em 0;
-        }
-        :global(.comment-body ol > li) {
-          list-style: inside;
-          list-style-type: decimal;
-          margin-left: 10px;
-        }
-        :global(.comment-body ul > li:not(.task-list-item)) {
-          list-style: inside;
-          list-style-type: disc;
-          margin-left: 10px;
-        }
-        :global(.comment-body ul > li > input[type='checkbox']) {
-          margin: 0 10px;
-        }
-        :global(.comment-body code) {
-          background-color: #eee;
-          font-family: monospace;
-          padding: 2px;
-        }
-        :global(.comment-body blockquote) {
-          border-left: 4px solid ${theme.colors.blueLight};
-          padding-left: 5px;
-          background-color: ${theme.colors.gray100};
-          font-style: italic;
-          margin: 5px 0;
-        }
-        :global(.comment-body a) {
-          color: ${theme.colors.blueLight};
-        }
-        :global(.comment-body a:hover) {
-          cursor: pointer;
-          text-decoration: underline;
-        }
-
-        // <-- MarkDown Styles
 
         .body-block :global(p) {
           word-wrap: break-word;

--- a/packages/web/components/Dashboard/Post/PostComments.tsx
+++ b/packages/web/components/Dashboard/Post/PostComments.tsx
@@ -179,7 +179,6 @@ const PostComments = ({
           width: 100%;
           height: 100%;
           padding: 20px;
-          text-align: center;
           display: flex;
           flex-direction: column;
           max-height: 100%;
@@ -194,6 +193,7 @@ const PostComments = ({
         h1 {
           ${theme.typography.headingLG};
           margin-bottom: 20px;
+          text-align: center;
         }
 
         .post-comments {

--- a/packages/web/components/EditableMarkdown/EditableMarkdown.tsx
+++ b/packages/web/components/EditableMarkdown/EditableMarkdown.tsx
@@ -1,0 +1,119 @@
+import { useRef, useEffect } from 'react'
+import Markdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+
+import theme from '@/theme'
+
+type EditableMarkdownProps = {
+  body: string
+  updatingCommentBody: string
+  setUpdatingCommentBody: (arg0: string) => void
+  editing?: boolean
+}
+
+const EditableMarkdown = ({
+  body,
+  updatingCommentBody,
+  setUpdatingCommentBody,
+  editing = false,
+}: EditableMarkdownProps) => {
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  // Focus textarea and select content when opening edit mode.
+  useEffect(() => {
+    if (!editing)
+      return
+
+    setTimeout(() => {
+      const el = textareaRef.current
+      if (el) {
+        el.focus()
+        el.setSelectionRange(el.value.length, el.value.length)
+      }
+    }, 0)
+  }, [editing])
+
+  return (
+    <div className="body-block">
+      {editing ? (
+        <textarea
+          ref={textareaRef}
+          value={updatingCommentBody}
+          onChange={(e) => setUpdatingCommentBody(e.target.value)}
+        />
+      ) : (
+        <Markdown
+          disallowedElements={['img']}
+          remarkPlugins={[remarkGfm]}
+        >
+          {body}
+        </Markdown>
+      )}
+
+      <style jsx>{`
+        // MarkDown Styles
+        .body-block :global(h1),
+        .body-block :global(h2),
+        .body-block :global(h3),
+        .body-block :global(h4) {
+          font-family: inherit;
+          font-size: 1.2em;
+          font-weight: 600;
+          margin: 0.5em 0 0.5em 0;
+        }
+        .body-block :global(ol > li) {
+          list-style: inside;
+          list-style-type: decimal;
+          margin-left: 10px;
+        }
+        .body-block :global(ul > li:not(.task-list-item)) {
+          list-style: inside;
+          list-style-type: disc;
+          margin-left: 10px;
+        }
+        .body-block :global(ul > li > input[type='checkbox']) {
+          margin: 0 10px;
+        }
+        .body-block :global(p) {
+          line-height: 1.3em;
+        }
+        .body-block :global(p:not(:last-child)) {
+          margin-bottom: 0.8em;
+        }
+        .body-block :global(code) {
+          background-color: #eee;
+          font-family: monospace;
+          padding: 2px;
+        }
+        .body-block :global(blockquote) {
+          border-left: 4px solid ${theme.colors.blueLight};
+          padding-left: 5px;
+          margin: 5px 0;
+          background-color: ${theme.colors.gray100};
+          font-style: italic;
+        }
+        .body-block :global(a) {
+          color: ${theme.colors.blueLight};
+        }
+        .body-block :global(a:hover) {
+          cursor: pointer;
+          text-decoration: underline;
+        }
+
+        textarea {
+          flex: 1;
+          width: 100%;
+          outline: none;
+          padding: 5px;
+          margin-right: 10px;
+          background-color: transparent;
+          resize: vertical;
+          border: 1px solid ${theme.colors.gray400};
+          border-radius: 5px;
+        }
+      `}</style>
+    </div>
+  )
+}
+
+export default EditableMarkdown

--- a/packages/web/components/EditableMarkdown/index.ts
+++ b/packages/web/components/EditableMarkdown/index.ts
@@ -1,0 +1,1 @@
+export { default } from './EditableMarkdown'

--- a/packages/web/components/InlineFeedbackPopover/Comment.tsx
+++ b/packages/web/components/InlineFeedbackPopover/Comment.tsx
@@ -1,9 +1,7 @@
-import React, { useState, useRef, useMemo } from 'react'
+import React, { useState, useMemo } from 'react'
 import Link from 'next/link'
 import { toast } from 'react-toastify'
 import classNames from 'classnames'
-import Markdown from 'react-markdown'
-import remarkGfm from 'remark-gfm'
 
 import {
   useUpdateCommentMutation,
@@ -16,6 +14,7 @@ import {
 } from '@/generated/graphql'
 import theme from '@/theme'
 import { useTranslation } from '@/config/i18n'
+import EditableMarkdown from '@/components/EditableMarkdown'
 import Button, { ButtonSize, ButtonVariant } from '@/components/Button'
 import { useConfirmationModal } from '@/components/Modals/ConfirmationModal'
 import EditIcon from '@/components/Icons/EditIcon'
@@ -35,7 +34,6 @@ type CommentProps = {
 
 const Comment = ({ comment, canEdit, onUpdateComment, currentUser }: CommentProps) => {
   const { t } = useTranslation('comment')
-  const editTextarea = useRef<HTMLTextAreaElement>(null)
   const [isEditMode, setIsEditMode] = useState(false)
   const [updatingCommentBody, setUpdatingCommentBody] = useState(comment.body)
   const [updateComment, { loading }] = useUpdateCommentMutation({
@@ -171,23 +169,12 @@ const Comment = ({ comment, canEdit, onUpdateComment, currentUser }: CommentProp
             </span>
           </div>
         </div>
-        <div className="body-block">
-          {isEditMode ? (
-            <textarea
-              ref={editTextarea}
-              value={updatingCommentBody}
-              onChange={(e) => setUpdatingCommentBody(e.target.value)}
-            />
-          ) : (
-            <Markdown
-              className="comment-body"
-              disallowedElements={['img']}
-              remarkPlugins={[remarkGfm]}
-            >
-              {comment.body}
-            </Markdown>
-          )}
-        </div>
+        <EditableMarkdown
+          body={comment.body}
+          updatingCommentBody={updatingCommentBody}
+          setUpdatingCommentBody={setUpdatingCommentBody}
+          editing={isEditMode}
+        />
       </div>
       {canEdit && !isEditMode && (
         <div className="edit-thanks-block">
@@ -204,13 +191,6 @@ const Comment = ({ comment, canEdit, onUpdateComment, currentUser }: CommentProp
               onClick={() => {
                 setIsEditMode(true)
                 setUpdatingCommentBody(comment.body)
-                setTimeout(() => {
-                  const el = editTextarea.current
-                  if (el) {
-                    el.focus()
-                    el.setSelectionRange(el.value.length, el.value.length)
-                  }
-                }, 0)
               }}
             >
               <EditIcon size={24} />
@@ -314,54 +294,6 @@ const Comment = ({ comment, canEdit, onUpdateComment, currentUser }: CommentProp
           text-align: left;
         }
 
-        .comment-body {
-          white-space: pre-line;
-          word-wrap: break-word;
-        }
-
-        // MarkDown Styles
-        :global(.comment-body h1),
-        :global(.comment-body h2),
-        :global(.comment-body h3),
-        :global(.comment-body h4) {
-          font-family: inherit;
-          font-size: 1.2em;
-          font-weight: 600;
-          margin: 0.5em 0 0.5em 0;
-        }
-        :global(.comment-body ol > li) {
-          list-style: inside;
-          list-style-type: decimal;
-          margin-left: 10px;
-        }
-        :global(.comment-body ul > li:not(.task-list-item)) {
-          list-style: inside;
-          list-style-type: disc;
-          margin-left: 10px;
-        }
-        :global(.comment-body ul > li > input[type='checkbox']) {
-          margin: 0 10px;
-        }
-        :global(.comment-body code) {
-          background-color: #eee;
-          font-family: monospace;
-          padding: 2px;
-        }
-        :global(.comment-body blockquote) {
-          border-left: 4px solid ${theme.colors.blueLight};
-          padding-left: 5px;
-          margin: 5px 0;
-          background-color: ${theme.colors.gray100};
-          font-style: italic;
-        }
-        :global(.comment-body a) {
-          color: ${theme.colors.blueLight};
-        }
-        :global(.comment-body a:hover) {
-          cursor: pointer;
-          text-decoration: underline;
-        }
-
         .edit-thanks-block {
           display: flex;
           flex-direction: column;
@@ -406,18 +338,6 @@ const Comment = ({ comment, canEdit, onUpdateComment, currentUser }: CommentProp
 
         .thanks-count {
           color: ${theme.colors.gray600};
-        }
-
-        textarea {
-          flex: 1;
-          width: 100%;
-          outline: none;
-          padding: 5px;
-          margin-right: 10px;
-          background-color: transparent;
-          resize: vertical;
-          border: 1px solid ${theme.colors.gray400};
-          border-radius: 5px;
         }
       `}</style>
     </div>


### PR DESCRIPTION
## Description

Changes to thread/post comments:

- Better visual separation of paragraphs in multi-paragraph post/thread comments:
  - Reduces the space between lines of a paragraph 
  - Increases the space between paragraphs
- Creates a new component that encapsulates presentation and editing markdown comments
  - This also adds the "focus edit textarea on edit" behavior to post comments to make it consistent with thread comments

### Deployment Checklist

- [x] 🚨 Deploy code to stage
- [x] 🚨 Deploy code to prod

## Migrations

No migs

## Screenshots
Before:
<img width="523" alt="Screen Shot 2021-12-18 at 12 50 22 PM" src="https://user-images.githubusercontent.com/2343714/146654304-d6914466-26a3-4fe6-9d8e-de7e8b971bbb.png">

After:
<img width="503" alt="Screen Shot 2021-12-18 at 12 50 34 PM" src="https://user-images.githubusercontent.com/2343714/146654303-3d8a8413-0257-4c23-89c0-a00b4197702d.png">


