### PR TITLE
🚀 EXPERIMENT: Boost Premium Visibility in Nav with "Go Premium" Badge/Button

### DIFF
--- a/packages/web/components/Dashboard/Nav/Nav.tsx
+++ b/packages/web/components/Dashboard/Nav/Nav.tsx
@@ -139,6 +139,17 @@ const Nav: React.FC<Props> = ({ expanded, collapse, disableLargeNav }) => {
                     <p className="current-user-name">{currentUser.handle}</p>
                   </a>
                 </Link>
+                <Link href="/settings/subscription" legacyBehavior>
+                  <a className="premium-status">
+                    {t(
+                      `dashboardNav.${
+                        currentUser.membershipSubscription?.isActive
+                          ? 'premiumStatus'
+                          : 'goPremiumStatus'
+                      }`,
+                    )}
+                  </a>
+                </Link>
               </div>
               <div className="nav-bottom">
                 <NavLink href="/my-feed">
@@ -410,6 +421,24 @@ const Nav: React.FC<Props> = ({ expanded, collapse, disableLargeNav }) => {
           transition: margin-left ${navConstants.transitionDuration}ms linear;
         }
 
+        .nav-top > .premium-status {
+          font-weight: 600;
+          text-transform: uppercase;
+          font-size: 16px;
+          width: fit-content;
+          margin: 12px auto;
+          color: ${currentUser?.membershipSubscription?.isActive
+            ? theme.colors.blueLight
+            : theme.colors.orangeDark};
+          padding: 4px 8px;
+          border-radius: 4px;
+          letter-spacing: 1.5px;
+          border: 1px solid
+            ${currentUser?.membershipSubscription?.isActive
+              ? theme.colors.blueLight
+              : theme.colors.orangeDark};
+        }
+
         @media (${navConstants.mobileNavOnly}) {
           :global(.mobile-hamburger-icon) {
             position: absolute;
@@ -492,6 +521,17 @@ const Nav: React.FC<Props> = ({ expanded, collapse, disableLargeNav }) => {
           .nav-top {
             margin-top: 50px;
           }
+          /* If updating these styles, be sure to also update the same ones
+          within the @media query: ${navConstants.aboveDesktopNav} to cover
+          the use case for the settings page where the skinny nav is forced */
+          .nav-top > .premium-status {
+            font-size: 10px;
+            margin: 16px auto;
+            padding: 4px 3px;
+            letter-spacing: 1px;
+            text-align: center;
+            line-height: 1.4;
+          }
         }
 
         @media (${navConstants.aboveDesktopNav}) {
@@ -548,6 +588,17 @@ const Nav: React.FC<Props> = ({ expanded, collapse, disableLargeNav }) => {
           .nav-wrapper:not(.disable-large-nav) .nav-link-text {
             margin-left: 15px;
             font-size: 16px;
+          }
+
+          /* We have to duplicate these styles here to cover the case where
+          a user is on the settings page which forces the skinny nav.*/
+          .nav-wrapper.disable-large-nav .premium-status {
+            font-size: 10px;
+            margin: 16px auto;
+            padding: 4px 3px;
+            letter-spacing: 1px;
+            text-align: center;
+            line-height: 1.4;
           }
         }
 

--- a/packages/web/public/static/locales/de/common.json
+++ b/packages/web/public/static/locales/de/common.json
@@ -41,7 +41,9 @@
     "newPost": "Neuer Beitrag",
     "notifications": "Benachrichtigungen",
     "settings": "Einstellungen",
-    "logOut": "Ausloggen"
+    "logOut": "Ausloggen",
+    "goPremiumStatus": "Go Premium",
+    "premiumStatus": "Premium"
   },
   "helpModal": {
     "header": "Hilfe",

--- a/packages/web/public/static/locales/en/common.json
+++ b/packages/web/public/static/locales/en/common.json
@@ -41,7 +41,9 @@
     "newPost": "New Post",
     "notifications": "Notifications",
     "settings": "Settings",
-    "logOut": "Log Out"
+    "logOut": "Log Out",
+    "goPremiumStatus": "Go Premium",
+    "premiumStatus": "Premium"
   },
   "helpModal": {
     "header": "Support",

--- a/packages/web/public/static/locales/es/common.json
+++ b/packages/web/public/static/locales/es/common.json
@@ -31,7 +31,9 @@
     "myPosts": "Mis publicaciones",
     "newPost": "Nueva publicación",
     "settings": "Ajustes",
-    "logOut": "Cerrar sesión"
+    "logOut": "Cerrar sesión",
+    "goPremiumStatus": "Go Premium",
+    "premiumStatus": "Premium"
   },
   "badge": {
     "ALPHA_USER": {

--- a/packages/web/public/static/locales/it/common.json
+++ b/packages/web/public/static/locales/it/common.json
@@ -40,7 +40,9 @@
     "newPost": "Nuovo Post",
     "notifications": "Notifiche",
     "settings": "Impostazioni",
-    "logOut": "Uscita"
+    "logOut": "Uscita",
+    "goPremiumStatus": "Go Premium",
+    "premiumStatus": "Premium"
   },
   "helpModal": {
     "header": "Supporto",

--- a/packages/web/public/static/locales/pt_BR/common.json
+++ b/packages/web/public/static/locales/pt_BR/common.json
@@ -40,7 +40,9 @@
     "newPost": "Nova postagem",
     "notifications": "Notificações",
     "settings": "Configurações",
-    "logOut": "Sair"
+    "logOut": "Sair",
+    "goPremiumStatus": "Go Premium",
+    "premiumStatus": "Premium"
   },
   "helpModal": {
     "header": "Ajuda",

--- a/packages/web/public/static/locales/zh_CN/common.json
+++ b/packages/web/public/static/locales/zh_CN/common.json
@@ -40,7 +40,9 @@
     "newPost": "新建日志",
     "notifications": "消息中心",
     "settings": "设置",
-    "logOut": "退出登录"
+    "logOut": "退出登录",
+    "goPremiumStatus": "Go Premium",
+    "premiumStatus": "Premium"
   },
   "helpModal": {
     "header": "帮助",

--- a/packages/web/public/static/locales/zh_TW/common.json
+++ b/packages/web/public/static/locales/zh_TW/common.json
@@ -40,7 +40,9 @@
     "newPost": "新建日誌",
     "notifications": "消息中心",
     "settings": "設置",
-    "logOut": "退出登錄"
+    "logOut": "退出登錄",
+    "goPremiumStatus": "Go Premium",
+    "premiumStatus": "Premium"
   },
   "helpModal": {
     "header": "幫助",

--- a/packages/web/theme/index.ts
+++ b/packages/web/theme/index.ts
@@ -29,6 +29,7 @@ type Colors =
   | 'greenDark'
   | 'highlightColor'
   | 'highlightColorHover'
+  | 'orangeDark'
 
 type Typography =
   | 'fontFamilySansSerif'
@@ -75,6 +76,7 @@ const theme: Theme = {
     red: '#c42f14',
     greenLight: '#B0EED3',
     greenDark: '#1AAE6F',
+    orangeDark: '#c47429',
   },
   breakpoints: fromEntries(
     // Add px to breakpoint values: { XS: '600px', SM: '768px' }


### PR DESCRIPTION
## Description

We've known for a long time that one of the biggest blockers we have with Journaly Premium is ***VISIBILITY***: most people simply don't know it exists. Historically, we've been purposely shy with shouting about Premium, since we wanted to really have a great offering first.

I think at this point, we do have a good amount of Premium features, and we at least show the ones that are coming soon, with multiple **AWESOME** ones coming with the launch of Direct Messaging. But DMs will take some time, and it's really time for us to make a push to increase revenue – so I think it's time to experiment and simply try to see what happens if we really boost the visibility of Premium. After all, we do still have people who sign up, so in theory if we made sure all users knew about it, we should see more signups.

Let's find out! This PR adds a new badge/button right in the main Dashboard Nav that says "Go Premium" for free users in orange, and "Premium" for those users in Journaly Blue 😎 Clicking on it takes them to the Premium Subscription settings page.

See screenshots below 📸

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Figure out the styling
- [x] Handle mobile
- [x] Handle the skinny nav
- [x] Translations

### Deployment Checklist

- [ ] ~🚨 Publish new j-db-client version and update in both `web` and `j-mail`~
- [ ] ~🚨 Deploy migs to stage~
- [x] 🚨 Deploy code to stage
- [ ] ~🚨 DEPLOY `j-mail` to stage~
- [ ] ~🚨 Deploy migs to prod~
- [ ] 🚨 Deploy code to prod
- [ ] ~🚨 DEPLOY `j-mail` TO PROD~

## Migrations

No migs!

## Screenshots

**1. Premium User, Desktop, Normal**
![image](https://github.com/Journaly/journaly/assets/34203886/72256920-6337-4001-ad59-8fa08546a4fe)

**2. Free User, Desktop, Normal**
![image](https://github.com/Journaly/journaly/assets/34203886/604150d3-8406-43ea-ab06-a17a0f28d444)

**3. Premium User, Mobile**
![image](https://github.com/Journaly/journaly/assets/34203886/389b429c-b5f3-40d4-bb9a-419a950c102a)

**4. Free User, Mobile**
![image](https://github.com/Journaly/journaly/assets/34203886/4ffe8ded-7667-4418-9cc3-996604266ffc)

**5. Premium User, Desktop, Skinny Nav**
![image](https://github.com/Journaly/journaly/assets/34203886/869cc5a5-6069-47c4-ac7f-03b84add4ff7)

**6. Free User, Desktop, Skinny Nav**
![image](https://github.com/Journaly/journaly/assets/34203886/449a7eed-3884-47ce-b47d-2e5732413248)
