### PR TITLE
🐞 Fix bug with Digest Email

### DIFF
--- a/packages/j-db-client/prisma/schema.prisma
+++ b/packages/j-db-client/prisma/schema.prisma
@@ -454,7 +454,7 @@ model NewPostNotification {
 
 model UserConfiguration {
   id          Int                      @id @default(autoincrement())
-  userId      Int
+  userId      Int                      @unique
   digestEmail DigestEmailConfiguration @default(DAILY)
   user        User                     @relation(fields: [userId], references: [id])
 }

--- a/packages/jadmin/jadmin.js
+++ b/packages/jadmin/jadmin.js
@@ -143,6 +143,12 @@ yargs
 
       await query`
         DELETE
+        FROM "UserConfiguration"
+        WHERE "userId" = ${userId}
+      `
+
+      await query`
+        DELETE
         FROM "SocialMedia"
         WHERE "userId" = ${userId}
       `

--- a/packages/web/resolvers/user.ts
+++ b/packages/web/resolvers/user.ts
@@ -356,6 +356,15 @@ const UserMutations = extendType({
           }
         }
 
+        await ctx.db.userConfiguration.create({
+          data: {
+            digestEmail: DigestEmailConfiguration.DAILY,
+            user: {
+              connect: { id: user.id },
+            },
+          },
+        })
+
         await sendEmailAddressVerificationEmail({ user, verificationToken: emailVerificationToken })
 
         const token = jwt.sign({ userId: user.id }, process.env.APP_SECRET!)


### PR DESCRIPTION
## Description

We found that because the `configuration` field (type: `UserConfiguration`) is nullable and we also weren't correctly optionally chaining in the code where we reference that config before sending emails - this caused a bug where email sends dropped dramatically - the first user who didn't have a config would cause the whole thing to fail.

This PR:
* Manually creates `UserConfiguration` record for new user during `createUser` mutation
* Checks for presence of config object before attempting to read
* Wraps that code in a try catch and makes sure we still clear all notifications from a user after failure so that they don't stop receiving emails indefinitely
* Updates `jadmin` script to include deletion clause for `UserConfiguration`

## Subtasks

- [x] I have added this PR to the Journaly Kanban project
- [x] Make fixes
- [x] Create this field/table w default values on user creation
- [x] Optional chaining fix
- [x] Wrap each email send in a try/catch within this map (be sure to log)
- [x] Deploy j-mail and web FIRST
- [x] THEN Backfill users who missed this so far
- [x] Clear table prior to the last couple of days

### Deployment Checklist

- [ ] 🚨 Publish new j-db-client version and update in both `web` and `j-mail`
- [ ] 🚨 Deploy migs to stage
- [ ] 🚨 Deploy code to stage
- [ ] 🚨 DEPLOY `j-mail` to stage
- [ ] 🚨 Deploy migs to prod
- [ ] 🚨 Deploy code to prod
- [ ] 🚨 DEPLOY `j-mail` TO PROD

## Migrations

N/A

## Screenshots

N/A