### PR TITLE
Fix Small Bug With New Profile URL Pattern From Inline-Feedback Comments

### DIFF
--- a/packages/web/components/InlineFeedbackPopover/Comment.tsx
+++ b/packages/web/components/InlineFeedbackPopover/Comment.tsx
@@ -152,7 +152,7 @@ const Comment = ({ comment, canEdit, onUpdateComment, currentUser }: CommentProp
     <div className="comment">
       <div className="author-body-container">
         <div className="author-block">
-          <Link href={`/user/${comment.author.id}`}>
+          <Link href={`/user/${comment.author.handle}`}>
             <a className="author-info">
               <UserAvatar user={comment.author} size={30} />
             </a>


### PR DESCRIPTION
## Description

It looks like the href it pointing to a combination of the old & new URL patterns when clicking on a profile image from within an inline-feedback comment. Quick fix 🏥👨🏻‍⚕️🚀