### PR TITLE
Add new Jadmin script for deleting a post

### DIFF
--- a/packages/jadmin/jadmin.js
+++ b/packages/jadmin/jadmin.js
@@ -239,11 +239,6 @@ yargs
       await db.pool.end()
     },
   })
-  .demandCommand(1)
-  .parse(process.argv.slice(2))
-
-  yargs
-  .scriptName('jadmin')
   .command({
     command: 'delete-post <postId>',
     describe: 'Hard delete a post and related records',

--- a/packages/jadmin/jadmin.js
+++ b/packages/jadmin/jadmin.js
@@ -241,3 +241,93 @@ yargs
   })
   .demandCommand(1)
   .parse(process.argv.slice(2))
+
+  yargs
+  .scriptName('jadmin')
+  .command({
+    command: 'delete-post <postId>',
+    describe: 'Hard delete a post and related records',
+    builder: (yargs) => {
+      yargs.option('force', {
+        describe: 'Bypass interactive safety checks',
+        type: 'boolean',
+      })
+      yargs.option('database-url', {
+        describe: 'The URL to connect to the database',
+        type: 'string',
+      })
+    },
+    handler: async (args) => {
+      const dbUrl = args.databaseUrl || process.env.DATABASE_URL
+
+      if (!dbUrl) {
+        console.error('No database URL has been provided')
+        process.exit(1)
+      }
+
+      const parsedDbUrl = parse(dbUrl)
+      let promptResponse
+
+      if (!['localhost', '127.0.0.1'].includes(parsedDbUrl.host) && !args.force) {
+        promptResponse = await prompts({
+          type: 'confirm',
+          name: 'confirmDbUrl',
+          message: `CAUTION: your $DATABASE_URL is currently set to a remote database: ${dbUrl}. Are you sure you want to continue?`,
+        })
+
+        if (!promptResponse.confirmDbUrl) return
+      }
+
+      const db = pgTag(
+        new Pool({
+          connectionString: dbUrl,
+        }),
+      )
+
+      const postId = parseInt(args.postId)
+      const post = await db.get`
+        SELECT *
+        FROM "Post"
+        WHERE id = ${postId}
+      `
+
+      if (!post) {
+        console.error(`No Post with ID ${postId} found`)
+        process.exit(1)
+      }
+      
+      const userId = post.authorId
+      const user = await db.get`
+        SELECT *
+        FROM "User"
+        WHERE id = ${userId}
+      `
+
+      if (!user) {
+        console.error(`No User with ID ${userId} found`)
+        process.exit(1)
+      }
+
+      if (!args.force) {
+        promptResponse = await prompts({
+          type: 'confirm',
+          name: 'confirmUserByHandle',
+          message: `Are you sure you want to delete post: ${post.title} by User handle: ${user.handle}, email: ${
+            user.email
+          }, ${user.name ? user.name : 'no name'}?`,
+        })
+
+        if (!promptResponse.confirmUserByHandle) return
+      }
+
+      const query = db.transaction()
+
+      await deletePosts([postId], query)
+      await query.commit()
+
+      console.table(post)
+      await db.pool.end()
+    },
+  })
+  .demandCommand(1)
+  .parse(process.argv.slice(2))


### PR DESCRIPTION
## Description

**Issue:** 
* closes #828 

In #824 we added a script that deletes a user (intended for those who brazenly violate our Terms of Service) and all related records. There are some cases where we may want to delete only a post, so this PR adds a script to handle that.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Add the new script
- [x] Test on local data

### Deployment Checklist

- [x] ~🚨 Publish new j-db-client version and update in both `web` and `j-mail`~
- [x] ~🚨 Deploy migs to stage~
- [ ] 🚨 Deploy code to stage
- [x] ~🚨 DEPLOY `j-mail` to stage~
- [x] ~🚨 Deploy migs to prod~
- [ ] 🚨 Deploy code to prod
- [x] ~🚨 DEPLOY `j-mail` TO PROD~

## Migrations

N/A

## Screenshots
N/A