### PR TITLE
Fix Notification Creation On New Thread Creation

### DIFF
--- a/packages/web/resolvers/comment.ts
+++ b/packages/web/resolvers/comment.ts
@@ -121,19 +121,15 @@ const createComment = async ({
     },
   })
 
-  const updatedThreadData = await db.thread.findUnique({
-    where: {
-      id: thread.id,
-    },
-    include: {
-      subscriptions: true,
-    },
+  const subscriptions = await db.threadSubscription.findMany({
+    where: { threadId: thread.id },
+    include: { user: true },
   })
 
-  if (!updatedThreadData) throw new Error('Error fetching updated thread data')
+  if (!subscriptions) throw new Error('Error fetching updated subscriptions')
 
   await Promise.all(
-    updatedThreadData.subscriptions.map(async ({ user }: { user: User }) => {
+    subscriptions.map(async ({ user }: { user: User }) => {
       if (user.id === author.id) {
         // This is the user creating the comment, do not notify them.
         return new Promise((res) => res(null))


### PR DESCRIPTION
## Description

Fixes an issue that surfaced where notifications weren't being created for comments in a newly opened thread after the optimizations we made in #728 .

Solution was to refetch the subscriptions after the upsert creating the new subscription and before creating the notifications - as the notifications were being created based on the outdated thread subscriptions.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Find issue
- [x] Fix issue
- [x] Test

### Deployment Checklist

- [N/A] 🚨 Publish new j-db-client version and update in both `web` and `j-mail`
- [N/A] 🚨 Deploy migs to stage
- [x] 🚨 Deploy code to stage
- [N/A] 🚨 DEPLOY `j-mail` to stage
- [N/A] 🚨 Deploy migs to prod
- [x] 🚨 Deploy code to prod
- [N/A] 🚨 DEPLOY `j-mail` TO PROD

## Migrations

None

## Screenshots

None