### PR TITLE
🔎 Display Follower & Following Stats On Journaler's Own Profile

### DIFF
--- a/packages/web/components/Dashboard/Profile/ProfileCard.tsx
+++ b/packages/web/components/Dashboard/Profile/ProfileCard.tsx
@@ -127,13 +127,17 @@ const ProfileCard: React.FC<Props> = ({ user }) => {
                 variant={ButtonVariant.Link}
                 onClick={() => setDisplayFollowerListModal(true)}
               >
-                <span className="follower-stat">{user.followedBy?.length} Followers</span>
+                <span className="follower-stat">
+                  {t('followerCount', { count: user.followedBy?.length })}
+                </span>
               </Button>
               <Button
                 variant={ButtonVariant.Link}
                 onClick={() => setDisplayFollowingListModal(true)}
               >
-                <span className="follower-stat">{user.following?.length} Following</span>
+                <span className="follower-stat">
+                  {t('followingCount', { count: user.following?.length })}
+                </span>
               </Button>
             </div>
           )}
@@ -183,14 +187,14 @@ const ProfileCard: React.FC<Props> = ({ user }) => {
       </div>
       {displayFollowerListModal && (
         <UserListModal
-          title={`${user.followedBy.length} Followers`}
+          title={t('followerCount', { count: user.followedBy.length })}
           users={user.followedBy}
           onClose={() => setDisplayFollowerListModal(false)}
         />
       )}
       {displayFollowingListModal && (
         <UserListModal
-          title={`${user.following.length} Following`}
+          title={t('followingCount', { count: user.following.length })}
           users={user.following}
           onClose={() => setDisplayFollowingListModal(false)}
         />

--- a/packages/web/components/Dashboard/Profile/ProfileCard.tsx
+++ b/packages/web/components/Dashboard/Profile/ProfileCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useTranslation } from '@/config/i18n'
 import FacebookIcon from '@/components/Icons/FacebookIcon'
 import InstagramIcon from '@/components/Icons/InstagramIcon'
@@ -14,10 +14,11 @@ import {
   useFollowUserMutation,
   useUnfollowUserMutation,
   LanguageLevel,
-  ProfileUserFragmentFragment
+  ProfileUserFragmentFragment,
 } from '@/generated/graphql'
 import Button, { ButtonVariant } from '@/components/Button'
 import UserAvatar from '@/components/UserAvatar'
+import UserListModal from '@/components/Modals/UserListModal'
 
 type Props = {
   user: ProfileUserFragmentFragment
@@ -26,7 +27,8 @@ type Props = {
 const ProfileCard: React.FC<Props> = ({ user }) => {
   const { t } = useTranslation('profile')
 
-
+  const [displayFollowerListModal, setDisplayFollowerListModal] = useState(false)
+  const [displayFollowingListModal, setDisplayFollowingListModal] = useState(false)
 
   const name = user.name || user.handle
   const showSeparator =
@@ -121,14 +123,18 @@ const ProfileCard: React.FC<Props> = ({ user }) => {
           {/* User is logged in viewing their own profile */}
           {currentUser && currentUser.id === user.id && (
             <div className="follower-stats-container">
-              <div className="follower-stat">
-                <span>{105}</span>
-                <span>Followers</span>
-              </div>
-              <div className="follower-stat">
-                <span>{53}</span>
-                <span>Following</span>
-              </div>
+              <Button
+                variant={ButtonVariant.Link}
+                onClick={() => setDisplayFollowerListModal(true)}
+              >
+                <span className="follower-stat">{user.followedBy?.length} Followers</span>
+              </Button>
+              <Button
+                variant={ButtonVariant.Link}
+                onClick={() => setDisplayFollowingListModal(true)}
+              >
+                <span className="follower-stat">{user.following?.length} Following</span>
+              </Button>
             </div>
           )}
 
@@ -175,7 +181,20 @@ const ProfileCard: React.FC<Props> = ({ user }) => {
           </div>
         </div>
       </div>
-
+      {displayFollowerListModal && (
+        <UserListModal
+          title={`${user.followedBy.length} Followers`}
+          users={user.followedBy}
+          onClose={() => setDisplayFollowerListModal(false)}
+        />
+      )}
+      {displayFollowingListModal && (
+        <UserListModal
+          title={`${user.following.length} Following`}
+          users={user.following}
+          onClose={() => setDisplayFollowingListModal(false)}
+        />
+      )}
       <style jsx>{`
         .profile-card {
           position: relative;
@@ -342,13 +361,10 @@ const ProfileCard: React.FC<Props> = ({ user }) => {
           display: flex;
           justify-content: center;
           gap: 12px;
-          color: ${theme.colors.blueLight};
-          font-weight: 600;
         }
 
         .follower-stat {
-          display: flex;
-          flex-direction: column;
+          font-weight: 600;
         }
       `}</style>
     </div>

--- a/packages/web/components/Dashboard/Profile/ProfileCard.tsx
+++ b/packages/web/components/Dashboard/Profile/ProfileCard.tsx
@@ -107,7 +107,7 @@ const ProfileCard: React.FC<Props> = ({ user }) => {
           <div className="profile-image-desktop">
             <UserAvatar user={user} size={150} />
           </div>
-
+          {/* User is logged in viewing another user's profile */}
           {currentUser && currentUser.id !== user.id && (
             <Button
               className="follow-btn"
@@ -117,6 +117,19 @@ const ProfileCard: React.FC<Props> = ({ user }) => {
             >
               {hasFollowedAuthor ? t('unfollow') : t('follow')}
             </Button>
+          )}
+          {/* User is logged in viewing their own profile */}
+          {currentUser && currentUser.id === user.id && (
+            <div className="follower-stats-container">
+              <div className="follower-stat">
+                <span>{105}</span>
+                <span>Followers</span>
+              </div>
+              <div className="follower-stat">
+                <span>{53}</span>
+                <span>Following</span>
+              </div>
+            </div>
           )}
 
           {user.bio && <p className="bio">{sanitize(user.bio)}</p>}
@@ -323,6 +336,19 @@ const ProfileCard: React.FC<Props> = ({ user }) => {
         }
         :global(.social-link:last-child) {
           margin-right: 0;
+        }
+
+        .follower-stats-container {
+          display: flex;
+          justify-content: center;
+          gap: 12px;
+          color: ${theme.colors.blueLight};
+          font-weight: 600;
+        }
+
+        .follower-stat {
+          display: flex;
+          flex-direction: column;
         }
       `}</style>
     </div>

--- a/packages/web/generated/graphql.tsx
+++ b/packages/web/generated/graphql.tsx
@@ -1167,6 +1167,8 @@ export type ProfilePageQuery = { __typename?: 'Query' } & {
 }
 
 export type ProfileUserFragmentFragment = { __typename?: 'User' } & {
+  followedBy: Array<{ __typename?: 'User' } & UserFragmentFragment>
+  following: Array<{ __typename?: 'User' } & UserFragmentFragment>
   badges: Array<{ __typename?: 'UserBadge' } & UserBadgeFragmentFragment>
   userInterests: Array<{ __typename?: 'UserInterest' } & UserInterestFragmentFragment>
 } & UserWithLanguagesFragmentFragment &
@@ -1961,6 +1963,12 @@ export const SocialMediaFragmentFragmentDoc = gql`
 export const ProfileUserFragmentFragmentDoc = gql`
   fragment ProfileUserFragment on User {
     ...UserWithLanguagesFragment
+    followedBy {
+      ...UserFragment
+    }
+    following {
+      ...UserFragment
+    }
     badges {
       ...UserBadgeFragment
     }
@@ -1970,6 +1978,7 @@ export const ProfileUserFragmentFragmentDoc = gql`
     ...SocialMediaFragment
   }
   ${UserWithLanguagesFragmentFragmentDoc}
+  ${UserFragmentFragmentDoc}
   ${UserBadgeFragmentFragmentDoc}
   ${UserInterestFragmentFragmentDoc}
   ${SocialMediaFragmentFragmentDoc}

--- a/packages/web/graphql/pages/profilePage.graphql
+++ b/packages/web/graphql/pages/profilePage.graphql
@@ -15,6 +15,12 @@ query profilePage($userId: Int!, $uiLanguage: UILanguage!) {
 
 fragment ProfileUserFragment on User {
   ...UserWithLanguagesFragment
+  followedBy {
+    ...UserFragment
+  }
+  following {
+    ...UserFragment
+  }
   badges {
     ...UserBadgeFragment
   }

--- a/packages/web/public/static/locales/de/profile.json
+++ b/packages/web/public/static/locales/de/profile.json
@@ -8,5 +8,9 @@
   "emptyPosts": "{{user}} hat noch keine Beiträge verfasst.",
   "loggedInUserEmptyPosts": "Du hast noch keine Beiträge. <1>Schreibe einen Beitrag</1>!",
   "follow": "Folgen",
-  "unfollow": "Nicht mehr folgen"
+  "unfollow": "Nicht mehr folgen",
+  "followerCount": "{{count}} Follower",
+  "followerCount_plural": "{{count}} Followers",
+  "followingCount": "{{count}} Following",
+  "followingCount_plural": "{{count}} Following"
 }

--- a/packages/web/public/static/locales/en/profile.json
+++ b/packages/web/public/static/locales/en/profile.json
@@ -28,5 +28,9 @@
   "emptyPosts": "{{user}} hasn't written any posts yet.",
   "loggedInUserEmptyPosts": "You have no recent posts. <1>Write a new post</1>!",
   "follow": "Follow",
-  "unfollow": "Unfollow"
+  "unfollow": "Unfollow",
+  "followerCount": "{{count}} Follower",
+  "followerCount_plural": "{{count}} Followers",
+  "followingCount": "{{count}} Following",
+  "followingCount_plural": "{{count}} Following"
 }

--- a/packages/web/public/static/locales/es/profile.json
+++ b/packages/web/public/static/locales/es/profile.json
@@ -8,5 +8,9 @@
   "emptyPosts": "{{usuario}} todavía no ha escrito publicaciones.",
   "loggedInUserEmptyPosts": "No tiene publicaciones recientes. <1>Escriba una nueva publicación</1>!",
   "follow": "Seguir",
-  "unfollow": "Dejar de seguir"
+  "unfollow": "Dejar de seguir",
+  "followerCount": "{{count}} Seguidor",
+  "followerCount_plural": "{{count}} Seguidores",
+  "followingCount": "{{count}} Siguiendo",
+  "followingCount_plural": "{{count}} Siguiendo"
 }

--- a/packages/web/public/static/locales/it/profile.json
+++ b/packages/web/public/static/locales/it/profile.json
@@ -28,5 +28,9 @@
   "emptyPosts": "{{user}} hasn't written any posts yet.",
   "loggedInUserEmptyPosts": "You have no recent posts. <1>Write a new post</1>!",
   "follow": "Follow",
-  "unfollow": "Unfollow"
+  "unfollow": "Unfollow",
+  "followerCount": "{{count}} Follower",
+  "followerCount_plural": "{{count}} Followers",
+  "followingCount": "{{count}} Following",
+  "followingCount_plural": "{{count}} Following"
 }

--- a/packages/web/public/static/locales/zh_CN/profile.json
+++ b/packages/web/public/static/locales/zh_CN/profile.json
@@ -28,5 +28,9 @@
   "emptyPosts": "{{user}} 暂时还没有发布日志",
   "loggedInUserEmptyPosts": "您没有近期日志。 <1>写新日志吧</1>！",
   "follow": "关注",
-  "unfollow": "取消关注"
+  "unfollow": "取消关注",
+  "followerCount": "{{count}} 粉丝",
+  "followerCount_plural": "{{count}} 粉丝",
+  "followingCount": "{{count}} 已关注",
+  "followingCount_plural": "{{count}} 已关注"
 }

--- a/packages/web/public/static/locales/zh_TW/profile.json
+++ b/packages/web/public/static/locales/zh_TW/profile.json
@@ -28,5 +28,9 @@
   "emptyPosts": "{{user}} 暫時還沒有發布日誌",
   "loggedInUserEmptyPosts": "您沒有近期日誌。 <1>寫新日誌吧</1>！",
   "follow": "關註",
-  "unfollow": "取消關註"
+  "unfollow": "取消關註",
+  "followerCount": "{{count}} 粉絲",
+  "followerCount_plural": "{{count}} 粉絲",
+  "followingCount": "{{count}} 追蹤中",
+  "followingCount_plural": "{{count}} 追蹤中"
 }


### PR DESCRIPTION
## Description

**Issue:**
- closes #606 

Final major improvements to the Journaly "following experience" by:
1. Enabling users to see how many Journalers are following them and they are following
2. Enabling users to see a complete list for each category

### UX Details/Decisions

- We did decide to keep this information for each user private, in accordance with our UX design philosophy and values of not building features that promote the kind of behaviour that many other social platforms do that can be negative longterm for the actual users (in this case, promoting the desire to chase more followers).

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Initial markup & visual design
- [x] Bring in real data for each stat
- [x] Implement `<UserList>` when clicking on each one
- [x] Add translations

### Deployment Checklist

- [ ] 🚨 Deploy code to stage
- [ ] 🚨 Deploy code to prod

## Migrations

No miggies

## Screenshots

![image](https://user-images.githubusercontent.com/34203886/147387267-875ce293-5500-4b88-bd9b-97bae205310b.png)

![image](https://user-images.githubusercontent.com/34203886/147387268-c756dfac-b3f3-491c-8321-449da05f0acc.png)

