### PR TITLE
Fix autosave

### DIFF
--- a/packages/web/components/JournalyEditor/JournalyEditor.tsx
+++ b/packages/web/components/JournalyEditor/JournalyEditor.tsx
@@ -68,6 +68,10 @@ const JournalyEditor = ({
     ;(slateRef as React.MutableRefObject<Editor>).current = editor
   }, [editor])
 
+  if (typeof window === 'undefined') {
+    return null
+  }
+
   return (
     <div className="editor-wrapper">
       <div className="editor-container">

--- a/packages/web/hooks/useAutosavedState.ts
+++ b/packages/web/hooks/useAutosavedState.ts
@@ -11,19 +11,21 @@ export default function useAutosavedState<T>(
   const storage: any = (typeof window !== 'undefined' && window.localStorage) || {}
   const storageKey = `autosave-v1[${opts.key || 'default'}]`
 
-  const [value, setValue] = React.useState<T>(initialValue)
-  const valueRef = React.useRef({ savePending: false, value })
-
-  React.useEffect(() => {
+  const initializer = React.useMemo(() => {
     if (storageKey in storage) {
       const { value, timestamp } = JSON.parse(storage[storageKey])
 
       if (timestamp > opts.initialTimestamp) {
-        console.info('Restoring value from storage')
-        setValue(value)
+        console.info('Restoring value from storage', storageKey)
+        return value
       }
     }
+
+    return initialValue
   }, [])
+
+  const [value, setValue] = React.useState<T>(initializer)
+  const valueRef = React.useRef({ savePending: false, value })
 
   React.useEffect(() => {
     valueRef.current.value = value


### PR DESCRIPTION
Eliminate second render introduced by restoring `useAutosaveState` and fix autosave state by not even trying to SSR the editor.

## Description

Fixes #755

Either some change in slate or unfortunate interaction of slate-plugins/plate and slate caused slate to fail to update DOM state when a new `value` prop is passed to slate-react's `Slate` component, which broke autosaving (strictly speaking autosaving always worked fine, but slate just wouldn't reflect a restored value correctly, which you could observe with e.g. post titles saving and restoring correctly). To fix this we need to make sure that slate has the autosaved value available on its very first render. Further the DOM state of the editor must be equal during SSR and on the first render in the client or else slate explodes. To make this work, given save state is not available on the server, the best solution I could come up with is simply not to render the editor during SSR and let its first render on the client have the restored state. This seems like a least-of-several-evils solution.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [ ] ...

### Deployment Checklist

- [ ] 🚨 Publish new j-db-client version and update in both `web` and `j-mail`
- [ ] 🚨 Deploy migs to stage
- [ ] 🚨 Deploy code to stage
- [ ] 🚨 DEPLOY `j-mail` to stage
- [ ] 🚨 Deploy migs to prod
- [ ] 🚨 Deploy code to prod
- [ ] 🚨 DEPLOY `j-mail` TO PROD

## Migrations

No migs

## Screenshots
