### PR TITLE
Full-justify rows of unspash images and condense layout a little bit.

### DIFF
--- a/packages/web/components/Modals/ImageUploadModal/SearchUnsplash.tsx
+++ b/packages/web/components/Modals/ImageUploadModal/SearchUnsplash.tsx
@@ -50,7 +50,7 @@ const ImageComp: React.FC<{
   return (
     <>
       <div className="img-container">
-        <img src={urls.thumb} onClick={handleImageClick} />
+        <img src={urls.small} onClick={handleImageClick} />
       </div>
       <a className="credit" target="_blank" href={`https://unsplash.com/@${user.username}`}>
         {user.name}
@@ -58,6 +58,8 @@ const ImageComp: React.FC<{
       <style jsx>{`
         .img-container {
           height: 200px;
+          border-radius: 3px;
+          overflow: hidden;
         }
 
         img {
@@ -125,12 +127,12 @@ const SearchUnsplash: React.FC<SearchUnsplashProps> = ({ onImageSelect }) => {
           margin: 0;
           display: flex;
           flex-wrap: wrap;
-          gap: 24px;
+          gap: 4px;
           justify-content: space-around;
         }
 
         li {
-          margin-bottom: 12px;
+          flex-grow: 1;
         }
       `}</style>
     </div>


### PR DESCRIPTION
## Description

Changes unsplash image search results to distribute the width of the row between images in it so images well take up and previously occupied space in proportion to their aspect ratio. Also reduced space between images both vertically and horizontally, and added a small border radius to images to make them a little less "sharp" as we generally avoid hard 90deg edges elsewhere.

## Subtasks

- [ ] I have added this PR to the Journaly Kanban project ✅
- [ ] ...

### Deployment Checklist

- [ ] 🚨 Publish new j-db-client version and update in both `web` and `j-mail`
- [ ] 🚨 Deploy migs to stage
- [ ] 🚨 Deploy code to stage
- [ ] 🚨 DEPLOY `j-mail` to stage
- [ ] 🚨 Deploy migs to prod
- [ ] 🚨 Deploy code to prod
- [ ] 🚨 DEPLOY `j-mail` TO PROD

## Migrations

No Migs

## Screenshots

Before: 
<img width="1661" alt="Screen Shot 2022-12-13 at 12 12 36 AM" src="https://user-images.githubusercontent.com/2343714/207242468-56ef35e7-efad-462d-bd49-622d118cb241.png">
<img width="1648" alt="Screen Shot 2022-12-13 at 12 13 44 AM" src="https://user-images.githubusercontent.com/2343714/207242475-39a799a2-86e4-4985-8a99-f0801330b02b.png">

After:
<img width="1071" alt="Screen Shot 2022-12-13 at 12 23 33 AM" src="https://user-images.githubusercontent.com/2343714/207242542-12604483-7188-4bf5-957b-09bdbef3a578.png">


<img width="1075" alt="Screen Shot 2022-12-13 at 12 27 45 AM" src="https://user-images.githubusercontent.com/2343714/207242711-73ad3b52-6b6c-4631-a43e-90d2fe2d9d9c.png">

