### PR TITLE
📐 Modal Design Improvements ✐

### DIFF
--- a/packages/web/components/Modal/ModalBody.tsx
+++ b/packages/web/components/Modal/ModalBody.tsx
@@ -38,7 +38,7 @@ const ModalBody: React.FC<Props> = (props) => {
         }
         @media (min-width: ${modalConstants.modalBreakpoint}) {
           #modal-body {
-            padding: 0 64px 64px;
+            padding: 0 40px 40px;
           }
         }
 

--- a/packages/web/components/Modal/ModalBody.tsx
+++ b/packages/web/components/Modal/ModalBody.tsx
@@ -44,7 +44,10 @@ const ModalBody: React.FC<Props> = (props) => {
 
         h1 {
           margin-bottom: 16px;
-          ${theme.typography.headingXL};
+          ${theme.typography.fontFamilySansSerif};
+          font-size: 24px;
+          text-align: center;
+          font-weight: 600;
         }
       `}</style>
     </div>

--- a/packages/web/components/Modal/ModalHeader.tsx
+++ b/packages/web/components/Modal/ModalHeader.tsx
@@ -24,12 +24,12 @@ const ModalHeader: React.FC<Props> = ({ onClose, title, showTitle }) => {
       <style jsx>{`
         .modal-header {
           position: relative;
-          padding: 14px 64px;
+          padding: ${showTitle ? '14px 64px' : '0'};
           border-bottom: ${showTitle ? '1px solid #d4d8db' : 0};
         }
         @media (min-width: ${modalConstants.modalBreakpoint}) {
           .modal-header {
-            padding: 22px 64px;
+            padding: ${showTitle ? '14px 64px' : '0'};
           }
         }
 
@@ -49,11 +49,12 @@ const ModalHeader: React.FC<Props> = ({ onClose, title, showTitle }) => {
         }
 
         h1 {
+          ${theme.typography.fontFamilySansSerif};
           margin: 0 auto;
           opacity: ${showTitle ? 1 : 0};
           font-size: 20px;
           line-height: 28px;
-          font-weight: 500;
+          font-weight: 600;
           text-align: center;
           transition: opacity 150ms ease-in, border 150ms ease-in;
           ${truncate(247)};

--- a/packages/web/components/UserList/UserList.tsx
+++ b/packages/web/components/UserList/UserList.tsx
@@ -13,7 +13,7 @@ const UserList: React.FC<UserListProps> = ({ users, colorScheme = 'light-mode' }
   return (
     <div className="list-container">
       {users.map((user) => (
-        <Link href={`/user/${user.handle}`}>
+        <Link href={`/user/${user.handle}`} key={user.id}>
           <a className="user-container">
             <UserAvatar user={user} size={50} />
             <div className="name-handle-container">


### PR DESCRIPTION
## Description

**Issue:**
- #785 

Our `<Modal>` component was built quite quickly very early on when we only really had one use case (gathering a user's language info when first signing up), but especially as we've expanded its use throughout the app, I've always felt like it needed a nice little design makeover. In particular the typography and spacing didn't feel right, so this PR makes the following improvements:
- Switches the font-family over to our sans-serif typeface
- Improves the spacing by removing the unnecessary huge amount of padding at the top when the header title isn't being shown
- Also reduces padding at the sides and bottom of the modal body to make things feel more balanced and spacious
- Centers title text

I think even this very simple change makes a big difference and the modal feels so much nicer and more spacious now without all that space being taken up by unnecessary padding!

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Adjust typography
- [x] Adjust spacing/layout
- [x] Test our various use cases

### Deployment Checklist

- [x] 🚨 Deploy code to stage
- [ ] 🚨 Deploy code to prod

## Migrations

N/A

## Screenshots

**1. Before**
<img src="https://user-images.githubusercontent.com/34203886/167305706-197f065b-5f6e-4aca-b88b-c7d3caba8506.png" width="450">

**1. After**
<img src="https://user-images.githubusercontent.com/34203886/167305921-718d87f2-d34c-4400-aaed-b9f1d8e4868e.png" width="450">

**2. Before**
<img src="https://user-images.githubusercontent.com/34203886/167305803-a1c492e3-8c03-490d-b790-be44d6c3e393.png" width="450">

**2. After**
<img width="450" alt="image" src="https://user-images.githubusercontent.com/34203886/167305919-161b1fca-3fb4-439b-a678-230bcca5cd53.png">

**3. Before**
<img src="https://user-images.githubusercontent.com/34203886/167306009-13074be0-1db9-4819-8330-de969a5d8f88.png" width="450">

**3. After**
<img src="https://user-images.githubusercontent.com/34203886/167306014-6dd20a70-cd71-4a9e-bd75-539926bef00a.png" width="450">

