### PR TITLE
BE: user search

### DIFF
--- a/packages/j-db-client/prisma/migrations/20230709145546_index_user_handle_trigram/migration.sql
+++ b/packages/j-db-client/prisma/migrations/20230709145546_index_user_handle_trigram/migration.sql
@@ -1,0 +1,3 @@
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX user_handle_trgm_idx ON "User" USING gist (handle gist_trgm_ops);

--- a/packages/web/resolvers/user.ts
+++ b/packages/web/resolvers/user.ts
@@ -245,8 +245,22 @@ const UserQueries = extendType({
   definition(t) {
     t.list.field('users', {
       type: 'User',
-      resolve: async (_parent, _args, ctx) => {
-        return ctx.db.user.findMany()
+      args: {
+        search: stringArg({ required: false })
+      },
+      resolve: async (_parent, args, ctx) => {
+        if (args.search) {
+          return ctx.db.$queryRaw`
+            SELECT
+              *,
+              SIMILARITY(handle, ${args.search}) AS sim
+            FROM "User"
+            ORDER BY sim DESC
+            LIMIT 5;
+          `
+        } else {
+          return ctx.db.user.findMany()
+        }
       },
     })
 


### PR DESCRIPTION
Add an index on user handles, and an arg to the `users` query to allow "fuzzy" searching by user handle

## Description

**Issue:** <#issue>

...

Journaly.com profile url (include if you'd like the "code contributor" badge):

## Subtasks

- [ ] I have added this PR to the Journaly Kanban project ✅
- [ ] ...

### Deployment Checklist

- [ ] 🚨 Publish new j-db-client version and update in both `web` and `j-mail`
- [ ] 🚨 Deploy migs to stage
- [ ] 🚨 Deploy code to stage
- [ ] 🚨 DEPLOY `j-mail` to stage
- [ ] 🚨 Deploy migs to prod
- [ ] 🚨 Deploy code to prod
- [ ] 🚨 DEPLOY `j-mail` TO PROD

## Migrations

If your PR doesn't involve any changes to the database, you can delete this section. If it does, briefly describe how it needs to be applied. Some common things you might mention are:

- Does the migration need to be applied before or after deploying code?
- Is applying the migration going to necessitate downtime?
- Is there any SQL or backfill logic that has to be run manually?
- Are the DB changes high risk in your estimation? Should a manual DB snapshot be taken before applying?

## Screenshots
