### PR TITLE
🥍🐞 Fix Toxic Notification Bug: Create DB Function & Triggers To Clean Up Empty Nester `InAppNotification` Records

### DIFF
--- a/packages/j-db-client/prisma/migrations/20231019145738_create_notification_deletion_triggers/migration.sql
+++ b/packages/j-db-client/prisma/migrations/20231019145738_create_notification_deletion_triggers/migration.sql
@@ -1,0 +1,150 @@
+-- Custom Migration
+-- When an InAppNotification loses all of its children,
+-- it needs to be cleaned up as well to avoid breaking the
+-- Notification Feed.
+--
+-- This migration creates a DB function to do that,
+-- and then sets up DB triggers for each sub-notification table.
+
+-- -- QUERY TO FIND AND CLEAN UP ANY EXISTING TOXIC NOTIFICATIONS
+-- DELETE
+-- FROM "InAppNotification"
+-- WHERE id IN (
+-- SELECT
+--   ian.id
+-- FROM "InAppNotification" AS ian
+-- FULL JOIN "ThreadCommentThanksNotification" AS tct
+--   ON tct."notificationId" = ian.id
+-- FULL JOIN "PostClapNotification" AS pc
+--   ON pc."notificationId" = ian.id
+-- FULL JOIN "MentionNotification" AS m
+--   ON m."notificationId" = ian.id
+-- FULL JOIN "NewPostNotification" AS np
+--   ON np."notificationId" = ian.id
+-- FULL JOIN "ThreadCommentNotification" AS c
+--   ON c."notificationId" = ian.id
+-- FULL JOIN "NewFollowerNotification" AS nf
+--   ON nf."notificationId" = ian.id
+-- FULL JOIN "PostCommentNotification" AS pct
+--   ON pct."notificationId" = ian.id
+-- -- WHERE ian.id = 113459
+-- GROUP BY ian.id
+-- HAVING COUNT(tct.id) + COUNT(pc.id) + COUNT(m.id) + COUNT(np.id) + COUNT(c.id) + COUNT(nf.id) + COUNT(pct.id) = 0);
+
+
+-- -- Set up DB trigger
+CREATE OR REPLACE FUNCTION clean_up_childless_inappnotifications()
+  RETURNS TRIGGER
+  LANGUAGE PLPGSQL
+  AS
+$$
+BEGIN
+	DELETE
+		FROM "InAppNotification"
+		WHERE id IN (
+			SELECT
+			  ian.id
+			FROM "InAppNotification" AS ian
+			FULL JOIN "ThreadCommentThanksNotification" AS tct
+			  ON tct."notificationId" = ian.id
+			FULL JOIN "PostClapNotification" AS pc
+			  ON pc."notificationId" = ian.id
+			FULL JOIN "MentionNotification" AS m
+			  ON m."notificationId" = ian.id
+			FULL JOIN "NewPostNotification" AS np
+			  ON np."notificationId" = ian.id
+			FULL JOIN "ThreadCommentNotification" AS c
+			  ON c."notificationId" = ian.id
+			FULL JOIN "NewFollowerNotification" AS nf
+			  ON nf."notificationId" = ian.id
+			FULL JOIN "PostCommentNotification" AS pct
+			  ON pct."notificationId" = ian.id
+			WHERE ian.id = OLD."notificationId"
+			GROUP BY ian.id
+			HAVING
+				COUNT(tct.id) +
+				COUNT(pc.id) +
+				COUNT(m.id) +
+				COUNT(np.id) +
+				COUNT(c.id) +
+				COUNT(nf.id) +
+				COUNT(pct.id) = 0
+			);
+	RETURN OLD;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS on_thread_comment_notification_deletion
+ON "ThreadCommentNotification";
+
+CREATE TRIGGER on_thread_comment_notification_deletion
+AFTER DELETE
+ON "ThreadCommentNotification"
+FOR EACH ROW
+EXECUTE PROCEDURE clean_up_childless_inappnotifications();
+
+--
+
+DROP TRIGGER IF EXISTS on_post_comment_notification_deletion
+ON "PostCommentNotification";
+
+CREATE TRIGGER on_post_comment_notification_deletion
+AFTER DELETE
+ON "PostCommentNotification"
+FOR EACH ROW
+EXECUTE PROCEDURE clean_up_childless_inappnotifications();
+
+--
+
+DROP TRIGGER IF EXISTS on_thread_comment_thanks_notification_deletion
+ON "ThreadCommentThanksNotification";
+
+CREATE TRIGGER on_thread_comment_thanks_notification_deletion
+AFTER DELETE
+ON "ThreadCommentThanksNotification"
+FOR EACH ROW
+EXECUTE PROCEDURE clean_up_childless_inappnotifications();
+
+--
+
+DROP TRIGGER IF EXISTS on_post_clap_notification_deletion
+ON "PostClapNotification";
+
+CREATE TRIGGER on_post_clap_notification_deletion
+AFTER DELETE
+ON "PostClapNotification"
+FOR EACH ROW
+EXECUTE PROCEDURE clean_up_childless_inappnotifications();
+
+--
+
+DROP TRIGGER IF EXISTS on_mention_notification_deletion
+ON "MentionNotification";
+
+CREATE TRIGGER on_mention_notification_deletion
+AFTER DELETE
+ON "MentionNotification"
+FOR EACH ROW
+EXECUTE PROCEDURE clean_up_childless_inappnotifications();
+
+--
+
+DROP TRIGGER IF EXISTS on_new_post_notification_deletion
+ON "NewPostNotification";
+
+CREATE TRIGGER on_new_post_notification_deletion
+AFTER DELETE
+ON "NewPostNotification"
+FOR EACH ROW
+EXECUTE PROCEDURE clean_up_childless_inappnotifications();
+
+--
+
+DROP TRIGGER IF EXISTS on_new_follower_notification_deletion
+ON "NewFollowerNotification";
+
+CREATE TRIGGER on_new_follower_notification_deletion
+AFTER DELETE
+ON "NewFollowerNotification"
+FOR EACH ROW
+EXECUTE PROCEDURE clean_up_childless_inappnotifications();

--- a/packages/j-db-client/prisma/schema.prisma
+++ b/packages/j-db-client/prisma/schema.prisma
@@ -586,6 +586,9 @@ enum EmailNotificationType {
   POST_CLAP
 }
 
+// WARNING: Every new notification type requires
+// updating our DB trigger to clean up toxic InAppNotifications
+// whenever sub-notifications are deleted.
 enum InAppNotificationType {
   THREAD_COMMENT
   POST_COMMENT


### PR DESCRIPTION
## Description

**Issue:** <#issue>

..

## Subtasks

- [ ] I have added this PR to the Journaly Kanban project ✅
- [ ] ...

### Deployment Checklist

- [ ] 🚨 Publish new j-db-client version and update in both `web` and `j-mail`
- [ ] 🚨 Deploy migs to stage
- [ ] 🚨 Deploy code to stage
- [ ] 🚨 DEPLOY `j-mail` to stage
- [ ] 🚨 Deploy migs to prod
- [ ] 🚨 Deploy code to prod
- [ ] 🚨 DEPLOY `j-mail` TO PROD

## Migrations

If your PR doesn't involve any changes to the database, you can delete this section. If it does, briefly describe how it needs to be applied. Some common things you might mention are:

- Does the migration need to be applied before or after deploying code?
- Is applying the migration going to necessitate downtime?
- Is there any SQL or backfill logic that has to be run manually?
- Are the DB changes high risk in your estimation? Should a manual DB snapshot be taken before applying?

## Screenshots
