### PR TITLE
Add Missing DELETE Clause for User Deletion Script

### DIFF
--- a/packages/jadmin/jadmin.js
+++ b/packages/jadmin/jadmin.js
@@ -143,6 +143,12 @@ yargs
 
       await query`
         DELETE
+        FROM "SocialMedia"
+        WHERE "userId" = ${userId}
+      `
+
+      await query`
+        DELETE
         FROM "UserInterest"
         WHERE "userId" = ${userId}
       `


### PR DESCRIPTION
## Description

When testing out our new spam user deletion script, it looks like none of our test users had `SocialMedia` records.
This PR just adds in an extra `DELETE` clause to handle that.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Make the change
- [x] Test locally

### Deployment Checklist

- [x] ~🚨 Publish new j-db-client version and update in both `web` and `j-mail`~
- [x] ~🚨 Deploy migs to stage~
- [x] 🚨 Deploy code to stage
- [x] ~🚨 DEPLOY `j-mail` to stage~
- [x] ~🚨 Deploy migs to prod~
- [x] 🚨 Deploy code to prod
- [x] ~🚨 DEPLOY `j-mail` TO PROD~

## Migrations

N/A

## Screenshots

N/A