### PR TITLE
Write Custom `useDebouncedCallback` Hook & Partially Remove Lodash Dependency

### DIFF
--- a/packages/web/components/Dashboard/Filters/SearchInput.tsx
+++ b/packages/web/components/Dashboard/Filters/SearchInput.tsx
@@ -1,6 +1,6 @@
-import React, { useCallback, useState } from 'react'
-import _ from 'lodash'
+import React, { useState } from 'react'
 import { useTranslation } from '@/config/i18n'
+import useDebouncedCallback from '@/hooks/useDebouncedCallback'
 
 type Props = {
   defaultValue: string
@@ -18,12 +18,9 @@ const SearchInput: React.FC<Props> = ({ defaultValue, onChange, debounceTime }) 
     setValue(defaultValue)
   }
 
-  const debounceSearch = useCallback(
-    _.debounce((_searchVal: string) => {
-      onChange(_searchVal)
-    }, debounceTime),
-    [],
-  )
+  const debounceSearch = useDebouncedCallback((searchVal: string) => {
+    onChange(searchVal)
+  }, debounceTime)
 
   const onSearchChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
     setValue(e.target.value)

--- a/packages/web/components/Dashboard/MyFeed/MyFeed.tsx
+++ b/packages/web/components/Dashboard/MyFeed/MyFeed.tsx
@@ -3,8 +3,6 @@ import Head from 'next/head'
 import { useRouter } from 'next/router'
 import { toast } from 'react-toastify'
 
-import _ from 'lodash'
-
 import { useTranslation } from '@/config/i18n'
 
 import PostCard from '../PostCard'

--- a/packages/web/components/JournalyEditor/Toolbar/Toolbar.tsx
+++ b/packages/web/components/JournalyEditor/Toolbar/Toolbar.tsx
@@ -31,6 +31,7 @@ import { options, isTableActive } from '../helpers'
 import SwitchToggle from '@/components/SwitchToggle'
 import { useTranslation } from '@/config/i18n'
 import useIntersectionObserver from '@/hooks/userIntersectionObserver'
+import useDebouncedCallback from '@/hooks/useDebouncedCallback'
 
 type ToolbarProps = {
   allowInlineImages: boolean
@@ -65,14 +66,16 @@ const Toolbar = ({
       setViewportsDiff(visualViewport.offsetTop)
     }
 
-    onVisualViewportChange()
+    const debouncedOnVisualViewportChange = useDebouncedCallback(onVisualViewportChange, 500)
 
-    visualViewport.addEventListener('resize', onVisualViewportChange)
-    visualViewport.addEventListener('scroll', onVisualViewportChange)
+    debouncedOnVisualViewportChange()
+
+    visualViewport.addEventListener('resize', debouncedOnVisualViewportChange)
+    visualViewport.addEventListener('scroll', debouncedOnVisualViewportChange)
 
     return () => {
-      visualViewport.removeEventListener('resize', onVisualViewportChange)
-      visualViewport.removeEventListener('scroll', onVisualViewportChange)
+      visualViewport.removeEventListener('resize', debouncedOnVisualViewportChange)
+      visualViewport.removeEventListener('scroll', debouncedOnVisualViewportChange)
     }
   }, [])
 

--- a/packages/web/hooks/useDebouncedCallback.ts
+++ b/packages/web/hooks/useDebouncedCallback.ts
@@ -1,0 +1,31 @@
+import { useRef, useCallback } from 'react'
+
+/**
+ * Returns a memoized function that will only call the passed function when it hasn't been called for the wait period
+ * @param callback The function to be called
+ * @param wait Wait period after function hasn't been called for
+ * @returns A memoized function that is debounced
+ */
+const useDebouncedCallback = <CallbackArgs extends any[]>(
+  callback: (...args: CallbackArgs) => void,
+  wait: number,
+) => {
+  // Use a ref to store the timeout between renders
+  // and prevent changes to it from causing re-renders
+  const timeout = useRef()
+
+  return useCallback(
+    (...args) => {
+      const later = () => {
+        clearTimeout(timeout.current)
+        callback(...args)
+      }
+
+      clearTimeout(timeout.current)
+      timeout.current = setTimeout(later, wait)
+    },
+    [callback, wait],
+  )
+}
+
+export default useDebouncedCallback


### PR DESCRIPTION
## Description

- A quick POC to look into simply creating our own custom hook for debouncing to partially remove our `lodash` dependency
- Removes a couple of imports where we were brining in all of `lodash` instead of importing a specific function

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Write the hook
- [x] Test the hook in My Feed with `<SearchInput>`
- [ ] Test the hook with `visualViewportDiff` in `<Toolbar>`
- [ ] A bit of TypeScript massaging with the hook

### Deployment Checklist

- [ ] 🚨 Publish new j-db-client version and update in both `web` and `j-mail`
- [ ] 🚨 Deploy migs to stage
- [ ] 🚨 Deploy code to stage
- [ ] 🚨 DEPLOY `j-mail` to stage
- [ ] 🚨 Deploy migs to prod
- [ ] 🚨 Deploy code to prod
- [ ] 🚨 DEPLOY `j-mail` TO PROD

## Migrations

If your PR doesn't involve any changes to the database, you can delete this section. If it does, briefly describe how it needs to be applied. Some common things you might mention are:

- Does the migration need to be applied before or after deploying code?
- Is applying the migration going to necessitate downtime?
- Is there any SQL or backfill logic that has to be run manually?
- Are the DB changes high risk in your estimation? Should a manual DB snapshot be taken before applying?

## Screenshots
