### PR TITLE
📉 Eliminate Slowest Query - Outage Resolution

### DIFF
--- a/packages/web/resolvers/post.ts
+++ b/packages/web/resolvers/post.ts
@@ -128,23 +128,7 @@ const PostObjectType = objectType({
     t.model.bumpedAt()
     t.model.bumpCount()
     t.int('commentCount', {
-      resolve: async (parent, _args, ctx, _info) => {
-        const [threadCommentCount, postCommentCount] = await Promise.all([
-          ctx.db.comment.count({
-            where: {
-              thread: {
-                postId: parent.id,
-              },
-            },
-          }),
-          ctx.db.postComment.count({
-            where: {
-              postId: parent.id,
-            },
-          }),
-        ])
-        return threadCommentCount + postCommentCount
-      },
+      resolve: () => 0,
     })
   },
 })


### PR DESCRIPTION
## Description

At 10:30pm U.K. time on Jan 28th we started getting reports of outages that revealed a concerning pattern where the DB was continuously but intermittently having problems. This PR is to test eliminating what appears to be by far the slowest query (and happens to be one of the least critical to User Experience and application functionality) to see if this resolves the outage.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Make changes
- [x] Smoke test

### Deployment Checklist

- [ ] 🚨 Deploy code to stage
- [ ] 🚨 Deploy code to prod

## Migrations

None

## Screenshots

N/A
