### PR TITLE
A smorgasbord of a11y changes to nav and the new post page

### DIFF
--- a/packages/web/components/Button/Button.tsx
+++ b/packages/web/components/Button/Button.tsx
@@ -36,6 +36,7 @@ type Props = {
   variant?: ButtonVariant
   style?: CSS.Properties | undefined
   dataTestId?: string
+  tabIndex?: number
 }
 
 const Button: React.FC<Props> = (props) => {
@@ -172,10 +173,9 @@ const Button: React.FC<Props> = (props) => {
           border: none;
           padding: 0;
         }
-        .${ButtonVariant.Link}:hover:not(:disabled) {
-          text-decoration: underline;
-        }
+        .${ButtonVariant.Link}:hover:not(:disabled),
         .${ButtonVariant.Link}:focus:not(:disabled) {
+          text-decoration: underline;
           outline: none;
           border-width: 0;
         }

--- a/packages/web/components/Dashboard/Nav/Nav.tsx
+++ b/packages/web/components/Dashboard/Nav/Nav.tsx
@@ -153,26 +153,26 @@ const Nav: React.FC<Props> = ({ expanded, collapse, disableLargeNav }) => {
               </div>
               <div className="nav-bottom">
                 <NavLink href="/my-feed">
-                  <a className="nav-link" onClick={handleCollapse} data-testid="my-feed-nav-link">
+                  <span className="nav-link" onClick={handleCollapse} data-testid="my-feed-nav-link">
                     <FeedIcon aria-hidden="true" />
                     <span className="nav-link-text">{t('dashboardNav.myFeed')}</span>
-                  </a>
+                  </span>
                 </NavLink>
                 <NavLink href="/my-posts">
-                  <a className="nav-link" onClick={handleCollapse} data-testid="my-posts-nav-link">
+                  <span className="nav-link" onClick={handleCollapse} data-testid="my-posts-nav-link">
                     <FeedIcon aria-hidden="true" />
                     <span className="nav-link-text">{t('dashboardNav.myPosts')}</span>
-                  </a>
+                  </span>
                 </NavLink>
                 <NavLink href="/new-post">
-                  <a className="nav-link" onClick={handleCollapse} data-testid="new-post-nav-link">
+                  <span className="nav-link" onClick={handleCollapse} data-testid="new-post-nav-link">
                     <NewPostIcon aria-hidden="true" />
                     <span className="nav-link-text">{t('dashboardNav.newPost')}</span>
-                  </a>
+                  </span>
                 </NavLink>
                 <hr />
 
-                <div
+                <button
                   className="nav-link notifications"
                   onClick={notificationFeedState.toggleDesktop}
                   data-testid="notifications-nav-link"
@@ -183,15 +183,15 @@ const Nav: React.FC<Props> = ({ expanded, collapse, disableLargeNav }) => {
                     aria-hidden="true"
                   />
                   <span className="nav-link-text">{t('dashboardNav.notifications')}</span>
-                </div>
+                </button>
                 <NavLink href="/settings/profile">
-                  <a className="nav-link" onClick={handleCollapse} data-testid="settings-nav-link">
+                  <span className="nav-link" onClick={handleCollapse} data-testid="settings-nav-link">
                     <SettingsIcon aria-hidden="true" />
                     <span className="nav-link-text">{t('dashboardNav.settings')}</span>
-                  </a>
+                  </span>
                 </NavLink>
 
-                <a
+                <button
                   role="button"
                   className="log-out nav-link"
                   onClick={handleLogOut}
@@ -199,21 +199,20 @@ const Nav: React.FC<Props> = ({ expanded, collapse, disableLargeNav }) => {
                 >
                   <LogOutIcon aria-hidden="true" />
                   <span className="nav-link-text">{t('dashboardNav.logOut')}</span>
-                </a>
+                </button>
               </div>
             </>
           )}
 
           <div className="nav-support">
             {currentUser && (
-              <span
-                role="button"
+              <button
                 className="help-btn"
                 onClick={() => setShouldShowModal(true)}
                 data-testid="help-nav-link"
               >
                 <HelpIcon width={30} height={30} />
-              </span>
+              </button>
             )}
             <h1 className="nav-logo">
               <Link href="/" legacyBehavior>
@@ -328,8 +327,9 @@ const Nav: React.FC<Props> = ({ expanded, collapse, disableLargeNav }) => {
           align-items: center;
         }
 
-        .help-btn:hover {
+        .help-btn {
           cursor: pointer;
+          ${theme.buttonReset}
         }
 
         .nav-wrapper:not(.logged-in) .nav-logo {
@@ -403,6 +403,7 @@ const Nav: React.FC<Props> = ({ expanded, collapse, disableLargeNav }) => {
           color: ${theme.colors.white};
           transition: padding-left ${navConstants.transitionDuration}ms linear,
             padding-right ${navConstants.transitionDuration}ms linear;
+          ${theme.buttonReset}
         }
 
         .nav-link.notifications {

--- a/packages/web/components/JournalyEditor/Toolbar/Toolbar.tsx
+++ b/packages/web/components/JournalyEditor/Toolbar/Toolbar.tsx
@@ -13,6 +13,7 @@ import { useSlate } from 'slate-react'
 
 import theme from '@/theme'
 
+import SkipLink, { SkipLinkTarget } from '@/components/SkipLink'
 import FormatBoldIcon from '@/components/Icons/FormatBoldIcon'
 import FormatItalicIcon from '@/components/Icons/FormatItalicIcon'
 import FormatUnderlinedIcon from '@/components/Icons/FormatUnderlinedIcon'
@@ -87,6 +88,7 @@ const Toolbar = ({
       <div ref={toolbarObserverRef} />
       <div className={toolbarClasses}>
         <div className="editor-toolbar">
+          <SkipLink target="end-editing-controls">Skip formatting controls</SkipLink>
           <div className="toolbar-row">
             <ToggleMarkButton type="bold">
               <FormatBoldIcon title="Bold" titleId="toolbar-bold-icon" />
@@ -165,6 +167,7 @@ const Toolbar = ({
               />
             </div>
           </div>
+          <SkipLinkTarget id="end-editing-controls" />
         </div>
         <style jsx>{`
           .editor-toolbar-container {

--- a/packages/web/components/Layouts/DashboardLayout.tsx
+++ b/packages/web/components/Layouts/DashboardLayout.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames'
 import { useRouter } from 'next/router'
 import Nav, { navConstants } from '@/components/Dashboard/Nav'
 import { layoutPadding } from '@/components/Dashboard/dashboardConstants'
+import SkipLink, { SkipLinkTarget } from '@/components/SkipLink'
 import Header from '@/components/Dashboard/Header'
 import NotificationContextProvider from '../NotificationFeed/NotificationContext'
 
@@ -25,6 +26,9 @@ const DashboardLayout: React.FC<Props> = ({ children, pad = 'always' }) => {
 
   return (
     <NotificationContextProvider>
+      <SkipLink target="start-of-content">
+        Skip to content
+      </SkipLink>
       <div className="dashboard">
         <Header onMenuClick={toggleNav} />
 
@@ -34,7 +38,10 @@ const DashboardLayout: React.FC<Props> = ({ children, pad = 'always' }) => {
           disableLargeNav={router.pathname.includes('/settings/')}
         />
 
-        <div className={dashboardContainerStyles}>{children}</div>
+        <div className={dashboardContainerStyles}>
+          <SkipLinkTarget id="start-of-content" />
+          {children}
+        </div>
 
         <style jsx>{`
           .dashboard {

--- a/packages/web/components/Modal/Modal.tsx
+++ b/packages/web/components/Modal/Modal.tsx
@@ -64,7 +64,12 @@ const Modal: React.FC<Props> = (props) => {
   }
 
   return ReactDOM.createPortal(
-    <div className="modal-container" onClick={onClose} data-testid={dataTestId}>
+    <div
+      className="modal-container"
+      role="dialog"
+      onClick={onClose}
+      data-testid={dataTestId}
+    >
       <div className="modal-wrapper">
         <ModalContent
           type={onFormSubmit ? 'form' : 'div'}

--- a/packages/web/components/Modals/ImageUploadModal/SearchUnsplash.tsx
+++ b/packages/web/components/Modals/ImageUploadModal/SearchUnsplash.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { createApi } from 'unsplash-js'
 import { toast } from 'react-toastify'
 import { InitiatePostImageUploadResponse } from '@/generated/graphql'
+import theme from '@/theme'
 import SearchInput from '@/components/Dashboard/Filters/SearchInput'
 import { useTranslation } from '@/config/i18n'
 
@@ -49,9 +50,12 @@ const ImageComp: React.FC<{
 
   return (
     <>
-      <div className="img-container">
-        <img src={urls.small} onClick={handleImageClick} />
-      </div>
+      <button
+        className="img-container"
+        onClick={handleImageClick}
+      >
+        <img src={urls.small} />
+      </button>
       <a className="credit" target="_blank" href={`https://unsplash.com/@${user.username}`}>
         {user.name}
       </a>
@@ -60,6 +64,8 @@ const ImageComp: React.FC<{
           height: 200px;
           border-radius: 3px;
           overflow: hidden;
+          width: 100%;
+          ${theme.buttonReset}
         }
 
         img {

--- a/packages/web/components/NavLink/NavLink.tsx
+++ b/packages/web/components/NavLink/NavLink.tsx
@@ -18,7 +18,7 @@ const NavLink: React.FC<NavLinkProps> = (props) => {
   }
 
   return (
-    <Link href={href} {...otherProps} legacyBehavior>
+    <Link href={href} {...otherProps}>
       {React.cloneElement(child, { className })}
     </Link>
   )

--- a/packages/web/components/NotificationCount/NotificationCount.tsx
+++ b/packages/web/components/NotificationCount/NotificationCount.tsx
@@ -14,8 +14,8 @@ const NotificationCount: React.FC<NotificationCountProps> = ({ count }) => {
           position: absolute;
           background: ${theme.colors.blueLight};
           color: ${theme.colors.white};
-          border-radius: 50%;
-          padding: 0 8px;
+          border-radius: 10px;
+          padding: 3px 5px;
           font-size: 12px;
           top: -10px;
           right: -5px;

--- a/packages/web/components/NotificationFeed/NotificationFeed.tsx
+++ b/packages/web/components/NotificationFeed/NotificationFeed.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useCallback } from 'react'
+import React, { useState, useRef, useCallback, useEffect } from 'react'
 import {
   CurrentUserDocument,
   CurrentUserQuery,
@@ -189,12 +189,16 @@ const NotificationFeed: React.FC<NotificationFeedProps> = ({ onClose }) => {
     })
   }
 
+  useEffect(() => {
+    document.getElementById('close-notif-feed')?.focus()
+  }, [])
+
   return (
     <div className="container" ref={feedContainerRef}>
       <div className="level-one">
         <div className="top">
           <p>Notifications</p>
-          <Button variant={ButtonVariant.Icon} onClick={onClose}>
+          <Button variant={ButtonVariant.Icon} onClick={onClose} id="close-notif-feed">
             <XIcon color={theme.colors.white} />
           </Button>
         </div>

--- a/packages/web/components/PostEditor/PostEditor.tsx
+++ b/packages/web/components/PostEditor/PostEditor.tsx
@@ -7,7 +7,7 @@ import JournalyEditor from '@/components/JournalyEditor'
 import XIcon from '@/components/Icons/XIcon'
 import Select from '@/components/Select'
 import MultiSelect from '@/components/MultiSelect'
-import Button from '@/components/Button'
+import Button, { ButtonVariant } from '@/components/Button'
 import theme from '@/theme'
 import useAutosavedState from '@/hooks/useAutosavedState'
 import {
@@ -237,11 +237,15 @@ const PostEditor: React.FC<PostEditorProps> = ({
             <Button onClick={() => setDisplayImageUploadModal(true)}>
               {t('uploadImageButtonText')}
             </Button>
-            <XIcon
-              className="cancel-image-icon"
-              color={theme.colors.white}
+            <Button
+              variant={ButtonVariant.Icon}
               onClick={() => setImage(null)}
-            />
+            >
+              <XIcon
+                className="cancel-image-icon"
+                color={theme.colors.white}
+              />
+            </Button>
           </div>
         </PostHeader>
       </div>

--- a/packages/web/components/PostHeader/PostHeader.tsx
+++ b/packages/web/components/PostHeader/PostHeader.tsx
@@ -43,6 +43,9 @@ const PostHeader: React.FC<PostHeaderProps> = ({
   return (
     <div className="post-header">
       <img src={postImage} alt={postTitle} />
+      <div className="embedded-content">
+        {children}
+      </div>
       <div className="post-header-info" dir="auto">
         <div className="top-badges">
           {language && (
@@ -84,7 +87,6 @@ const PostHeader: React.FC<PostHeaderProps> = ({
           ))}
         </div>
       </div>
-      {children}
       <style jsx>{`
         .post-header {
           position: relative;
@@ -169,6 +171,13 @@ const PostHeader: React.FC<PostHeaderProps> = ({
           min-height: 310px;
           display: flex;
           flex-direction: column;
+        }
+
+        .embedded-content {
+          z-index: 1;
+          width: 100%;
+          height: 100%;
+          position: absolute;
         }
 
         .title-and-info {

--- a/packages/web/components/Select/Select.tsx
+++ b/packages/web/components/Select/Select.tsx
@@ -134,9 +134,6 @@ const SelectBase = <T extends OptionValue>(
           -ms-appearance: none;
           appearance: none;
         }
-        select:focus {
-          outline: none;
-        }
         select::-ms-expand {
           display: none;
         }

--- a/packages/web/components/Site/Nav/Nav.tsx
+++ b/packages/web/components/Site/Nav/Nav.tsx
@@ -16,22 +16,22 @@ const Nav = () => {
 
         <ul className="nav-items">
           <NavLink href="/about">
-            <a className="nav-link">{t('home.nav.about')}</a>
+            <span className="nav-link">{t('home.nav.about')}</span>
           </NavLink>
           <NavLink href="/pricing">
-            <a className="nav-link">{t('home.nav.pricing')}</a>
+            <span className="nav-link">{t('home.nav.pricing')}</span>
           </NavLink>
           {currentUser ? (
             <NavLink href="/my-feed">
-              <a className="nav-link">{t('home.nav.dashboard')}</a>
+              <span className="nav-link">{t('home.nav.dashboard')}</span>
             </NavLink>
           ) : (
             <>
               <NavLink href="/login">
-                <a className="nav-link">{t('home.nav.logIn')}</a>
+                <span className="nav-link">{t('home.nav.logIn')}</span>
               </NavLink>
               <NavLink href="/signup">
-                <a className="nav-link">{t('home.nav.signUp')}</a>
+                <span className="nav-link">{t('home.nav.signUp')}</span>
               </NavLink>
             </>
           )}

--- a/packages/web/components/SkipLink/SkipLink.tsx
+++ b/packages/web/components/SkipLink/SkipLink.tsx
@@ -1,0 +1,55 @@
+import React, { useCallback } from 'react'
+
+type Props = {
+  target: string,
+  children: React.ReactNode
+}
+
+const SkipLink = ({ target, children }: Props) => {
+  const handleSkipLinkClick = useCallback((
+    e: React.MouseEvent<HTMLAnchorElement>
+  ) => {
+    e.preventDefault()
+    document.getElementById(target)?.focus()
+  }, [target])
+
+  return (
+    <>
+      <a
+        className="skip-link"
+        href={'#' + target}
+        onClick={handleSkipLinkClick}
+      >
+        {children}
+      </a>
+
+      <style jsx>{`
+        .skip-link {
+          display: block;
+          background: white;
+          padding: 10px 20px;
+        }
+        .skip-link:not(:focus) { 
+          width: 1px !important;
+          height: 1px !important;
+          padding: 0 !important;
+          overflow: hidden !important;
+          clip: rect(1px, 1px, 1px, 1px) !important;
+          border: 0 !important;
+        }
+        .skip-link:focus {
+          display: block;
+          z-index: 999;
+          position: absolute;
+        }
+      `}</style>
+    </>
+  )
+}
+
+const SkipLinkTarget = ({ id }: { id: string }) => (
+  <div id={id} tabIndex={-1} />
+)
+
+export default SkipLink
+export { SkipLinkTarget }

--- a/packages/web/components/SkipLink/index.ts
+++ b/packages/web/components/SkipLink/index.ts
@@ -1,0 +1,4 @@
+import SkipLink, { SkipLinkTarget } from './SkipLink'
+
+export default SkipLink
+export { SkipLinkTarget }

--- a/packages/web/components/SwipeableElement/SwipeableElement.tsx
+++ b/packages/web/components/SwipeableElement/SwipeableElement.tsx
@@ -105,6 +105,7 @@ const SwipeableElement: React.FC<SwipeableElementProps> = ({
         <div className="right-hand-actions" ref={rightHandActionsRef}>
           <Button
             variant={ButtonVariant.Icon}
+            tabIndex={-1}
             onClick={() => {
               handleCloseActions()
               nonDestructiveAction()
@@ -117,6 +118,7 @@ const SwipeableElement: React.FC<SwipeableElementProps> = ({
           </Button>
           <Button
             variant={ButtonVariant.Icon}
+            tabIndex={-1}
             onClick={() => {
               handleCloseActions()
               destructiveAction()

--- a/packages/web/styles/globalStyles.css
+++ b/packages/web/styles/globalStyles.css
@@ -94,10 +94,6 @@ textarea {
   background-color: white;
 }
 
-input:focus {
-  outline: 0;
-}
-
 ::placeholder {
   font-family: 'Source Sans Pro', sans-serif;
 }
@@ -112,4 +108,3 @@ input:focus {
   width: 1px;
   overflow: hidden;
 }
-

--- a/packages/web/theme/index.ts
+++ b/packages/web/theme/index.ts
@@ -53,6 +53,7 @@ export type Theme = {
   typography: {
     readonly [key in Typography]: string
   }
+  buttonReset: string
 }
 
 const theme: Theme = {
@@ -147,6 +148,13 @@ const theme: Theme = {
       font-size: 12px;
     `,
   },
+  buttonReset: `
+    appearance: none;
+    border: none;
+    background: unset;
+    padding: 0;
+    margin: 0;
+  `
 }
 
 export default theme


### PR DESCRIPTION

## Description

point-by-point re: the email that spawned this effort:

>When I try to add a photo via Unsplash I don't seem to be able to access the tab. In the screencast attached, I'm tabbing repeatedly at a consistent speed but only the 'choose image to upload' and 'close' links are highlighted. After a bit of trial and error I think at one point I *can* hit return to access the 'search Unsplash' option but if the active element was always highlighted, this would be a piece of cake and one less barrier :)

Fixed, although the approach was to use an underline (same as the hover state) to signal focus on these links. I think the looks reasonable but maybe it's not super duper obvious. Open to considering a more visually impactful signal of focus if this doesn't work

>Similarly, when I'm on the New Post page, I can tab through the fields (title, language, etc) much more logically, but the two dropdowns aren't highlighted when active either. I can use access them if I'm paying close attention and use alt-down to open the list and navigate up and down them.

Fixed issue with focus not being visually indicated, looks like this:

![image](https://github.com/Journaly/journaly/assets/2343714/6fc567aa-c75e-42ef-bfe8-7c82ef83c42d)

Only change here was to remove our override of the browser default focus indicator (so behavior is a little different between browsers, e.g. in chromium the focus indicator is orange :shrug: ). I think it looks fine, but then I also am a semi-regular tab-er so I generally value an indication of focus position over aesthetics

WRT the keyboard interaction for actually selecting a value, the language select seems wholly reasonable to me. The multi-select ones (i.e. topics) are kinda janky, if you focus and then use the arrow keys, each keypress results in a new topic being added. On FF on linux using alt+down actually behaved how I'd expect, but we should probably fix the "press arrow while focused" case, which I didn't do, will need to think about what the appropriate behavior here is and what's within reach to do.

>However, when I try to escape out of the list (either with Escape or alt-up or tab) the tag I'm on is automatically added. I haven't yet found a way to close the list without adding another tag, though maybe there is one?! It means I have to close the list then go and delete the last random tag added (I'm usually still browsing to see if there's another appropriate tag) before carrying on.

Specifically around exiting, this is all browser controlled. Linux/FF allowed me to alt+down, move through options without selecting anything, and press escape to close the select without picking anything. I'm not sure we have a lot of control over this, although we could probably improve the multi-select experience if only by disabling raw arrow inputs while focused. 

>I also wonder if the username could *not* be an active link in this screen? It's a bit odd that the tab/element order takes you to the username before the 'choose image' element, and I don't see a benefit of hyperlinking the username as it can't be changed here.

This is somewhat intentional behavior. The username is in fact a link, so it should be focusable for comparable functionality to what mouse users get. re: it not being changeable, that's true, but we keep it as a link here because it will be a link in the final post and we're going for a "preview" kinda effect here. I'm going to make the case for keeping it focusable on the grounds that it's a better parallel to the mouse-using experience (and actually kinda important when looking at a published post) but I did change the tab order to be what you'd expect as a top-down RTL reader.

> Bypass blocks would be a fantastic thing to add in, too (see [2.4.1 bypass blocks](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=241#navigable)) as I do spend a lot of time going through a) the left-hand menu and b) the formatting bar.
The left-hand menu seems to have an error in the element labelling too, as tabbing skips Notifications, Log out, and Help (I've added a screencast of that too).

Added skip links to both the nav and the editor toolbar.

**Issue:** <#issue>

...

Journaly.com profile url (include if you'd like the "code contributor" badge):

## Subtasks

- [ ] I have added this PR to the Journaly Kanban project ✅
- [ ] ...

### Deployment Checklist

- [ ] 🚨 Publish new j-db-client version and update in both `web` and `j-mail`
- [ ] 🚨 Deploy migs to stage
- [ ] 🚨 Deploy code to stage
- [ ] 🚨 DEPLOY `j-mail` to stage
- [ ] 🚨 Deploy migs to prod
- [ ] 🚨 Deploy code to prod
- [ ] 🚨 DEPLOY `j-mail` TO PROD

## Migrations

If your PR doesn't involve any changes to the database, you can delete this section. If it does, briefly describe how it needs to be applied. Some common things you might mention are:

- Does the migration need to be applied before or after deploying code?
- Is applying the migration going to necessitate downtime?
- Is there any SQL or backfill logic that has to be run manually?
- Are the DB changes high risk in your estimation? Should a manual DB snapshot be taken before applying?

## Screenshots

