### PR TITLE
🐞🔧 Fix Filter-Pagination-Reset Bug & Some Refactoring/Improvements

### DIFF
--- a/packages/web/components/Dashboard/Filters/Filters.tsx
+++ b/packages/web/components/Dashboard/Filters/Filters.tsx
@@ -46,12 +46,14 @@ const Filters: React.FC<Props> = ({
   const [showAdvancedFilters, setShowAdvancedFilters] = useToggle(false)
   const [displayPremiumFeatureModal, setDisplayPremiumFeatureModal] = useState(false)
   const onSearchChange = useCallback(
-    (val): void =>
+    (val): void => {
       setPostQueryVars((prevState) => ({
         ...prevState,
         search: val,
-      })),
-    [],
+      }))
+      resetPagination()
+    },
+    [resetPagination],
   )
 
   const isPremiumFeatureEligible =
@@ -124,19 +126,31 @@ const Filters: React.FC<Props> = ({
       ...prevState,
       followedAuthors: !prevState.followedAuthors,
     }))
-  }, [])
+    resetPagination()
+  }, [resetPagination])
+
   const toggleNeedsFeedbackFilter = useCallback(() => {
     setPostQueryVars((prevState) => ({
       ...prevState,
       needsFeedback: !prevState.needsFeedback,
     }))
-  }, [])
+    resetPagination()
+  }, [resetPagination])
   const toggleHasInteractedFilter = useCallback(() => {
     setPostQueryVars((prevState) => ({
       ...prevState,
       hasInteracted: !prevState.hasInteracted,
     }))
-  }, [])
+    resetPagination()
+  }, [resetPagination])
+  
+  const toggleMyLanguagesFilter = useCallback(() => {
+    setPostQueryVars((prevState) => ({
+      ...prevState,
+      languages: [...userLanguages.values()],
+    }))
+    resetPagination()
+  }, [resetPagination])
 
   const handleToggleSavedPosts = useCallback(() => {
     if (!isPremiumFeatureEligible) {
@@ -146,8 +160,22 @@ const Filters: React.FC<Props> = ({
         ...prevState,
         savedPosts: !prevState.savedPosts,
       }))
+      resetPagination()
     }
-  }, [])
+  }, [resetPagination])
+
+  const handleClearFilters = useCallback(() => {
+    setPostQueryVars({
+      languages: [],
+      topics: [],
+      search: '',
+      followedAuthors: false,
+      needsFeedback: false,
+      hasInteracted: false,
+      savedPosts: false,
+    })
+    resetPagination()
+  }, [resetPagination])
 
   const uiLanguage = useUILanguage()
   const { data: { topics } = {} } = useTopicsQuery({
@@ -194,29 +222,14 @@ const Filters: React.FC<Props> = ({
                 <Button
                   variant={ButtonVariant.Link}
                   className="filter-action-btn"
-                  onClick={() => {
-                    setPostQueryVars({
-                      languages: [],
-                      topics: [],
-                      search: '',
-                      followedAuthors: false,
-                      needsFeedback: false,
-                      hasInteracted: false,
-                      savedPosts: false,
-                    })
-                  }}
+                  onClick={handleClearFilters}
                 >
                   {t('ui.clearFilters')}
                 </Button>
                 <Button
                   variant={ButtonVariant.Link}
                   className={`filter-action-btn ${isUserLanguagesFilterActive ? 'active' : ''}`}
-                  onClick={() => {
-                    setPostQueryVars((prevState) => ({
-                      ...prevState,
-                      languages: [...userLanguages.values()],
-                    }))
-                  }}
+                  onClick={toggleMyLanguagesFilter}
                 >
                   {t('ui.myLanguages')}
                 </Button>

--- a/packages/web/components/Dashboard/MyFeed/MyFeed.tsx
+++ b/packages/web/components/Dashboard/MyFeed/MyFeed.tsx
@@ -34,6 +34,7 @@ export type InitialSearchFilters = {
   needsFeedback: boolean
   hasInteracted: boolean
   savedPosts: boolean
+  search: string
 }
 
 const MyFeed: React.FC<Props> = ({ currentUser, initialSearchFilters }) => {
@@ -101,6 +102,7 @@ const MyFeed: React.FC<Props> = ({ currentUser, initialSearchFilters }) => {
       needsFeedback: postQueryVars.needsFeedback,
       hasInteracted: postQueryVars.hasInteracted,
       savedPosts: postQueryVars.savedPosts,
+      search: postQueryVars.search,
     }
     document.cookie = `default_search_filters=${JSON.stringify(searchFilters)};`
   }, [postQueryVars])


### PR DESCRIPTION
## Description

**Issue:**
- fixes: #738 

* Ensures that setting, unsetting, or changing any filters resets the pagination.
* Refactors some filter-related functions to make sure that they are all defined functions with `useCallback()`

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Test and find broken use cases
- [x] Make the fix!
- [x] Refactor inline functions
- [x] Test a wee bit more

### Deployment Checklist

- [x] ~🚨 Publish new j-db-client version and update in both `web` and `j-mail`~
- [x] ~🚨 Deploy migs to stage~
- [ ] 🚨 Deploy code to stage
- [x] ~🚨 DEPLOY `j-mail` to stage~
- [x] ~🚨 Deploy migs to prod~
- [ ] 🚨 Deploy code to prod
- [x] ~🚨 DEPLOY `j-mail` TO PROD~

## Migrations

No hay migs!

## Screenshots

N/A