### PR TITLE
Update `My Feed` Greetings To Use `name` by default

### DIFF
--- a/packages/web/components/Dashboard/MyFeed/FeedHeader.tsx
+++ b/packages/web/components/Dashboard/MyFeed/FeedHeader.tsx
@@ -11,8 +11,7 @@ const FeedHeader: React.FC<Props> = ({ currentUser }) => {
   let greetingLanguage = 'English'
 
   if (currentUser.languages.length === 1) {
-    greetingLanguage =
-      currentUser.languages[0].language.devName || currentUser.languages[0].language.name
+    greetingLanguage = currentUser.languages[0].language.name
   }
 
   const learningLanguages = currentUser.languages.filter(
@@ -21,8 +20,7 @@ const FeedHeader: React.FC<Props> = ({ currentUser }) => {
 
   if (learningLanguages.length > 0) {
     const index = Math.floor(Math.random() * learningLanguages.length)
-    const greetingLanguageKey =
-      learningLanguages[index].language.devName || learningLanguages[index].language.name
+    const greetingLanguageKey = learningLanguages[index].language.name
     greetingLanguage = greetings[greetingLanguageKey] ? greetingLanguageKey : 'English'
   }
 

--- a/packages/web/components/Dashboard/MyFeed/FeedHeader.tsx
+++ b/packages/web/components/Dashboard/MyFeed/FeedHeader.tsx
@@ -20,7 +20,12 @@ const FeedHeader: React.FC<Props> = ({ currentUser }) => {
 
   if (learningLanguages.length > 0) {
     const index = Math.floor(Math.random() * learningLanguages.length)
-    const greetingLanguageKey = learningLanguages[index].language.name
+    const greetingLanguageName = learningLanguages[index].language.name
+    const greetingLanguageDialect = learningLanguages[index].language.dialect
+
+    const greetingLanguageKey = greetingLanguageDialect
+      ? `${greetingLanguageDialect} ${greetingLanguageName}`
+      : greetingLanguageName
     greetingLanguage = greetings[greetingLanguageKey] ? greetingLanguageKey : 'English'
   }
 


### PR DESCRIPTION
## Description

As a part of the project to switch our language lists back to using the English names of each language for now, a small update to (simplify) make the greeting code always just use the `name` field instead of using `devName` by default.

This is because I have now switched the columns so that `name` is the English word for the language and `devName` contains the Endonym.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Make the initial change & test
- [x] Make it work with dialects (ex: "European Portuguese" vs. "Brazilian Portuguese"
