### PR TITLE
Revert "📉 Eliminate Slowest Query - Outage Resolution"

### DIFF
--- a/packages/web/resolvers/post.ts
+++ b/packages/web/resolvers/post.ts
@@ -128,7 +128,23 @@ const PostObjectType = objectType({
     t.model.bumpedAt()
     t.model.bumpCount()
     t.int('commentCount', {
-      resolve: () => 0,
+      resolve: async (parent, _args, ctx, _info) => {
+        const [threadCommentCount, postCommentCount] = await Promise.all([
+          ctx.db.comment.count({
+            where: {
+              thread: {
+                postId: parent.id,
+              },
+            },
+          }),
+          ctx.db.postComment.count({
+            where: {
+              postId: parent.id,
+            },
+          }),
+        ])
+        return threadCommentCount + postCommentCount
+      },
     })
   },
 })


### PR DESCRIPTION
Reverts Journaly/journaly#770

While experiencing some puzzling outages yesterday we tried removing our most expensive query to test the impact, but we finally understood that these outages appeared to actually be due to some connectivity issues between Vercel and the DB... another catalyst to move off of Vercel and manage our deployment system internally at last.

Reverting that change.