### PR TITLE
🛜 Implement Solution For Storing Post & Comment Author's IP Address in Respective Tables

### DIFF
--- a/packages/j-db-client/package.json
+++ b/packages/j-db-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@journaly/j-db-client",
-  "version": "13.20.0",
+  "version": "13.22.0",
   "description": "Journaly's internal database client.",
   "main": "dist/index",
   "scripts": {

--- a/packages/j-db-client/prisma/migrations/20240822150636_add_posting_ip_to_posts_and_comments/migration.sql
+++ b/packages/j-db-client/prisma/migrations/20240822150636_add_posting_ip_to_posts_and_comments/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "Comment" ADD COLUMN     "postingIpAddress" TEXT;
+
+-- AlterTable
+ALTER TABLE "Post" ADD COLUMN     "postingIpAddress" TEXT;
+
+-- AlterTable
+ALTER TABLE "PostComment" ADD COLUMN     "postingIpAddress" TEXT;

--- a/packages/j-db-client/prisma/schema.prisma
+++ b/packages/j-db-client/prisma/schema.prisma
@@ -140,6 +140,7 @@ model Post {
   savedUsers               User[]                    @relation("UserSavedPosts", references: [id])
   privateShareId           String?                   @unique
   newPostNotifications     NewPostNotification[]
+  postingIpAddress         String?
 }
 
 model Language {
@@ -247,6 +248,7 @@ model Comment {
   authorLanguageLevel               LanguageLevel                      @default(BEGINNER)
   threadCommentNotifications        ThreadCommentNotification[]
   mentionNotifications              MentionNotification[]
+  postingIpAddress                  String?
 }
 
 model PostComment {
@@ -263,6 +265,7 @@ model PostComment {
   postCommentNotifications        PostCommentNotification[]
   mentionNotifications            MentionNotification[]
   authorLanguageLevel             LanguageLevel                    @default(BEGINNER)
+  postingIpAddress                String?
 }
 
 model Thread {

--- a/packages/j-mail/package.json
+++ b/packages/j-mail/package.json
@@ -36,7 +36,7 @@
     "typescript": "4.2.4"
   },
   "dependencies": {
-    "@journaly/j-db-client": "^13.20.0",
+    "@journaly/j-db-client": "^13.22.0",
     "@types/nodemailer": "^6.4.0",
     "aws-sdk": "^2.737.0",
     "date-fns": "^2.16.1",

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@apollo/client": "3.7.14",
         "@github/text-expander-element": "^2.5.0",
-        "@journaly/j-db-client": "^13.20.0",
+        "@journaly/j-db-client": "^13.22.0",
         "@prisma/client": "^3.15.2",
         "@stripe/react-stripe-js": "^1.2.2",
         "@stripe/stripe-js": "^1.12.1",
@@ -2747,9 +2747,9 @@
       "integrity": "sha512-CtzORUwWTTOTqfVtHaKRJ0I1kNQd1bpn3sUh8I3nJDVY+5/M/Oe1DnEWzPQvqq/xPIIkzzzIP7mfCoAjFRvDhg=="
     },
     "node_modules/@journaly/j-db-client": {
-      "version": "13.20.0",
-      "resolved": "https://registry.npmjs.org/@journaly/j-db-client/-/j-db-client-13.20.0.tgz",
-      "integrity": "sha512-azX4mKZhicDmomFZqtliVhRaEjlu2Y9gz9u+NkrN1epDewov4SvwAoSn98/90cRr6W2Vh6GbjfxjUddzs7YraQ==",
+      "version": "13.22.0",
+      "resolved": "https://registry.npmjs.org/@journaly/j-db-client/-/j-db-client-13.22.0.tgz",
+      "integrity": "sha512-yeqsGOHqf6KC39Up52cSXq/VxWo+MvzvBEqqllI30r6YigDBgXoO8PUYVZ+1UwSS6f9ssKsR/JY8UrB+oUQ84A==",
       "dependencies": {
         "@prisma/client": "^3.15.2"
       }
@@ -20715,9 +20715,9 @@
       "integrity": "sha512-CtzORUwWTTOTqfVtHaKRJ0I1kNQd1bpn3sUh8I3nJDVY+5/M/Oe1DnEWzPQvqq/xPIIkzzzIP7mfCoAjFRvDhg=="
     },
     "@journaly/j-db-client": {
-      "version": "13.20.0",
-      "resolved": "https://registry.npmjs.org/@journaly/j-db-client/-/j-db-client-13.20.0.tgz",
-      "integrity": "sha512-azX4mKZhicDmomFZqtliVhRaEjlu2Y9gz9u+NkrN1epDewov4SvwAoSn98/90cRr6W2Vh6GbjfxjUddzs7YraQ==",
+      "version": "13.22.0",
+      "resolved": "https://registry.npmjs.org/@journaly/j-db-client/-/j-db-client-13.22.0.tgz",
+      "integrity": "sha512-yeqsGOHqf6KC39Up52cSXq/VxWo+MvzvBEqqllI30r6YigDBgXoO8PUYVZ+1UwSS6f9ssKsR/JY8UrB+oUQ84A==",
       "requires": {
         "@prisma/client": "^3.15.2"
       }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@apollo/client": "3.7.14",
     "@github/text-expander-element": "^2.5.0",
-    "@journaly/j-db-client": "^13.20.0",
+    "@journaly/j-db-client": "^13.22.0",
     "@prisma/client": "^3.15.2",
     "@stripe/react-stripe-js": "^1.2.2",
     "@stripe/stripe-js": "^1.12.1",

--- a/packages/web/resolvers/context.ts
+++ b/packages/web/resolvers/context.ts
@@ -1,8 +1,8 @@
 import { PrismaClient } from '@journaly/j-db-client'
 import { IncomingMessage, ServerResponse } from 'http';
 
-interface Request extends IncomingMessage {
-  userId: number,
+export interface Request extends IncomingMessage {
+  userId: number
 }
 
 

--- a/packages/web/resolvers/post.ts
+++ b/packages/web/resolvers/post.ts
@@ -20,8 +20,8 @@ import {
   generatePostPrivateShareId,
   createInAppNotification,
   sendReportSpamPostEmail,
+  getPostingIpAddress,
 } from './utils'
-
 
 import { NotFoundError, NotAuthorizedError, ResolverError } from './errors'
 import {
@@ -486,6 +486,7 @@ const PostMutations = extendType({
             publishedAt: isPublished ? new Date() : null,
             bumpedAt: isPublished ? new Date() : null,
             publishedLanguageLevel: userLanguageLevel,
+            postingIpAddress: getPostingIpAddress(ctx.req),
             postCommentSubscriptions: {
               create: [
                 {

--- a/packages/web/resolvers/post.ts
+++ b/packages/web/resolvers/post.ts
@@ -486,7 +486,7 @@ const PostMutations = extendType({
             publishedAt: isPublished ? new Date() : null,
             bumpedAt: isPublished ? new Date() : null,
             publishedLanguageLevel: userLanguageLevel,
-            postingIpAddress: getPostingIpAddress(ctx.req),
+            postingIpAddress: getPostingIpAddress(ctx.request),
             postCommentSubscriptions: {
               create: [
                 {

--- a/packages/web/resolvers/utils/getPostingIpAddress.ts
+++ b/packages/web/resolvers/utils/getPostingIpAddress.ts
@@ -1,0 +1,5 @@
+import { NextRequest } from 'next/server'
+
+export const getPostingIpAddress = (req: NextRequest) => {
+  return req?.ip ?? req?.headers.get('X-Forwarded-For')?.split(',')?.[0]
+}

--- a/packages/web/resolvers/utils/getPostingIpAddress.ts
+++ b/packages/web/resolvers/utils/getPostingIpAddress.ts
@@ -1,5 +1,15 @@
 import { NextRequest } from 'next/server'
+import { Request } from '../context'
 
-export const getPostingIpAddress = (req: NextRequest) => {
-  return req?.ip ?? req?.headers.get('X-Forwarded-For')?.split(',')?.[0]
+const isNextRequest = (req: NextRequest | Request): req is NextRequest => {
+  return !!(req as NextRequest).ip
+}
+
+export const getPostingIpAddress = (req: NextRequest | Request) => {
+  if (isNextRequest(req)) return req.ip
+
+  const headers = req?.headers['X-Forwarded-For']
+  if (typeof headers === 'string') return headers.split(',')?.[0]
+
+  return undefined
 }

--- a/packages/web/resolvers/utils/index.ts
+++ b/packages/web/resolvers/utils/index.ts
@@ -305,4 +305,5 @@ export * from './db'
 export * from './notifications'
 export * from './types'
 export * from './badges'
+export * from './getPostingIpAddress'
 export type { NodeType }


### PR DESCRIPTION
## Description

For security and moderation purposes, we are going to start storing the IP address of the author of posts and comments.
This will allow us to identify particular users who engage in behavior that harms other users and potentially create multiple accounts.
This will also allow us to implement IP Blocking, should those users need to be banned from the platform.

## Subtasks

- [x] I have added this PR to the Journaly Kanban project ✅
- [x] Implement new `getPostingIpAddress` function
- [x] Add new `postingIpAddress` field to `Post`, `Comment`, and `PostComment` tables
- [x] Implement resolver code
- [x] Test!

### Deployment Checklist

- [x] 🚨 Publish new j-db-client version and update in both `web` and `j-mail`
- [x] 🚨 Deploy migs to stage
- [x] 🚨 Deploy code to stage
- [x] 🚨 DEPLOY `j-mail` to stage
- [ ] 🚨 Deploy migs to prod
- [ ] 🚨 Deploy code to prod
- [ ] 🚨 DEPLOY `j-mail` TO PROD

## Migrations

- Does the migration need to be applied before or after deploying code? **Before**
- Is applying the migration going to necessitate downtime? **Negative**
- Is there any SQL or backfill logic that has to be run manually? **Negativo**
- Are the DB changes high risk in your estimation? Should a manual DB snapshot be taken before applying? **These should be low risk. It's a new, nullable field.**

## Screenshots

The following screenshot shows one new comment record that has a special IP address stored (I believe this is due to it being local)

<img width="1328" alt="Screenshot 2024-08-28 at 20 08 23" src="https://github.com/user-attachments/assets/9dcead7f-15b8-4be4-bdb6-3ed02c774b00">

