### PR TITLE
🚩 FEATURE: "Report Spam" Button on Posts 🚫

### DIFF
--- a/packages/web/components/Dashboard/Post/Post.tsx
+++ b/packages/web/components/Dashboard/Post/Post.tsx
@@ -26,6 +26,7 @@ import { Router, useTranslation } from '@/config/i18n'
 import PostHeader from '@/components/PostHeader'
 import ConfirmationModal from '@/components/Modals/ConfirmationModal'
 import PremiumFeatureModal from '@/components/Modals/PremiumFeatureModal'
+import { useConfirmationModal } from '@/components/Modals/ConfirmationModal'
 import CommentSelectionButton from './CommentSelectionButton'
 
 import {
@@ -43,7 +44,7 @@ import BookmarkIcon from '@/components/Icons/BookmarkIcon'
 import UserListModal from '@/components/Modals/UserListModal'
 import useOnClickOut from '@/hooks/useOnClickOut'
 import { DOMOffsetTarget } from '@/components/Popover'
-
+import ReportSpamFlagIcon from '@/components/Icons/ReportSpamFlagIcon'
 
 type UseDeepLinkingArg = {
   setActiveThreadId: (arg: number) => void
@@ -168,6 +169,10 @@ const Post = ({ post, currentUser, refetch }: PostProps) => {
   const [displayPremiumFeatureModal, setDisplayPremiumFeatureModal] = useState(false)
   const [displayUserListModal, setDisplayUserListModal] = useState(false)
   const [premiumFeatureModalExplanation, setPremiumFeatureModalExplanation] = useState()
+  const [ReportSpamConfirmationModal, confirmReportSpam] = useConfirmationModal({
+    title: t('reportSpamModal.title'),
+    body: t('reportSpamModal.confirmationText'),
+  })
 
   const imageContainerRefCallback = useDeepLinking({
     setActiveThreadId,
@@ -594,19 +599,26 @@ const Post = ({ post, currentUser, refetch }: PostProps) => {
         />
         <article className="post-body selectable-text-area" dir="auto" onClick={onThreadClick}>
           <PostContent body={post.body} ref={selectableRef} />
-          { post.headlineImage.unsplashPhotographer && (
+          {post.headlineImage.unsplashPhotographer && (
             <p className="image-attribution">
               {/* TODO (robin): discuss handling translations here */}
-              Headline image by {' '}
-                <a target="_blank" href={`https://unsplash.com/@${post.headlineImage.unsplashPhotographer}?utm_source=journaly&utm_medium=referral`}>
-                  {post.headlineImage.unsplashPhotographer}
-                </a> on {' '}
-                    <a target="_blank" href="https://unsplash.com/?utm_source=journaly&utm_medium=referral">
-                      Unsplash
-                    </a>
-            </p>  
+              Headline image by{' '}
+              <a
+                target="_blank"
+                href={`https://unsplash.com/@${post.headlineImage.unsplashPhotographer}?utm_source=journaly&utm_medium=referral`}
+              >
+                {post.headlineImage.unsplashPhotographer}
+              </a>{' '}
+              on{' '}
+              <a
+                target="_blank"
+                href="https://unsplash.com/?utm_source=journaly&utm_medium=referral"
+              >
+                Unsplash
+              </a>
+            </p>
           )}
-          </article>
+        </article>
         <div className="post-controls">
           <div className="clap-container">
             {currentUser?.id === post.author.id ? (
@@ -692,6 +704,13 @@ const Post = ({ post, currentUser, refetch }: PostProps) => {
               <>
                 <Button
                   variant={ButtonVariant.Icon}
+                  onClick={confirmReportSpam}
+                  title={t('reportSpamTooltipText')}
+                >
+                  <ReportSpamFlagIcon size={22} />
+                </Button>
+                <Button
+                  variant={ButtonVariant.Icon}
                   loading={savingPost || unsavingPost}
                   onClick={() => {
                     hasSavedPost ? unsavePost({ variables: { postId: post.id } }) : handleSavePost()
@@ -743,6 +762,7 @@ const Post = ({ post, currentUser, refetch }: PostProps) => {
         body={t('deleteModal.body')}
         show={displayDeleteModal}
       />
+      <ReportSpamConfirmationModal />
       {displayPremiumFeatureModal && (
         <PremiumFeatureModal
           featureExplanation={premiumFeatureModalExplanation}

--- a/packages/web/components/Dashboard/Post/Post.tsx
+++ b/packages/web/components/Dashboard/Post/Post.tsx
@@ -583,7 +583,11 @@ const Post = ({ post, currentUser, refetch }: PostProps) => {
       toast.success(t('reportSpamPostSuccess'))
     },
     onError: () => {
-      toast.error(t('reportSpamPostError'))
+      toast.error(
+        t('reportSpamPostError', {
+          postId: post.id,
+        }),
+      )
     },
   })
 

--- a/packages/web/components/Dashboard/Post/Post.tsx
+++ b/packages/web/components/Dashboard/Post/Post.tsx
@@ -17,6 +17,7 @@ import {
   UserRole,
   useSavePostMutation,
   useUnsavePostMutation,
+  useReportSpamPostMutation,
 } from '@/generated/graphql'
 import Button, { ButtonVariant } from '@/components/Button'
 import theme from '@/theme'
@@ -573,6 +574,24 @@ const Post = ({ post, currentUser, refetch }: PostProps) => {
     },
   })
 
+  const [reportSpamPost] = useReportSpamPostMutation({
+    variables: {
+      postId: post.id,
+      postAuthorId: post.author.id,
+    },
+    onCompleted: () => {
+      toast.success(t('reportSpamPostSuccess'))
+    },
+    onError: () => {
+      toast.error(t('reportSpamPostError'))
+    },
+  })
+
+  const reportPostAsSpam = async () => {
+    if (!(await confirmReportSpam())) return
+    reportSpamPost()
+  }
+
   return (
     <div className="post-container" ref={imageContainerRefCallback}>
       <Head>
@@ -704,7 +723,7 @@ const Post = ({ post, currentUser, refetch }: PostProps) => {
               <>
                 <Button
                   variant={ButtonVariant.Icon}
-                  onClick={confirmReportSpam}
+                  onClick={reportPostAsSpam}
                   title={t('reportSpamTooltipText')}
                 >
                   <ReportSpamFlagIcon size={22} />

--- a/packages/web/components/Icons/ReportSpamFlagIcon.tsx
+++ b/packages/web/components/Icons/ReportSpamFlagIcon.tsx
@@ -1,0 +1,37 @@
+import theme from '@/theme'
+import * as React from 'react'
+
+interface SVGRProps {
+  title?: string
+  titleId?: string
+  size?: number
+}
+
+function ReportSpamFlagIcon({
+  title,
+  titleId,
+  size = 24,
+  ...props
+}: React.SVGProps<SVGSVGElement> & SVGRProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 1200 1200"
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path
+        d="M1111.2 27.75a24.99 24.99 0 00-12.77-2.36c-4.39.35-8.61 1.86-12.23 4.36-2 1.5-194.5 138.5-400 47.25C501.7-4.25 301.45 26.5 224.95 43.25V25c0-8.93-4.77-17.18-12.5-21.65a25.028 25.028 0 00-25 0A25.017 25.017 0 00174.95 25v1150c0 8.93 4.77 17.18 12.5 21.65a25.028 25.028 0 0025 0 25.017 25.017 0 0012.5-21.65V594.5c59.75-13.75 261.5-50 439.75 28.25A416.217 416.217 0 00835.2 659a514.746 514.746 0 00279.5-88.75 25.004 25.004 0 0010.25-20.25V50c-.02-4.62-1.3-9.14-3.73-13.07a24.902 24.902 0 00-10.02-9.18h0zm-36.25 508.75c-42.75 26.75-211.5 119.75-389.75 40.5-183.25-81.25-383.5-50-460.25-34V94.5c59.75-13.75 261.5-50 439.75 28.25s337.75 11.75 410.25-28V536.5z"
+        stroke={theme.colors.red}
+        strokeMiterlimit={10}
+        strokeWidth={30}
+        fill={theme.colors.red}
+      />
+    </svg>
+  )
+}
+
+export default ReportSpamFlagIcon

--- a/packages/web/components/Modals/ConfirmationModal/ConfirmationModal.tsx
+++ b/packages/web/components/Modals/ConfirmationModal/ConfirmationModal.tsx
@@ -11,24 +11,24 @@ type Props = {
   show: boolean
 }
 
-const ConfirmationModal: React.FC<Props> = (props) => {
+const ConfirmationModal: React.FC<Props> = ({ title, body, onConfirm, onCancel, show }) => {
   const { t } = useTranslation('common')
 
-  return props.show ? (
+  return show ? (
     <Modal
-      title={props.title}
-      body={props.body}
+      title={title}
+      body={body}
       footer={
         <>
-          <Button variant={ButtonVariant.Primary} onClick={props.onConfirm}>
+          <Button variant={ButtonVariant.Primary} onClick={onConfirm}>
             {t('modal.confirm')}
           </Button>
-          <Button variant={ButtonVariant.Secondary} onClick={props.onCancel}>
+          <Button variant={ButtonVariant.Secondary} onClick={onCancel}>
             {t('modal.cancel')}
           </Button>
         </>
       }
-      onClose={props.onCancel}
+      onClose={onCancel}
     />
   ) : null
 }

--- a/packages/web/generated/graphql.tsx
+++ b/packages/web/generated/graphql.tsx
@@ -199,6 +199,7 @@ export type Mutation = {
   initiatePostImageUpload: InitiatePostImageUploadResponse
   initiateInlinePostImageUpload: InitiateInlinePostImageUploadResponse
   bumpPost: Post
+  reportSpamPost: Post
   createUser: User
   updateUser: User
   initiateAvatarImageUpload: InitiateAvatarImageUploadResponse
@@ -300,6 +301,11 @@ export type MutationDeletePostArgs = {
 
 export type MutationBumpPostArgs = {
   postId: Scalars['Int']
+}
+
+export type MutationReportSpamPostArgs = {
+  postId: Scalars['Int']
+  postAuthorId: Scalars['Int']
 }
 
 export type MutationCreateUserArgs = {
@@ -1302,6 +1308,15 @@ export type PostsQuery = { __typename?: 'Query' } & {
   posts: { __typename?: 'PostPage' } & Pick<PostPage, 'count'> & {
       posts: Array<{ __typename?: 'Post' } & PostCardFragmentFragment>
     }
+}
+
+export type ReportSpamPostMutationVariables = Exact<{
+  postId: Scalars['Int']
+  postAuthorId: Scalars['Int']
+}>
+
+export type ReportSpamPostMutation = { __typename?: 'Mutation' } & {
+  reportSpamPost: { __typename?: 'Post' } & Pick<Post, 'id'>
 }
 
 export type SavePostMutationVariables = Exact<{
@@ -3738,6 +3753,53 @@ export function usePostsLazyQuery(
 export type PostsQueryHookResult = ReturnType<typeof usePostsQuery>
 export type PostsLazyQueryHookResult = ReturnType<typeof usePostsLazyQuery>
 export type PostsQueryResult = ApolloReactCommon.QueryResult<PostsQuery, PostsQueryVariables>
+export const ReportSpamPostDocument = gql`
+  mutation reportSpamPost($postId: Int!, $postAuthorId: Int!) {
+    reportSpamPost(postId: $postId, postAuthorId: $postAuthorId) {
+      id
+    }
+  }
+`
+export type ReportSpamPostMutationFn = ApolloReactCommon.MutationFunction<
+  ReportSpamPostMutation,
+  ReportSpamPostMutationVariables
+>
+
+/**
+ * __useReportSpamPostMutation__
+ *
+ * To run a mutation, you first call `useReportSpamPostMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useReportSpamPostMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [reportSpamPostMutation, { data, loading, error }] = useReportSpamPostMutation({
+ *   variables: {
+ *      postId: // value for 'postId'
+ *      postAuthorId: // value for 'postAuthorId'
+ *   },
+ * });
+ */
+export function useReportSpamPostMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    ReportSpamPostMutation,
+    ReportSpamPostMutationVariables
+  >,
+) {
+  return ApolloReactHooks.useMutation<ReportSpamPostMutation, ReportSpamPostMutationVariables>(
+    ReportSpamPostDocument,
+    baseOptions,
+  )
+}
+export type ReportSpamPostMutationHookResult = ReturnType<typeof useReportSpamPostMutation>
+export type ReportSpamPostMutationResult = ApolloReactCommon.MutationResult<ReportSpamPostMutation>
+export type ReportSpamPostMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  ReportSpamPostMutation,
+  ReportSpamPostMutationVariables
+>
 export const SavePostDocument = gql`
   mutation savePost($postId: Int!) {
     savePost(postId: $postId) {

--- a/packages/web/graphql/post/reportSpamPost.graphql
+++ b/packages/web/graphql/post/reportSpamPost.graphql
@@ -1,0 +1,5 @@
+mutation reportSpamPost($postId: Int!, $postAuthorId: Int!) {
+  reportSpamPost(postId: $postId, postAuthorId: $postAuthorId) {
+    id
+  }
+}

--- a/packages/web/public/static/locales/de/post.json
+++ b/packages/web/public/static/locales/de/post.json
@@ -38,6 +38,11 @@
     "title": "Bearbeiten abbrechen",
     "body": "Bist du dir sicher, dass du das Bearbeiten des Beitrags abbrechen möchtest? Ungespeicherte Änderungen gehen verloren."
   },
+  "reportSpamModal": {
+    "title": "Report Post as Spam",
+    "confirmationText": "Are you sure you want to report this post as spam?",
+    "explanationText": "If you're not sure whether or not this post is spam, please take a look at our guidelines: "
+  },
   "enterUrlPrompt": "Gib die URL des Links ein",
   "websitePatternError": "Ungültiger Webseiten-Link, z. B. DeineDomain.com oder DeineSubdomain.domain.com",
   "claps": {
@@ -52,5 +57,11 @@
   "savePostError": "Beim Anheften dieses Beitrags ist etwas schief gegangen",
   "unsavePostSuccess": "Dieser Beitrag wurde von deiner Liste entfernt",
   "unsavePostError": "Beim Entfernen dieses Beitrags von deiner Liste ist etwas schief gegangen",
-  "savePostPremiumFeatureExplanation": "Angeheftete Beiträge ist ein angenehmes Premium-Feature, dass dir das Anheften von Beiträgen ermöglicht, sodass du diese später einfach wiederfinden und lesen kannst. Die Liste kannst du über die erweiterten Filter der Mein-Feed-Seite erreichen! Klicke unten, um alle Vorteile von Journaly Premium zu entdecken oder nutze all die kostenfreien Features von Journaly weiterhin kostenlos."
+  "savePostPremiumFeatureExplanation": "Angeheftete Beiträge ist ein angenehmes Premium-Feature, dass dir das Anheften von Beiträgen ermöglicht, sodass du diese später einfach wiederfinden und lesen kannst. Die Liste kannst du über die erweiterten Filter der Mein-Feed-Seite erreichen! Klicke unten, um alle Vorteile von Journaly Premium zu entdecken oder nutze all die kostenfreien Features von Journaly weiterhin kostenlos.",
+  "sharePrivatelyCTA": "Publish Privately",
+  "privateShareLinkText": "Your private share link:",
+  "privatePublishingPremiumFeatureExplanation": "Private Publishing is a nifty Premium feature that generates a private share link that you can give to anybody you'd like to share your post with in private! Click below to check out all the details of Journaly Premium, or please feel free to continue Journaling with all our fantastic free features!",
+  "reportSpamTooltipText": "Report Spam",
+  "reportSpamPostSuccess": "Post reported successfully. Thank you for helping us keep Journaly spam-free!",
+  "reportSpamPostError": "Something went wrong reporting this post! Please email us and include this post ID: {{postId}}"
 }

--- a/packages/web/public/static/locales/de/post.json
+++ b/packages/web/public/static/locales/de/post.json
@@ -39,9 +39,9 @@
     "body": "Bist du dir sicher, dass du das Bearbeiten des Beitrags abbrechen möchtest? Ungespeicherte Änderungen gehen verloren."
   },
   "reportSpamModal": {
-    "title": "Report Post as Spam",
-    "confirmationText": "Are you sure you want to report this post as spam?",
-    "explanationText": "If you're not sure whether or not this post is spam, please take a look at our guidelines: "
+    "title": "Beitrag als Spam melden",
+    "confirmationText": "Bist du dir sicher, dass du diesen Beitrag als Spam melden möchtest?",
+    "explanationText": "Falls du dir nicht sicher bist, ob dieser Beitrag Spam ist oder nicht, schau bitte in unsere Leitlinien: "
   },
   "enterUrlPrompt": "Gib die URL des Links ein",
   "websitePatternError": "Ungültiger Webseiten-Link, z. B. DeineDomain.com oder DeineSubdomain.domain.com",
@@ -57,11 +57,11 @@
   "savePostError": "Beim Anheften dieses Beitrags ist etwas schief gegangen",
   "unsavePostSuccess": "Dieser Beitrag wurde von deiner Liste entfernt",
   "unsavePostError": "Beim Entfernen dieses Beitrags von deiner Liste ist etwas schief gegangen",
-  "savePostPremiumFeatureExplanation": "Angeheftete Beiträge ist ein angenehmes Premium-Feature, dass dir das Anheften von Beiträgen ermöglicht, sodass du diese später einfach wiederfinden und lesen kannst. Die Liste kannst du über die erweiterten Filter der Mein-Feed-Seite erreichen! Klicke unten, um alle Vorteile von Journaly Premium zu entdecken oder nutze all die kostenfreien Features von Journaly weiterhin kostenlos.",
-  "sharePrivatelyCTA": "Publish Privately",
-  "privateShareLinkText": "Your private share link:",
-  "privatePublishingPremiumFeatureExplanation": "Private Publishing is a nifty Premium feature that generates a private share link that you can give to anybody you'd like to share your post with in private! Click below to check out all the details of Journaly Premium, or please feel free to continue Journaling with all our fantastic free features!",
-  "reportSpamTooltipText": "Report Spam",
-  "reportSpamPostSuccess": "Post reported successfully. Thank you for helping us keep Journaly spam-free!",
-  "reportSpamPostError": "Something went wrong reporting this post! Please email us and include this post ID: {{postId}}"
+  "savePostPremiumFeatureExplanation": "Angeheftete Beiträge ist ein angenehmes Premium-Feature, das dir das Anheften von Beiträgen ermöglicht, sodass du diese später einfach wiederfinden und lesen kannst. Die Liste kannst du über die erweiterten Filter der Mein-Feed-Seite erreichen! Klicke unten, um alle Vorteile von Journaly Premium zu entdecken oder nutze all die kostenfreien Feature von Journaly weiterhin kostenlos!",
+  "sharePrivatelyCTA": "Privat veröffentlichen",
+  "privateShareLinkText": "Dein privater Link zum Teilen:",
+  "privatePublishingPremiumFeatureExplanation": "Privat Veröffentlichen ist ein elegantes Premium-Feature, das es dir ermöglicht private Links zu erstellen, die du anschließend an ausgewählte Personen weitergeben kannst. Klicke unten, um alle Vorteile von Journaly Premium zu entdecken oder nutze all die tollen kostenfreien Feature von Journaly weiterhin kostenlos!",
+  "reportSpamTooltipText": "Spam melden",
+  "reportSpamPostSuccess": "Der Beitrag wurde erfolgreich gemeldet. Danke, dass du uns hilfst Journaly frei von Spam zu halten!",
+  "reportSpamPostError": "Beim Melden des Beitrags ist etwas schief gegangen! Bitte schreib uns eine E-Mail und gib diese Post-ID mit an: {{postId}}"
 }

--- a/packages/web/public/static/locales/en/post.json
+++ b/packages/web/public/static/locales/en/post.json
@@ -42,6 +42,11 @@
     "title": "Cancel editing post",
     "body": "Are you sure you want to cancel editing this post? Unsaved progress will be lost."
   },
+  "reportSpamModal": {
+    "title": "Report Post as Spam",
+    "confirmationText": "Are you sure you want to report this post as spam?",
+    "explanationText": "If you're not sure whether or not this post is spam, please take a look at our guidelines: "
+  },
   "enterUrlPrompt": "Enter the URL of the link:",
   "websitePatternError": "Invalid website url. e.g. domain.com or sub.domain.com",
   "claps": {
@@ -59,5 +64,6 @@
   "savePostPremiumFeatureExplanation": "Saved Posts is a delightful Premium feature that allows you to save posts for later and access your list from the My Feed page's advanced filters! Click below to check out all the details of Journaly Premium, or please feel free to continue Journaling with all our fantastic free features!",
   "sharePrivatelyCTA": "Publish Privately",
   "privateShareLinkText": "Your private share link:",
-  "privatePublishingPremiumFeatureExplanation": "Private Publishing is a nifty Premium feature that generates a private share link that you can give to anybody you'd like to share your post with in private! Click below to check out all the details of Journaly Premium, or please feel free to continue Journaling with all our fantastic free features!"
+  "privatePublishingPremiumFeatureExplanation": "Private Publishing is a nifty Premium feature that generates a private share link that you can give to anybody you'd like to share your post with in private! Click below to check out all the details of Journaly Premium, or please feel free to continue Journaling with all our fantastic free features!",
+  "reportSpamTooltipText": "Report Spam"
 }

--- a/packages/web/public/static/locales/en/post.json
+++ b/packages/web/public/static/locales/en/post.json
@@ -65,5 +65,7 @@
   "sharePrivatelyCTA": "Publish Privately",
   "privateShareLinkText": "Your private share link:",
   "privatePublishingPremiumFeatureExplanation": "Private Publishing is a nifty Premium feature that generates a private share link that you can give to anybody you'd like to share your post with in private! Click below to check out all the details of Journaly Premium, or please feel free to continue Journaling with all our fantastic free features!",
-  "reportSpamTooltipText": "Report Spam"
+  "reportSpamTooltipText": "Report Spam",
+  "reportSpamPostSuccess": "Post reported successfully. Thank you for helping us keep Journaly spam-free!",
+  "reportSpamPostError": "Something went wrong reporting this post! Please email us and include this post ID: {{postId}}"
 }

--- a/packages/web/public/static/locales/zh_CN/post.json
+++ b/packages/web/public/static/locales/zh_CN/post.json
@@ -43,9 +43,9 @@
     "body": "确认取消编辑日志？未保存的进度将丢失。"
   },
   "reportSpamModal": {
-    "title": "Report Post as Spam",
-    "confirmationText": "Are you sure you want to report this post as spam?",
-    "explanationText": "If you're not sure whether or not this post is spam, please take a look at our guidelines: "
+    "title": "举报垃圾贴文",
+    "confirmationText": "你确定你想要举报这则贴文为垃圾贴文吗?",
+    "explanationText": "如果你不确定这则贴文是否为垃圾贴文，请参考我们的守则："
   },
   "enterUrlPrompt": "输入链接地址：",
   "websitePatternError": "无效网页地址。如：domain.com 或 sub.domain.com",

--- a/packages/web/public/static/locales/zh_CN/post.json
+++ b/packages/web/public/static/locales/zh_CN/post.json
@@ -42,6 +42,11 @@
     "title": "取消编辑日志",
     "body": "确认取消编辑日志？未保存的进度将丢失。"
   },
+  "reportSpamModal": {
+    "title": "Report Post as Spam",
+    "confirmationText": "Are you sure you want to report this post as spam?",
+    "explanationText": "If you're not sure whether or not this post is spam, please take a look at our guidelines: "
+  },
   "enterUrlPrompt": "输入链接地址：",
   "websitePatternError": "无效网页地址。如：domain.com 或 sub.domain.com",
   "claps": {
@@ -59,5 +64,8 @@
   "savePostPremiumFeatureExplanation": "收藏日志是一项尊享会员功能，您将可以收藏日志，稍后通过 我的页面 > 高级筛选 找到它们！点击下方了解Journaly会员详情，或尽情享受我们所有精彩的免费功能，继续写日志吧！",
   "sharePrivatelyCTA": "私密发布",
   "privateShareLinkText": "您的私密分享链接：",
-  "privatePublishingPremiumFeatureExplanation": "私密发布是一项尊享会员功能，您将可以通过生成的私密链接将日志分享给任何人！点击下方了解Journaly会员详情，或尽情享受我们所有精彩的免费功能，继续写日志吧！"
+  "privatePublishingPremiumFeatureExplanation": "私密发布是一项尊享会员功能，您将可以通过生成的私密链接将日志分享给任何人！点击下方了解Journaly会员详情，或尽情享受我们所有精彩的免费功能，继续写日志吧！",
+  "reportSpamTooltipText": "Report Spam",
+  "reportSpamPostSuccess": "Post reported successfully. Thank you for helping us keep Journaly spam-free!",
+  "reportSpamPostError": "Something went wrong reporting this post! Please email us and include this post ID: {{postId}}"
 }

--- a/packages/web/public/static/locales/zh_TW/post.json
+++ b/packages/web/public/static/locales/zh_TW/post.json
@@ -43,9 +43,9 @@
     "body": "確認取消編輯日誌？未保存的進度將丟失。"
   },
   "reportSpamModal": {
-    "title": "Report Post as Spam",
-    "confirmationText": "Are you sure you want to report this post as spam?",
-    "explanationText": "If you're not sure whether or not this post is spam, please take a look at our guidelines: "
+    "title": "舉報垃圾貼文",
+    "confirmationText": "你確定你想要舉報這則貼文為垃圾貼文嗎?",
+    "explanationText": "如果你不確定這則貼文是否為垃圾貼文，請參考我們的守則： "
   },
   "enterUrlPrompt": "輸入鏈接地址：",
   "websitePatternError": "無效網頁地址。如：domain.com 或 sub.domain.com",

--- a/packages/web/public/static/locales/zh_TW/post.json
+++ b/packages/web/public/static/locales/zh_TW/post.json
@@ -42,6 +42,11 @@
     "title": "取消編輯日誌",
     "body": "確認取消編輯日誌？未保存的進度將丟失。"
   },
+  "reportSpamModal": {
+    "title": "Report Post as Spam",
+    "confirmationText": "Are you sure you want to report this post as spam?",
+    "explanationText": "If you're not sure whether or not this post is spam, please take a look at our guidelines: "
+  },
   "enterUrlPrompt": "輸入鏈接地址：",
   "websitePatternError": "無效網頁地址。如：domain.com 或 sub.domain.com",
   "claps": {
@@ -59,5 +64,8 @@
   "savePostPremiumFeatureExplanation": "收藏日誌是一項尊享會員功能，您將可以收藏日誌，稍後通過 我的頁面 > 高級篩選 找到它們！點擊下方了解Journaly會員詳情，或盡情享受我們所有精彩的免費功能，繼續寫日誌吧！",
   "sharePrivatelyCTA": "私密發布",
   "privateShareLinkText": "您的私密分享鏈接：",
-  "privatePublishingPremiumFeatureExplanation": "私密發布是一項尊享會員功能，您將可以通過生成的私密鏈接將日誌分享給任何人！點擊下方了解Journaly會員詳情，或盡情享受我們所有精彩的免費功能，繼續寫日誌吧！"
+  "privatePublishingPremiumFeatureExplanation": "私密發布是一項尊享會員功能，您將可以通過生成的私密鏈接將日誌分享給任何人！點擊下方了解Journaly會員詳情，或盡情享受我們所有精彩的免費功能，繼續寫日誌吧！",
+  "reportSpamTooltipText": "Report Spam",
+  "reportSpamPostSuccess": "Post reported successfully. Thank you for helping us keep Journaly spam-free!",
+  "reportSpamPostError": "Something went wrong reporting this post! Please email us and include this post ID: {{postId}}"
 }

--- a/packages/web/resolvers/post.ts
+++ b/packages/web/resolvers/post.ts
@@ -942,17 +942,21 @@ const PostMutations = extendType({
         const { userId } = ctx.request
         if (!userId) throw new NotAuthorizedError()
 
+        const post = await ctx.db.post.findUnique({
+          where: {
+            id: args.postId,
+          },
+        })
+
+        if (!post) throw new NotFoundError()
+
         await sendReportSpamPostEmail({
           postId: args.postId,
           postAuthorId: args.postAuthorId,
           reportingUserId: userId,
         })
 
-        return ctx.db.post.findUnique({
-          where: {
-            id: args.postId,
-          },
-        })
+        return post
       },
     })
   },

--- a/packages/web/resolvers/post.ts
+++ b/packages/web/resolvers/post.ts
@@ -18,6 +18,7 @@ import {
   getThumbusterVars,
   generatePostPrivateShareId,
   createInAppNotification,
+  sendReportSpamPostEmail,
 } from './utils'
 
 
@@ -926,6 +927,31 @@ const PostMutations = extendType({
           data: {
             bumpedAt: new Date(),
             bumpCount: post.bumpCount + 1,
+          },
+        })
+      },
+    })
+
+    t.field('reportPostAsSpam', {
+      type: 'Post',
+      args: {
+        postId: intArg({ required: true }),
+        postAuthorId: intArg({ required: true }),
+        reportingUserId: intArg({ required: true }),
+      },
+      resolve: async (_parent, args, ctx) => {
+        const { userId } = ctx.request
+        if (!userId) throw new NotAuthorizedError()
+
+        await sendReportSpamPostEmail({
+          postId: args.postId,
+          postAuthorId: args.postAuthorId,
+          reportingUserId: userId,
+        })
+
+        return ctx.db.post.findUnique({
+          where: {
+            id: args.postId,
           },
         })
       },

--- a/packages/web/resolvers/post.ts
+++ b/packages/web/resolvers/post.ts
@@ -932,12 +932,11 @@ const PostMutations = extendType({
       },
     })
 
-    t.field('reportPostAsSpam', {
+    t.field('reportSpamPost', {
       type: 'Post',
       args: {
         postId: intArg({ required: true }),
         postAuthorId: intArg({ required: true }),
-        reportingUserId: intArg({ required: true }),
       },
       resolve: async (_parent, args, ctx) => {
         const { userId } = ctx.request

--- a/packages/web/resolvers/utils/email.ts
+++ b/packages/web/resolvers/utils/email.ts
@@ -272,9 +272,9 @@ const sendReportSpamPostEmail = ({
     subject: `Spam Report: Post ${postId}`,
     html: makeEmail(`
       <h3>Spam Post Report:</h3>
-      <p>Post ID: ${postId}</p>
-      <p>Post Author ID: ${postAuthorId}</p>
-      <p>Reported by User ID: ${reportingUserId}</p>
+      <p><a href="${process.env.SITE_DOMAIN}/post/${postId}">Post ID ${postId}</a></p>
+      <p><a href="${process.env.SITE_DOMAIN}/dashboard/profile/${postAuthorId}">Post Author ID ${postAuthorId}</a></p>
+      <p><a href="${process.env.SITE_DOMAIN}/dashboard/profile/${reportingUserId}">Reporting User ID ${reportingUserId}</a></p>
     `),
   })
 }

--- a/packages/web/resolvers/utils/email.ts
+++ b/packages/web/resolvers/utils/email.ts
@@ -25,6 +25,12 @@ type sendNewBadgeEmailArgs = {
   user: User
 }
 
+type sendReportSpamPostEmailArgs = {
+  postId: number
+  postAuthorId: number
+  reportingUserId: number
+}
+
 type EmailParams = {
   from: string
   to: string
@@ -255,6 +261,24 @@ const sendPremiumWelcomeEmail = ({ user }: sendPremiumWelcomeEmailArgs) => {
   })
 }
 
+const sendReportSpamPostEmail = ({
+  postId,
+  postAuthorId,
+  reportingUserId,
+}: sendReportSpamPostEmailArgs) => {
+  return sendJmail({
+    from: 'robin@journaly.com',
+    to: 'hello@journaly.com',
+    subject: `Spam Report: Post ${postId}`,
+    html: makeEmail(`
+      <h3>Spam Post Report:</h3>
+      <p>Post ID: ${postId}</p>
+      <p>Post Author ID: ${postAuthorId}</p>
+      <p>Reported by User ID: ${reportingUserId}</p>
+    `),
+  })
+}
+
 export {
   sendJmail,
   sendPasswordResetTokenEmail,
@@ -262,4 +286,5 @@ export {
   subscribeUserToProductUpdates,
   sendEmailAddressVerificationEmail,
   sendPremiumWelcomeEmail,
+  sendReportSpamPostEmail,
 }


### PR DESCRIPTION
## Description

**Issues:**
- closes #818 

This PR builds a simple mechanism for users to report spam posts directly from a post with just two clicks. It introduces a new "Report Spam" icon/button at the bottom of a post, which opens a confirmation modal. Upon confirmation, an email is sent to the Journaly Customer Support inbox with the data needed to remove the post and - if needed - its author.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Find icon for the new button & convert to React Component.
- [x] Build out the UI.
- [x] Write backend code for sending the report spam email.
- [x] Write GraphQL mutation
- [x] Wire everything up in the frontend!
- [x] Add English translation strings
- [x] Collect Chinese translations
- [x] Collect German translations

### Deployment Checklist

- [x] 🚨 ~Publish new j-db-client version and update in both `web` and `j-mail`~
- [x] 🚨 ~Deploy migs to stage~
- [x] 🚨 Deploy code to stage
- [x] 🚨 ~DEPLOY `j-mail` to stage~
- [x] 🚨 ~Deploy migs to prod~
- [x] 🚨 Deploy code to prod
- [x] 🚨 ~DEPLOY `j-mail` TO PROD~

## Migrations

No migs!

## Screenshots

**1. New Report Spam Button**
<img width="1000" alt="Screenshot 2023-01-25 at 10 26 55 PM" src="https://user-images.githubusercontent.com/34203886/214773728-6b90e882-2397-4fb4-a211-5c6fa1afb90d.png">

**2. New Report Spam Modal**
<img width="1000" alt="Screenshot 2023-01-25 at 10 28 17 PM" src="https://user-images.githubusercontent.com/34203886/214773741-a93c7ad9-2646-4c47-aa8f-98e220fb13c4.png">

**3. Success Toast**
<img width="1000" alt="Screenshot 2023-01-25 at 10 28 17 PM" src="https://user-images.githubusercontent.com/34203886/216213444-2820bd75-b635-4a24-bc41-7548759975f0.png">

**4. The Spam Report Email**
<img width="500" alt="Screenshot 2023-01-25 at 10 28 17 PM" src="https://user-images.githubusercontent.com/34203886/216214640-066510f8-bbf3-4b79-89ca-471821e69c8b.png">
