### PR TITLE
💥 FINALLY Fix Exploding Email Verification User Experience ✅

### DIFF
--- a/packages/web/components/AuthGate/AuthGate.tsx
+++ b/packages/web/components/AuthGate/AuthGate.tsx
@@ -40,11 +40,12 @@ const AuthGate: React.FC<Props> = ({ children }) => {
     return null
   }
 
-  if (!currentUser && typeof window !== 'undefined') {
-    router.push({
-      pathname: '/login',
-    })
-
+  if (!currentUser) {
+    if (typeof window !== 'undefined') {
+      router.push({
+        pathname: '/login',
+      })
+    }
     return null
   }
 


### PR DESCRIPTION
## Description

**Issue:**
* Fixes #843 
* Fixes #604 

We did it! Finally figured out what in the world was going on where a decent number of people were ending up on an exploding server/Vercel error page after clicking the link to verify their email address.

## Breakdown

In the end, the issue lay within `<AuthGate>` where we were only null-checking the `currentUser` on the client, but not on the server. This meant that if someone went to any AuthGated page while not being logged in, things would explode spectacularly and instead of our own client-side error page and message, we were getting the Vercel page due to this occurring on the server.

We believe the User Behavior Pattern that would cause this is a user signing up on their laptop/computer, and then clicking the verification link on their phone.

This also fixes the weird problem we have had for a long time handling the logged out UX on the My Feed page! 🎉

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Make the fix
- [x] Test the fix
- [x] Test other logged out UX
- [x] Document the breakdown! 🎙️

### Deployment Checklist

- [x] ~🚨 Publish new j-db-client version and update in both `web` and `j-mail`~
- [x] ~🚨 Deploy migs to stage~
- [x] ~🚨 Deploy code to stage
- [x] ~🚨 DEPLOY `j-mail` to stage~
- [x] ~🚨 Deploy migs to prod~
- [x] ~🚨 Deploy code to prod
- [x] ~🚨 DEPLOY `j-mail` TO PROD~

## Migrations

No hay migraciones

## Screenshots

**What happens in prod today if you visit `journaly.com/my-feed` without being logged in:**
![image](https://user-images.githubusercontent.com/34203886/233526976-9298ac9b-7aad-49d1-982d-7c224ac2fdfe.png)
