### PR TITLE
Allow unauth'd users to view profile pages

### DIFF
--- a/packages/web/resolvers/post.ts
+++ b/packages/web/resolvers/post.ts
@@ -293,14 +293,16 @@ const PostQueries = extendType({
       resolve: async (_parent, args, ctx) => {
         const { userId } = ctx.request
 
-        const currentUser = await ctx.db.user.findUnique({
-          where: {
-            id: userId,
-          },
-          include: {
-            following: true,
-          },
-        })
+        const currentUser = userId
+          ? await ctx.db.user.findUnique({
+              where: {
+                id: userId,
+              },
+              include: {
+                following: true,
+              },
+            })
+          : null
 
         if (!args.first) args.first = 10
         if (args.first > 50) args.first = 50


### PR DESCRIPTION
## Description

**Issue:**
- Fixes #660 
- Related to #604 

Fixes issue in resolver where unauth'd user could not use the `posts` query, despite that query being designed for both auth'd and unauth'd cases.

### Deployment Checklist

- [ ] 🚨 Deploy code to stage
- [ ] 🚨 Deploy code to prod

## Migrations

No migs

## Screenshots
<img width="2417" alt="Screen Shot 2021-12-18 at 2 27 32 PM" src="https://user-images.githubusercontent.com/2343714/146654728-d83d06d9-2304-4bcb-be3d-af8b40cadfd6.png">

