### PR TITLE
Update `slate-react` To 0.72.7

### DIFF
--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -13561,9 +13561,9 @@
       }
     },
     "slate-react": {
-      "version": "0.72.4",
-      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.72.4.tgz",
-      "integrity": "sha512-aUQLZwkAxu6PpuAiQSqNRALAFRwX7f8t9Kh5/NSPvqTVk9oDaNOrlal1WuAMRyX4bTpFYLrEOq6LAoPG/F12+g==",
+      "version": "0.72.7",
+      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.72.7.tgz",
+      "integrity": "sha512-W7GG2Smoq4VLSMNfxhepA0eyBpiIxCZneBhz4gJSyrIsk5y0GE2vXPCg1TLbZrsN0qNxx+R0Dk/JPl8E+5XJkA==",
       "requires": {
         "@types/is-hotkey": "^0.1.1",
         "@types/lodash": "^4.14.149",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -85,7 +85,7 @@
     "slate": "^0.72.3",
     "slate-history": "^0.66.0",
     "slate-hyperscript": "^0.67.0",
-    "slate-react": "^0.72.4",
+    "slate-react": "^0.72.7",
     "stripe": "^8.137.0",
     "swot-node": "^2.0.173",
     "ts-node": "^9.0.0",


### PR DESCRIPTION
## Description

Just keeping Slate up-to-date as much as possible in light of recent reports. 

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Make updates
- [x] Regression Testing
- [ ] Verify if any improvements to known bugs

### Deployment Checklist

- [ ] 🚨 Publish new j-db-client version and update in both `web` and `j-mail`
- [ ] 🚨 Deploy migs to stage
- [ ] 🚨 Deploy code to stage
- [ ] 🚨 DEPLOY `j-mail` to stage
- [ ] 🚨 Deploy migs to prod
- [ ] 🚨 Deploy code to prod
- [ ] 🚨 DEPLOY `j-mail` TO PROD
