### PR TITLE
🐞 Suggestions: Make The Suggested Text Wrap

### DIFF
--- a/packages/web/components/EditableMarkdown/EditableMarkdown.tsx
+++ b/packages/web/components/EditableMarkdown/EditableMarkdown.tsx
@@ -151,6 +151,7 @@ const EditableMarkdown = ({
         }
         .body-block :global(.suggestion > code) {
           padding: 0;
+          text-wrap: wrap;
         }
         .body-block :global(.old-string) {
           background: ${theme.colors.redHighlight};


### PR DESCRIPTION
## Description

**Issue:**
* Fixes #883 

This PR makes sure that the text inside of a suggestion block wraps correctly, if the highlighted and/or suggested text is wider than the popover component.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Make the fix
- [x] Test

### Deployment Checklist

- [x] ~🚨 Publish new j-db-client version and update in both `web` and `j-mail`~
- [x] ~🚨 Deploy migs to stage~
- [x] 🚨 Deploy code to stage
- [x] ~🚨 DEPLOY `j-mail` to stage~
- [x] ~🚨 Deploy migs to prod~
- [x] 🚨 Deploy code to prod
- [x] ~🚨 DEPLOY `j-mail` TO PROD~

## Migrations

N/A

## Screenshots

**BEFORE - User Report:**
<img width="450" src="https://github.com/Journaly/journaly/assets/34203886/348213ca-3880-43f0-ab5c-7c0b40da77ed">


**AFTER:**
<img width="493" alt="Screenshot 2023-12-28 at 4 13 05 PM" src="https://github.com/Journaly/journaly/assets/34203886/cf357637-e2b0-4ceb-93fb-dedf5f9ab48c">
